### PR TITLE
feat: Update Backstage image reference to core-portal

### DIFF
--- a/platform/base/backstage/deployment.yaml
+++ b/platform/base/backstage/deployment.yaml
@@ -31,7 +31,7 @@ spec:
               echo "PostgreSQL is ready!"
       containers:
         - name: backstage
-          image: ghcr.io/digiorg/core-backstage-image:latest
+          image: ghcr.io/digiorg/core-portal:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 7007


### PR DESCRIPTION
Closes #37

Updates the Backstage deployment to use the new container image from `digiorg/core-portal`.

## Change

| | Before | After |
|-|--------|-------|
| Image | `ghcr.io/digiorg/core-backstage-image:latest` | `ghcr.io/digiorg/core-portal:latest` |
| Source Repo | `digiorg/core-backstage-image` | `digiorg/core-portal` |

No other references to `core-backstage-image` remain in the repository.