### PR TITLE
fix: Remove PKCE enforcement from landingpage Keycloak client

### DIFF
--- a/platform/base/keycloak/realm-export.json
+++ b/platform/base/keycloak/realm-export.json
@@ -182,9 +182,7 @@
       "directAccessGrantsEnabled": false,
       "serviceAccountsEnabled": false,
       "fullScopeAllowed": true,
-      "attributes": {
-        "pkce.code.challenge.method": "S256"
-      },
+      "attributes": {},
       "protocolMappers": [
         {
           "name": "groups",


### PR DESCRIPTION
Fixes digiorg/core-landingpage#12

Removes `pkce.code.challenge.method: S256` from the `landingpage` Keycloak client in `realm-export.json`.

Keycloak was rejecting login redirects with `Missing parameter: code_challenge_method` because the client enforced PKCE server-side, while the browser cannot generate PKCE challenges over HTTP (Web Crypto API unavailable in insecure contexts).

**Note:** PKCE can be re-enabled once HTTPS is configured on the cluster.