### PR TITLE
fix: Update landingpage services ConfigMap with functional names and order

### DIFF
--- a/platform/base/landingpage/services-configmap.yaml
+++ b/platform/base/landingpage/services-configmap.yaml
@@ -12,47 +12,52 @@ data:
     [
       {
         "id": "keycloak",
-        "name": "Keycloak",
-        "description": "Identity & Access Management",
+        "name": "Identities & Access",
+        "description": "Authentication and authorization",
         "path": "/keycloak",
         "icon": "key",
         "category": "security",
-        "requiresAuth": false
-      },
-      {
-        "id": "argocd",
-        "name": "Argo CD",
-        "description": "GitOps Continuous Delivery",
-        "path": "/argocd",
-        "icon": "git-branch",
-        "category": "deployment",
-        "requiresAuth": true
-      },
-      {
-        "id": "grafana",
-        "name": "Grafana",
-        "description": "Observability & Dashboards",
-        "path": "/grafana",
-        "icon": "chart",
-        "category": "monitoring",
-        "requiresAuth": true
+        "requiresAuth": false,
+        "displayOrder": 1
       },
       {
         "id": "backstage",
-        "name": "Backstage",
-        "description": "Developer Portal",
+        "name": "Components & Catalog",
+        "description": "Service catalog and documentation",
         "path": "/backstage",
         "icon": "code",
         "category": "developer",
-        "requiresAuth": false
+        "requiresAuth": false,
+        "displayOrder": 2
       },
       {
         "id": "gitea",
-        "name": "Gitea",
-        "description": "Git Repository Service",
+        "name": "Repositories & Pipelines",
+        "description": "Git repositories and code review",
         "path": "/gitea",
         "icon": "git",
         "category": "developer",
-        "requiresAuth": false
+        "requiresAuth": false,
+        "displayOrder": 3
+      },
+      {
+        "id": "argocd",
+        "name": "GitOps & Deployment",
+        "description": "Continuous delivery and deployments",
+        "path": "/argocd",
+        "icon": "rocket",
+        "category": "deployment",
+        "requiresAuth": true,
+        "displayOrder": 4
+      },
+      {
+        "id": "grafana",
+        "name": "Logging & Monitoring",
+        "description": "Metrics and dashboards",
+        "path": "/grafana",
+        "icon": "chart",
+        "category": "monitoring",
+        "requiresAuth": true,
+        "displayOrder": 5
       }
     ]


### PR DESCRIPTION
The services ConfigMap contained outdated product names (Keycloak, Argo CD, Grafana, Backstage, Gitea) and incorrect display order. Since this ConfigMap is mounted into the container at runtime and overrides the bundled services.json, the old names were always shown regardless of the image contents.

## Changes

Updated `platform/base/landingpage/services-configmap.yaml`:

| Before | After | Order |
|--------|-------|-------|
| Keycloak | Identities & Access | 1 |
| Backstage | Components & Catalog | 2 |
| Gitea | Repositories & Pipelines | 3 |
| Argo CD | GitOps & Deployment | 4 |
| Grafana | Logging & Monitoring | 5 |

Also added `displayOrder` field to ensure consistent ordering.