### PR TITLE
fix: Use additionalConfigFromEnvs for Gitea database password

### DIFF
--- a/platform/base/gitea/values.yaml
+++ b/platform/base/gitea/values.yaml
@@ -37,6 +37,16 @@ gitea:
     username: gitea_admin
     existingSecret: gitea-admin-secret
   
+  # Environment variables injected into ALL containers (including init containers)
+  # This is required for database password to be available during configure-gitea init
+  # See: https://gitea.com/gitea/helm-gitea#user-defined-environment-variables-in-appini
+  additionalConfigFromEnvs:
+    - name: GITEA__database__PASSWD
+      valueFrom:
+        secretKeyRef:
+          name: gitea-secrets
+          key: POSTGRES_PASSWORD
+  
   config:
     APP_NAME: "DigiOrg Git"
     
@@ -56,8 +66,8 @@ gitea:
       HOST: postgresql.platform-db.svc.cluster.local:5432
       NAME: gitea
       USER: gitea
-      # Password injected via environment variable from secret
-      PASSWD: ""
+      # Password injected via gitea.additionalConfigFromEnvs (GITEA__database__PASSWD)
+      # This ensures the password is available in init containers for migrations
     
     security:
       INSTALL_LOCK: true
@@ -92,13 +102,9 @@ gitea:
     actions:
       ENABLED: true
 
-# Additional environment variables from secrets
-extraEnvVars:
-  - name: GITEA__database__PASSWD
-    valueFrom:
-      secretKeyRef:
-        name: gitea-secrets
-        key: POSTGRES_PASSWORD
+# Note: Database password is injected via gitea.additionalConfigFromEnvs above,
+# NOT via extraEnvVars. extraEnvVars only applies to the main container,
+# but the configure-gitea init container needs the password for migrations.
 
 # Ingress disabled — using platform-wide ingress
 ingress:


### PR DESCRIPTION
Fixes #14

## Problem

Gitea `configure-gitea` init container failed with:

```
2026/04/11 17:13:20 cmd/migrate.go:40:runMigrate() [F] Failed to initialize ORM engine: 
pq: password authentication failed for user "gitea"
```

## Root Cause

The database password was configured via `extraEnvVars`:

```yaml
extraEnvVars:
  - name: GITEA__database__PASSWD
    valueFrom:
      secretKeyRef:
        name: gitea-secrets
        key: POSTGRES_PASSWORD
```

**Problem:** `extraEnvVars` only applies to the **main container**, not init containers.

The Gitea Helm chart runs several init containers:
1. `init-directories` — Creates data directories
2. `init-app-ini` — Generates `app.ini` from values
3. `configure-gitea` — **Runs database migrations** ← needs password!

The `configure-gitea` init container needs the database password to run migrations, but wasn't receiving it.

## Solution

Move the database password injection from `extraEnvVars` to `gitea.additionalConfigFromEnvs`:

```yaml
gitea:
  additionalConfigFromEnvs:
    - name: GITEA__database__PASSWD
      valueFrom:
        secretKeyRef:
          name: gitea-secrets
          key: POSTGRES_PASSWORD
```

Per the [Helm chart documentation](https://gitea.com/gitea/helm-gitea#user-defined-environment-variables-in-appini):

> `gitea.additionalConfigFromEnvs`: Additional configuration sources from environment variables

This injects the `GITEA__database__PASSWD` environment variable into **ALL containers** (including init containers), allowing the `configure-gitea` init container to connect to PostgreSQL successfully.

## Changes

| Before | After |
|--------|-------|
| `extraEnvVars` (main container only) | `gitea.additionalConfigFromEnvs` (all containers) |
| `PASSWD: ""` in config | Removed (injected via env) |

## Testing

After merge:
```bash
# Delete existing pod to force re-creation
kubectl delete pod -n gitea -l app.kubernetes.io/name=gitea

# Watch init container logs — should show successful DB connection
kubectl logs -n gitea -l app.kubernetes.io/name=gitea -c configure-gitea -f

# Verify Gitea UI
curl -I http://digiorg.local/gitea
```

## Related

- Issue #12 (initContainers template error) — fixed in PR #13
- PR #11 (Gitea integration)