### PR TITLE
fix: Add --force-conflicts to ArgoCD helm upgrade for CA cert patch

### DIFF
--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -604,6 +604,7 @@ rootCA: |\n($indented_cert)
         --reuse-values
         --values platform/base/argocd/values.yaml
         --values ./argocd-oidc-override.yaml
+        --force-conflicts
         --wait --timeout 5m)
 
     print $"(ansi green)✓ ArgoCD OIDC config updated with CA cert via Helm(ansi reset)"


### PR DESCRIPTION
Closes #35

## Problem

`helm upgrade` in `patch_argocd_oidc_ca` failed with:
```
conflict with "argocd-controller": .data.policy.csv
```

ArgoCD controller writes to `argocd-rbac-cm` after startup, claiming field ownership of `policy.csv`. When the second `helm upgrade` runs to embed the CA cert, Helm conflicts on that field.

## Fix

Added `--force-conflicts` to the `helm upgrade` call. This is the standard Helm approach when an operator and Helm both manage the same resource — Helm takes back ownership of fields defined in its values.