### PR TITLE
feat: Add NATS JetStream messaging broker + Surveyor UI with Keycloak SSO

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -10,6 +10,7 @@ apps/
 ├── platform/              # Platform infrastructure apps
 │   ├── cert-manager.yaml  # TLS Certificate Management (Wave 0)
 │   ├── postgresql.yaml    # Shared PostgreSQL database (Wave 0)
+│   ├── nats.yaml          # NATS JetStream Message Broker (Wave 0)
 │   ├── argocd.yaml        # Self-managed ArgoCD (Wave 1)
 │   ├── keycloak.yaml      # Identity Provider (Wave 1)
 │   ├── landingpage.yaml   # Platform Entry Point (Wave 2)
@@ -28,7 +29,7 @@ Applications are deployed in order using ArgoCD sync waves:
 | Wave | Applications | Description |
 |------|--------------|-------------|
 | -1 | root-app | Bootstrap (deployed by setup script) |
-| 0 | cert-manager, postgresql | TLS certificates + shared database layer |
+| 0 | cert-manager, postgresql, nats | TLS certificates + shared database layer + messaging |
 | 1 | keycloak, argocd | Core infrastructure (IdP, GitOps) |
 | 2 | landingpage, gitea, backstage, monitoring | Platform services (depend on PostgreSQL + Keycloak) |
 | 3 | crossplane, kyverno | Extensions (no Keycloak dependency) |

--- a/apps/platform/nats.yaml
+++ b/apps/platform/nats.yaml
@@ -1,0 +1,51 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nats
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 0: Deploy alongside cert-manager and postgresql
+    # No Keycloak dependency — NATS must be ready before Wave 1
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: default
+
+  sources:
+    # NATS Server via Helm chart
+    - repoURL: https://nats-io.github.io/k8s/helm/charts
+      chart: nats
+      targetRevision: "1.2.x"
+      helm:
+        releaseName: nats
+        valueFiles:
+          - $values/platform/base/nats/values.yaml
+
+    # Reference to values file in Git repo
+    - repoURL: https://github.com/digiorg/core.git
+      targetRevision: HEAD
+      ref: values
+
+    # Surveyor, oauth2-proxy, namespace via Kustomize
+    - repoURL: https://github.com/digiorg/core.git
+      targetRevision: HEAD
+      path: platform/base/nats
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: messaging
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/platform/base/ingress/digiorg-ingress.yaml
+++ b/platform/base/ingress/digiorg-ingress.yaml
@@ -67,6 +67,14 @@ spec:
                 name: prometheus-grafana
                 port:
                   number: 80
+          # NATS Surveyor UI (via oauth2-proxy for SSO)
+          - path: /nats(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: nats-oauth2-proxy
+                port:
+                  number: 4180
           # Landing Page (root path - must be last due to catch-all)
           - path: /
             pathType: Prefix
@@ -208,3 +216,14 @@ spec:
   externalName: landingpage.platform-apps.svc.cluster.local
   ports:
     - port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats-oauth2-proxy
+  namespace: ingress-nginx
+spec:
+  type: ExternalName
+  externalName: nats-oauth2-proxy.messaging.svc.cluster.local
+  ports:
+    - port: 4180

--- a/platform/base/keycloak/realm-export.json
+++ b/platform/base/keycloak/realm-export.json
@@ -200,6 +200,28 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "nats-surveyor",
+      "name": "NATS Surveyor",
+      "description": "NATS Surveyor Observability UI — SSO via oauth2-proxy",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "nats-surveyor-client-secret",
+      "redirectUris": [
+        "https://digiorg.local/nats/*",
+        "https://digiorg.local/nats/oauth2/callback"
+      ],
+      "webOrigins": [
+        "https://digiorg.local"
+      ],
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": true
     }
   ],
   "roles": {

--- a/platform/base/landingpage/services-configmap.yaml
+++ b/platform/base/landingpage/services-configmap.yaml
@@ -59,5 +59,15 @@ data:
         "category": "monitoring",
         "requiresAuth": true,
         "displayOrder": 5
+      },
+      {
+        "id": "nats",
+        "name": "Messaging & Events",
+        "description": "Event streaming and messaging infrastructure",
+        "path": "/nats",
+        "icon": "message",
+        "category": "messaging",
+        "requiresAuth": true,
+        "displayOrder": 6
       }
     ]

