### PR TITLE
fix: Update service configs to HTTPS after TLS migration

### DIFF
--- a/platform/base/argocd/values.yaml
+++ b/platform/base/argocd/values.yaml
@@ -29,10 +29,10 @@ configs:
     # SSO/OIDC via Keycloak (digiorg-core-platform realm)
     # Using digiorg.local with path-based routing (standard port 80)
     # Requires /etc/hosts: 127.0.0.1 digiorg.local
-    url: http://digiorg.local/argocd
+    url: https://digiorg.local/argocd
     oidc.config: |
       name: Keycloak
-      issuer: http://digiorg.local/keycloak/realms/digiorg-core-platform
+      issuer: https://digiorg.local/keycloak/realms/digiorg-core-platform
       clientID: argocd
       clientSecret: $oidc.keycloak.clientSecret
       requestedScopes:
@@ -40,6 +40,9 @@ configs:
         - profile
         - email
         - roles
+      # Skip TLS verification for self-signed cert in local dev
+      # Remove in production (use proper CA trust instead)
+      insecureSkipVerify: true
 
   # argocd-cmd-params-cm ConfigMap
   params:

--- a/platform/base/backstage/deployment.yaml
+++ b/platform/base/backstage/deployment.yaml
@@ -38,9 +38,9 @@ spec:
           env:
             # Application URLs
             - name: APP_BASE_URL
-              value: "http://digiorg.local/backstage"
+              value: "https://digiorg.local/backstage"
             - name: BACKEND_BASE_URL
-              value: "http://digiorg.local/backstage"
+              value: "https://digiorg.local/backstage"
             
             # PostgreSQL connection (using shared PostgreSQL in platform-db namespace)
             - name: POSTGRES_HOST
@@ -64,7 +64,11 @@ spec:
             
             # Keycloak OIDC configuration
             - name: AUTH_OIDC_METADATA_URL
-              value: "http://digiorg.local/keycloak/realms/digiorg-core-platform/.well-known/openid-configuration"
+              value: "https://digiorg.local/keycloak/realms/digiorg-core-platform/.well-known/openid-configuration"
+            # Skip TLS verification for self-signed cert in local dev
+            # Remove NODE_TLS_REJECT_UNAUTHORIZED in production (use proper CA trust instead)
+            - name: NODE_TLS_REJECT_UNAUTHORIZED
+              value: "0"
             - name: AUTH_OIDC_CLIENT_ID
               value: backstage
             - name: AUTH_OIDC_CLIENT_SECRET

--- a/platform/base/monitoring/values.yaml
+++ b/platform/base/monitoring/values.yaml
@@ -12,7 +12,7 @@ grafana:
   # Grafana served under /grafana path
   grafana.ini:
     server:
-      root_url: "http://digiorg.local/grafana"
+      root_url: "https://digiorg.local/grafana"
       serve_from_sub_path: true
 
     auth.generic_oauth:
@@ -23,11 +23,13 @@ grafana:
       # For local dev only — in production use envValueFrom with a Secret reference
       client_secret: grafana-client-secret
       scopes: openid email profile roles
-      # Using digiorg.local with path-based routing (standard port 80)
-      auth_url: http://digiorg.local/keycloak/realms/digiorg-core-platform/protocol/openid-connect/auth
-      token_url: http://digiorg.local/keycloak/realms/digiorg-core-platform/protocol/openid-connect/token
-      api_url: http://digiorg.local/keycloak/realms/digiorg-core-platform/protocol/openid-connect/userinfo
+      auth_url: https://digiorg.local/keycloak/realms/digiorg-core-platform/protocol/openid-connect/auth
+      token_url: https://digiorg.local/keycloak/realms/digiorg-core-platform/protocol/openid-connect/token
+      api_url: https://digiorg.local/keycloak/realms/digiorg-core-platform/protocol/openid-connect/userinfo
       role_attribute_path: "contains(realm_access.roles[*], 'platform-admin') && 'Admin' || 'Viewer'"
+      # Skip TLS verification for self-signed cert in local dev
+      # Remove in production (use proper CA trust instead)
+      tls_skip_verify_insecure: true
 
 prometheus:
   prometheusSpec:


### PR DESCRIPTION
Closes #29

## Changes

### Backstage — `platform/base/backstage/deployment.yaml`
- `APP_BASE_URL` + `BACKEND_BASE_URL` → `https://digiorg.local/backstage`
- `AUTH_OIDC_METADATA_URL` → `https://` (fixes 308 redirect on OIDC discovery)
- Added `NODE_TLS_REJECT_UNAUTHORIZED=0` — Backstage (Node.js) does not trust the self-signed CA; this env var disables TLS verification for local dev

### ArgoCD — `platform/base/argocd/values.yaml`
- `url` → `https://digiorg.local/argocd`
- `oidc.config.issuer` → `https://digiorg.local/keycloak/realms/...`
- Added `insecureSkipVerify: true` — ArgoCD cannot verify the self-signed CA when making OIDC requests to Keycloak

### Grafana — `platform/base/monitoring/values.yaml`
- `root_url` → `https://digiorg.local/grafana` (fixes 503 / redirect loop on startup)
- `auth_url`, `token_url`, `api_url` → `https://`
- Added `tls_skip_verify_insecure: true` — Grafana backend cannot verify the self-signed CA

## ⚠️ Local Dev Only

The TLS skip flags (`insecureSkipVerify`, `NODE_TLS_REJECT_UNAUTHORIZED=0`, `tls_skip_verify_insecure`) are acceptable for `digiorg.local` with a self-signed certificate. For production environments with a trusted CA (Let's Encrypt), these must be removed.