### PR TITLE
feat: Require auth for Backstage and Gitea tiles in services ConfigMap

### DIFF
--- a/platform/base/landingpage/services-configmap.yaml
+++ b/platform/base/landingpage/services-configmap.yaml
@@ -27,7 +27,7 @@ data:
         "path": "/backstage",
         "icon": "code",
         "category": "developer",
-        "requiresAuth": false,
+        "requiresAuth": true,
         "displayOrder": 2
       },
       {
@@ -37,7 +37,7 @@ data:
         "path": "/gitea",
         "icon": "git",
         "category": "developer",
-        "requiresAuth": false,
+        "requiresAuth": true,
         "displayOrder": 3
       },
       {


### PR DESCRIPTION
Part of digiorg/core-landingpage#16

Updates `platform/base/landingpage/services-configmap.yaml` — the ConfigMap mounted at runtime into the landing page container, which overrides the bundled `services.json`.

Sets `requiresAuth: true` for backstage and gitea entries so the tiles are locked when the user is not authenticated.