--- a/platform/base/nats/README.md
+++ b/platform/base/nats/README.md
@@ -1,0 +1,74 @@
+# NATS JetStream Messaging
+
+NATS JetStream is the platform message broker, providing pub/sub messaging with persistence, consumer groups, and dead-letter queues.
+
+## Components
+
+| Component | Description | Port |
+|-----------|-------------|------|
+| NATS Server | Core broker with JetStream | 4222 (client), 8222 (monitor) |
+| NATS Surveyor | Read-only observability UI | 7777 (internal only) |
+| oauth2-proxy | Keycloak SSO gateway for Surveyor | 4180 (internal only) |
+
+## Access
+
+| Environment | URL | Auth |
+|-------------|-----|------|
+| Local Dev | `https://digiorg.local/nats` | Keycloak SSO |
+| Internal (cluster) | `nats://nats.messaging.svc.cluster.local:4222` | None (cluster-internal) |
+
+## Secrets
+
+The following secrets must be created before ArgoCD sync (handled by `scripts/local-setup.nu`):
+
+```bash
+# oauth2-proxy secrets
+kubectl create secret generic nats-oauth2-proxy-secret \
+  -n messaging \
+  --from-literal=client-secret=<keycloak-client-secret> \
+  --from-literal=cookie-secret=$(openssl rand -base64 32)
+```
+
+## Deployment
+
+NATS is deployed via Helm (ArgoCD Application `nats.yaml`, Wave 0):
+
+```bash
+# Manually install/upgrade
+helm repo add nats https://nats-io.github.io/k8s/helm/charts
+helm upgrade --install nats nats/nats \
+  --namespace messaging \
+  --create-namespace \
+  --values platform/base/nats/values.yaml
+```
+
+## Keycloak Client
+
+The `nats-surveyor` OIDC client is configured in the `digiorg-core-platform` realm:
+- **Client ID**: `nats-surveyor`
+- **Redirect URIs**: `https://digiorg.local/nats/*`
+- **Type**: Confidential (uses oauth2-proxy)
+
+## NATS CLI
+
+```bash
+# Install nats CLI
+curl -sf https://binaries.nats.dev/nats-io/natscli/nats@latest | sh
+
+# Connect to local NATS
+nats --server nats://localhost:4222 server info
+
+# Port-forward for local access
+kubectl port-forward -n messaging svc/nats 4222:4222
+
+# JetStream status
+nats stream ls
+nats consumer ls DIGIORG_EVENTS
+```
+
+## Production
+
+For production environments, replace NATS with cloud-native backends via Dapr:
+- **Azure**: Azure Service Bus (`pubsub.azure.servicebus`)
+- **AWS**: SNS + SQS (`pubsub.snssqs`)
+- **GCP**: Google Pub/Sub (`pubsub.gcp.pubsub`)

--- a/platform/base/nats/kustomization.yaml
+++ b/platform/base/nats/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: messaging
+
+resources:
+  - namespace.yaml
+  - surveyor.yaml
+  - oauth2-proxy.yaml
+
+# Note: NATS server itself is deployed via Helm by the ArgoCD Application (apps/platform/nats.yaml)
+# The secrets (nats-oauth2-proxy-secret) are created by scripts/local-setup.nu before ArgoCD sync

--- a/platform/base/nats/namespace.yaml
+++ b/platform/base/nats/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: messaging
+  labels:
+    app.kubernetes.io/part-of: digiorg-core-platform
+    app.kubernetes.io/component: messaging

--- a/platform/base/nats/oauth2-proxy.yaml
+++ b/platform/base/nats/oauth2-proxy.yaml
@@ -1,0 +1,96 @@
+# =============================================================================
+# oauth2-proxy — SSO gateway for NATS Surveyor UI
+# Handles Keycloak OIDC authentication before forwarding to Surveyor
+# =============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats-oauth2-proxy
+  namespace: messaging
+  labels:
+    app.kubernetes.io/name: nats-oauth2-proxy
+    app.kubernetes.io/component: auth-proxy
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nats-oauth2-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nats-oauth2-proxy
+        app.kubernetes.io/component: auth-proxy
+    spec:
+      containers:
+        - name: oauth2-proxy
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+          args:
+            - --provider=oidc
+            - --oidc-issuer-url=https://digiorg.local/keycloak/realms/digiorg-core-platform
+            - --client-id=nats-surveyor
+            - --redirect-url=https://digiorg.local/nats/oauth2/callback
+            - --upstream=http://nats-surveyor.messaging.svc.cluster.local:7777
+            - --http-address=0.0.0.0:4180
+            - --cookie-secure=true
+            - --cookie-samesite=lax
+            - --email-domain=*
+            - --skip-provider-button=true
+            - --pass-access-token=false
+            - --pass-authorization-header=false
+            - --set-xauthrequest=false
+            # Skip TLS verification for self-signed cert (local dev only)
+            # Remove in production with trusted CA
+            - --ssl-insecure-skip-verify=true
+            - --oidc-extra-audience=nats-surveyor
+          env:
+            - name: OAUTH2_PROXY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: nats-oauth2-proxy-secret
+                  key: client-secret
+            - name: OAUTH2_PROXY_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: nats-oauth2-proxy-secret
+                  key: cookie-secret
+          ports:
+            - name: http
+              containerPort: 4180
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats-oauth2-proxy
+  namespace: messaging
+  labels:
+    app.kubernetes.io/name: nats-oauth2-proxy
+    app.kubernetes.io/component: auth-proxy
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: nats-oauth2-proxy
+  ports:
+    - name: http
+      port: 4180
+      targetPort: http

