### PR TITLE
fix: Use nats-headless service for Surveyor initContainer health check

### DIFF
--- a/platform/base/nats/surveyor.yaml
+++ b/platform/base/nats/surveyor.yaml
@@ -30,7 +30,7 @@ spec:
             - sh
             - -c
             - |
-              until wget -q -O /dev/null http://nats:8222/healthz 2>/dev/null; do
+              until wget -q -O /dev/null http://nats-headless:8222/healthz 2>/dev/null; do
                 echo "Waiting for NATS monitoring endpoint..."; sleep 2
               done
               echo "NATS is ready"


### PR DESCRIPTION
Closes #48

**One word change:** `nats` → `nats-headless`

The NATS Helm chart creates two services:
- `nats` (ClusterIP) — port 4222 only (client)
- `nats-headless` (headless) — ports 4222 + 8222

Port 8222 (monitoring HTTP) is not exposed on the `nats` ClusterIP service, so `wget http://nats:8222/healthz` always fails with connection refused — even when NATS is fully running. The headless service exposes both ports and resolves correctly within the same namespace.