### PR TITLE
fix: Use container.merge instead of podTemplate.merge for NATS resource limits

### DIFF
--- a/platform/base/nats/values.yaml
+++ b/platform/base/nats/values.yaml
@@ -23,25 +23,18 @@ config:
 natsBox:
   enabled: false
 
-# Container image
+# Resource limits for the NATS container
+# Use container.merge (not podTemplate.merge.spec.containers) to avoid
+# generating a container entry without an image field (causes StatefulSet validation failure)
 container:
-  image:
-    repository: nats
-    tag: "2.10-alpine"
-
-# Resource limits for local dev
-podTemplate:
   merge:
-    spec:
-      containers:
-        - name: nats
-          resources:
-            requests:
-              cpu: 50m
-              memory: 64Mi
-            limits:
-              cpu: 500m
-              memory: 256Mi
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
 
 # Service configuration
 service:


### PR DESCRIPTION
Closes #46

## Problem

`platform/base/nats/values.yaml` used `podTemplate.merge.spec.containers` to set resource limits:

```yaml
podTemplate:
  merge:
    spec:
      containers:
        - name: nats
          resources: ...
```

The NATS Helm chart processes this as a strategic merge patch that **adds a new container entry** without an `image` field. Kubernetes rejects the resulting StatefulSet:

```
StatefulSet "nats" is invalid:
spec.template.spec.containers[0].image: Required value
```

## Fix

Use `container.merge` instead — the chart-native way to patch the main NATS container spec:

```yaml
container:
  merge:
    resources:
      requests:
        cpu: 50m
        memory: 64Mi
      limits:
        cpu: 500m
        memory: 256Mi
```

Also removed `container.image` block — the chart manages the image by default, no need to override unless pinning a specific version.

## Result

- NATS StatefulSet deploys successfully
- Surveyor `initContainer` (`wget http://nats:8222/healthz`) completes once NATS is ready
- ArgoCD sync succeeds