--- a/platform/base/nats/surveyor.yaml
+++ b/platform/base/nats/surveyor.yaml
@@ -1,0 +1,75 @@
+# =============================================================================
+# NATS Surveyor UI — Read-only observability dashboard
+# Protected by oauth2-proxy (Keycloak SSO)
+# Accessible internally only — external access via oauth2-proxy at /nats
+# =============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats-surveyor
+  namespace: messaging
+  labels:
+    app.kubernetes.io/name: nats-surveyor
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nats-surveyor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nats-surveyor
+        app.kubernetes.io/component: observability
+    spec:
+      containers:
+        - name: nats-surveyor
+          image: natsio/nats-surveyor:latest
+          args:
+            - --servers
+            - nats://nats.messaging.svc.cluster.local:4222
+            - --port
+            - "7777"
+            - --count
+            - "1"
+          ports:
+            - name: http
+              containerPort: 7777
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats-surveyor
+  namespace: messaging
+  labels:
+    app.kubernetes.io/name: nats-surveyor
+    app.kubernetes.io/component: observability
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: nats-surveyor
+  ports:
+    - name: http
+      port: 7777
+      targetPort: http

--- a/platform/base/nats/values.yaml
+++ b/platform/base/nats/values.yaml
@@ -1,0 +1,56 @@
+# NATS Helm Values
+# Chart: nats/nats
+# https://github.com/nats-io/k8s/tree/main/helm/charts/nats
+
+config:
+  # Enable JetStream for persistent messaging
+  jetstream:
+    enabled: true
+    fileStorage:
+      enabled: true
+      size: 1Gi
+      storageDirectory: /data
+
+  # Single-node for local dev (no clustering needed)
+  cluster:
+    enabled: false
+
+  # NATS monitoring endpoint (used by Surveyor)
+  monitor:
+    port: 8222
+
+# Disable nats-box utility container (not needed)
+natsBox:
+  enabled: false
+
+# Container image
+container:
+  image:
+    repository: nats
+    tag: "2.10-alpine"
+
+# Resource limits for local dev
+podTemplate:
+  merge:
+    spec:
+      containers:
+        - name: nats
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+
+# Service configuration
+service:
+  ports:
+    client:
+      port: 4222
+    monitor:
+      port: 8222
+    leafnode:
+      enabled: false
+    websocket:
+      enabled: false

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -74,14 +74,18 @@ def "main up" [] {
     print $"Export kubeconfig:"
     print $"  export KUBECONFIG=($KUBECONFIG_PATH)"
     print ""
-    print "Access services (all via digiorg.local):"
-    print "  Keycloak:   http://digiorg.local/keycloak   (admin / admin)"
-    print "  ArgoCD:     http://digiorg.local/argocd     (Login via Keycloak)"
-    print "  Grafana:    http://digiorg.local/grafana    (Login via Keycloak)"
-    print "  Backstage:  http://digiorg.local/backstage  (Login via Keycloak)"
-    print "  Gitea:      http://digiorg.local/gitea      (admin login; configure OIDC in Admin UI)"
+    print "Access services (all via https://digiorg.local):"
+    print "  Landing Page: https://digiorg.local/          (Login via Keycloak)"
+    print "  Keycloak:     https://digiorg.local/keycloak  (admin / admin)"
+    print "  ArgoCD:       https://digiorg.local/argocd    (Login via Keycloak)"
+    print "  Grafana:      https://digiorg.local/grafana   (Login via Keycloak)"
+    print "  Backstage:    https://digiorg.local/backstage (Login via Keycloak)"
+    print "  Gitea:        https://digiorg.local/gitea     (admin login; configure OIDC in Admin UI)"
+    print "  NATS:         https://digiorg.local/nats      (Login via Keycloak)"
     print ""
-    print $"(ansi yellow)Prerequisite: Add to /etc/hosts: 127.0.0.1 digiorg.local(ansi reset)"
+    print $"(ansi yellow)Prerequisites:(ansi reset)"
+    print $"  1. Add to /etc/hosts: 127.0.0.1 digiorg.local"
+    print $"  2. Import CA cert into your OS trust store (see above)"
 }
 
 # Run only Phase 1 bootstrap (no root app)
