### PR TITLE
fix: Remove invalid initContainers from Gitea values

### DIFF
--- a/platform/base/gitea/values.yaml
+++ b/platform/base/gitea/values.yaml
@@ -137,17 +137,11 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 3
 
-# Init container to wait for PostgreSQL
-initContainers:
-  - name: wait-for-postgres
-    image: busybox:1.36
-    command:
-      - sh
-      - -c
-      - |
-        echo "Waiting for PostgreSQL to be ready..."
-        until nc -z postgresql.platform-db.svc.cluster.local 5432; do
-          echo "PostgreSQL not ready yet, waiting..."
-          sleep 2
-        done
-        echo "PostgreSQL is ready!"
+# Note: Custom initContainers removed.
+# The Gitea Helm chart has built-in init containers (init-directories, init-app-ini, configure-gitea)
+# that handle initialization. PostgreSQL readiness is ensured by ArgoCD sync waves:
+# - Wave 0: PostgreSQL (deployed first)
+# - Wave 2: Gitea (deployed after PostgreSQL is healthy)
+#
+# The Gitea chart's initContainers key expects a map for configuring built-in
+# init containers (resources, securityContext), not an array of custom containers.


### PR DESCRIPTION
Fixes #12

## Problem

Gitea ArgoCD Application failed to sync with:

```
Error: template: gitea/templates/gitea/deployment.yaml:96:30:
executing "gitea/templates/gitea/deployment.yaml" at <.Values.initContainers.resources>:
can't evaluate field resources in type interface {}
```

Result: Gitea pod never started, HTTP 503 on UI access.

## Root Cause

The `initContainers` key in the official Gitea Helm chart (v10.x) expects a **map** for configuring built-in init containers (resources, securityContext), not an **array** of custom container definitions.

```yaml
# Our config (incorrect - array)
initContainers:
  - name: wait-for-postgres
    image: busybox:1.36
    ...

# Chart expectation (map)
initContainers:
  resources: {}
  securityContext: {}
```

The template at `deployment.yaml:96` accesses `.Values.initContainers.resources`, which fails when `initContainers` is an array (`interface{}`).

## Solution

Remove the custom `initContainers` block entirely.

**Why this is safe:**
1. **ArgoCD sync waves** ensure PostgreSQL (Wave 0) is healthy before Gitea (Wave 2) starts
2. **Gitea's built-in init containers** (`init-directories`, `init-app-ini`, `configure-gitea`) handle application initialization
3. The database connection will be available when the main Gitea container starts

## Testing

After merge:
```bash
# Force ArgoCD re-sync
kubectl patch application gitea -n argocd --type merge -p '{"operation":{"initiatedBy":{"username":"admin"},"sync":{}}}'

# Check pod status
kubectl get pods -n gitea

# Verify UI
curl -I http://digiorg.local/gitea
```