### PR TITLE
fix: Replace nc -z with wget HTTP check in NATS Surveyor initContainer

### DIFF
--- a/platform/base/nats/surveyor.yaml
+++ b/platform/base/nats/surveyor.yaml
@@ -30,8 +30,8 @@ spec:
             - sh
             - -c
             - |
-              until nc -z nats.messaging.svc.cluster.local 4222; do
-                echo "Waiting for NATS on port 4222..."; sleep 2
+              until wget -q -O /dev/null http://nats:8222/healthz 2>/dev/null; do
+                echo "Waiting for NATS monitoring endpoint..."; sleep 2
               done
               echo "NATS is ready"
       containers:


### PR DESCRIPTION
Closes #44

## Problem

`nc -z` in BusyBox defaults to **UDP**, not TCP. NATS listens on TCP port 4222, so the connectivity check always failed — the initContainer looped forever even with NATS fully running.

## Fix

Replace `nc -z nats.messaging.svc.cluster.local 4222` with a wget HTTP check against the NATS built-in monitoring endpoint:

```sh
# Before (UDP scan, always fails for TCP service)
nc -z nats.messaging.svc.cluster.local 4222

# After (HTTP/TCP check against NATS healthz endpoint)
wget -q -O /dev/null http://nats:8222/healthz
```

**Why this is better:**
- BusyBox `wget` reliably uses HTTP over TCP
- `/healthz` on port 8222 is the NATS-native health endpoint — returns 200 when NATS is ready
- Short service name `nats` (same namespace) — simpler DNS resolution