### PR TITLE
fix: Add URL rewriting for Gitea subpath deployment

### DIFF
--- a/platform/base/ingress/digiorg-ingress.yaml
+++ b/platform/base/ingress/digiorg-ingress.yaml
@@ -54,14 +54,6 @@ spec:
                 name: prometheus-grafana
                 port:
                   number: 80
-          # Gitea
-          - path: /gitea(/|$)(.*)
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: gitea-http
-                port:
-                  number: 3000
 ---
 # Backstage needs URL rewriting because it doesn't natively support subpath deployment
 # /backstage/foo -> /foo on the backend
@@ -87,6 +79,33 @@ spec:
                 name: backstage
                 port:
                   number: 7007
+---
+# Gitea needs URL rewriting for subpath deployment
+# /gitea/foo -> /foo on the backend
+# See: https://docs.gitea.com/administration/reverse-proxies#use-a-sub-path
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gitea-ingress
+  namespace: ingress-nginx
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/proxy-body-size: "512m"  # Large Git pushes
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: digiorg.local
+      http:
+        paths:
+          - path: /gitea(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: gitea-http
+                port:
+                  number: 3000
 ---
 # ExternalName services to route cross-namespace
 apiVersion: v1


### PR DESCRIPTION
Fixes #16

## Problem

Gitea returned HTTP 404 for static assets:

```
Failed to load asset files from http://digiorg.local/gitea/assets/js/index.js?v=1.22.3. 
Please make sure the asset files can be accessed.
```

## Root Cause

The main Ingress passed requests to Gitea **without URL rewriting**:

| Request | Forwarded As | Expected |
|---------|--------------|----------|
| `/gitea/assets/js/index.js` | `/gitea/assets/js/index.js` | `/assets/js/index.js` |

Per [Gitea Reverse Proxy Documentation](https://docs.gitea.com/administration/reverse-proxies#use-a-sub-path):

> Make the reverse-proxy pass `https://common.example.com/gitea/foo` to `http://gitea:3000/foo`.

## Solution

Create a dedicated `gitea-ingress` with `rewrite-target: /$2`, following the same pattern used for Backstage:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: gitea-ingress
  annotations:
    nginx.ingress.kubernetes.io/rewrite-target: /$2
    nginx.ingress.kubernetes.io/proxy-body-size: "512m"  # Large Git pushes
spec:
  rules:
    - host: digiorg.local
      http:
        paths:
          - path: /gitea(/|$)(.*)
            backend:
              service:
                name: gitea-http
                port:
                  number: 3000
```

This rewrites:
- `/gitea/assets/js/index.js` → `/assets/js/index.js` ✅
- `/gitea/user/login` → `/user/login` ✅
- `/gitea/api/v1/repos` → `/api/v1/repos` ✅

## Changes

| Before | After |
|--------|-------|
| Gitea in main Ingress (no rewrite) | Dedicated `gitea-ingress` with `rewrite-target` |
| No body size limit | `proxy-body-size: 512m` for large Git pushes |

## Testing

After merge:
```bash
# Force ArgoCD re-sync of ingress
kubectl rollout restart deployment ingress-nginx-controller -n ingress-nginx

# Test static assets
curl -I http://digiorg.local/gitea/assets/js/index.js
# Expected: HTTP 200

# Test login page
curl -I http://digiorg.local/gitea/user/login
# Expected: HTTP 200

# Access in browser
open http://digiorg.local/gitea
```

## Related

- Issue #14 (database auth) — fixed in PR #15
- Issue #12 (initContainers) — fixed in PR #13
- PR #11 (Gitea integration)