@@ -253,7 +257,7 @@ def "main status" [] {
         print $"(ansi cyan_bold)Platform Pods(ansi reset)"
         print "============="
         
-        let namespaces = ["platform-db", "argocd", "keycloak", "crossplane-system", "kyverno", "monitoring", "backstage", "gitea"]
+        let namespaces = ["platform-db", "argocd", "keycloak", "messaging", "crossplane-system", "kyverno", "monitoring", "backstage", "gitea", "platform-apps"]
         for ns in $namespaces {
             let status = try {
                 let pods = (kubectl get pods -n $ns --no-headers 2>/dev/null | lines | length)
@@ -469,6 +473,16 @@ def create_platform_secrets [] {
         print $"(ansi green)✓ Gitea namespace and secrets created(ansi reset)"
         print $"(ansi yellow)  ! Existing gitea-admin-secret preserved; set GITEA_ADMIN_PASSWORD to rotate(ansi reset)"
     }
+
+    # NATS oauth2-proxy secrets (messaging namespace)
+    let nats_client_secret = ($env.NATS_SURVEYOR_CLIENT_SECRET? | default "nats-surveyor-client-secret")
+    let nats_cookie_secret = ($env.NATS_COOKIE_SECRET? | default (openssl rand -base64 32 | str trim))
+    kubectl create namespace messaging --dry-run=client -o yaml | kubectl apply -f -
+    (kubectl create secret generic nats-oauth2-proxy-secret -n messaging
+        --from-literal=client-secret=($nats_client_secret)
+        --from-literal=cookie-secret=($nats_cookie_secret)
+        --dry-run=client -o yaml | kubectl apply -f -)
+    print $"(ansi green)✓ NATS oauth2-proxy secrets created [messaging](ansi reset)"
 }
 
 def install_argocd [] {


### PR DESCRIPTION
Closes #21

## Summary

Adds NATS JetStream as message broker to the platform with NATS Surveyor UI protected by Keycloak SSO via oauth2-proxy.

## New Files

| File | Description |
|------|-------------|
| `platform/base/nats/namespace.yaml` | `messaging` namespace |
| `platform/base/nats/values.yaml` | NATS Helm values (JetStream, 1Gi) |
| `platform/base/nats/surveyor.yaml` | NATS Surveyor UI deployment + service |
| `platform/base/nats/oauth2-proxy.yaml` | Keycloak SSO proxy for Surveyor |
| `platform/base/nats/kustomization.yaml` | Kustomize entrypoint |
| `platform/base/nats/README.md` | Documentation |
| `apps/platform/nats.yaml` | ArgoCD Application (Wave 0, multi-source) |

## Modified Files

| File | Change |
|------|--------|
| `platform/base/ingress/digiorg-ingress.yaml` | Add `/nats` → oauth2-proxy route + ExternalName svc |
| `platform/base/keycloak/realm-export.json` | Add `nats-surveyor` OIDC client |
| `platform/base/landingpage/services-configmap.yaml` | Add NATS tile (Messaging & Events) |
| `scripts/local-setup.nu` | 10 apps in wait loop, nats secret, NATS in status |
| `apps/README.md` | Updated sync wave table |

## Architecture

```
Browser → https://digiorg.local/nats (HTTPS, TLS terminated at Ingress)
  → ExternalName svc → oauth2-proxy (Keycloak OIDC)
  → NATS Surveyor (internal, :7777)

Services → nats://nats.messaging.svc.cluster.local:4222 (cluster-internal)
```

## Notes

- NATS server deployed via Helm (multi-source ArgoCD Application)
- `nats-oauth2-proxy-secret` created by setup script before ArgoCD sync
- `--ssl-insecure-skip-verify=true` on oauth2-proxy is for local dev only (self-signed CA)