### PR TITLE
fix: Fix NATS CrashLoopBackOff - cookie secret and Surveyor startup race

### DIFF
--- a/platform/base/nats/surveyor.yaml
+++ b/platform/base/nats/surveyor.yaml
@@ -23,6 +23,17 @@ spec:
         app.kubernetes.io/name: nats-surveyor
         app.kubernetes.io/component: observability
     spec:
+      initContainers:
+        - name: wait-for-nats
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z nats.messaging.svc.cluster.local 4222; do
+                echo "Waiting for NATS on port 4222..."; sleep 2
+              done
+              echo "NATS is ready"
       containers:
         - name: nats-surveyor
           image: natsio/nats-surveyor:latest

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -476,7 +476,9 @@ def create_platform_secrets [] {
 
     # NATS oauth2-proxy secrets (messaging namespace)
     let nats_client_secret = ($env.NATS_SURVEYOR_CLIENT_SECRET? | default "nats-surveyor-client-secret")
-    let nats_cookie_secret = ($env.NATS_COOKIE_SECRET? | default (openssl rand -base64 32 | str trim))
+    # openssl rand -hex 16 produces a 32-char hex string = exactly 16 bytes (AES-128)
+    # base64 32 would produce 44 chars which oauth2-proxy rejects (must be 16/24/32 bytes)
+    let nats_cookie_secret = ($env.NATS_COOKIE_SECRET? | default (openssl rand -hex 16 | str trim))
     kubectl create namespace messaging --dry-run=client -o yaml | kubectl apply -f -
     (kubectl create secret generic nats-oauth2-proxy-secret -n messaging
         --from-literal=client-secret=($nats_client_secret)


### PR DESCRIPTION
Closes #42

## Fixes

### Bug 1: oauth2-proxy — invalid cookie secret length

**`scripts/local-setup.nu`**

| | Before | After |
|-|--------|-------|
| Command | `openssl rand -base64 32` | `openssl rand -hex 16` |
| Output | 44-char base64 string (rejected) | 32-char hex = 16 bytes AES-128 (valid) |

oauth2-proxy requires the cookie secret to decode to exactly 16, 24, or 32 bytes. `base64 32` encodes 32 bytes into 44 characters — oauth2-proxy sees 44 bytes and rejects it.

### Bug 2: NATS Surveyor — connection failure on startup

**`platform/base/nats/surveyor.yaml`**

Added `initContainer` that waits for NATS port 4222 to be reachable before the Surveyor container starts:

```yaml
initContainers:
  - name: wait-for-nats
    image: busybox:1.36
    command: [sh, -c, "until nc -z nats.messaging... 4222; do sleep 2; done"]
```

Prevents the `nats: no servers available for connection` race condition when Surveyor starts before the NATS pod is ready.

### Bug 3: releaseName already set

`apps/platform/nats.yaml` already has `releaseName: nats` — no change needed.