### PR TITLE
fix: Use /metrics path for NATS Surveyor liveness/readiness probes

### DIFF
--- a/platform/base/nats/surveyor.yaml
+++ b/platform/base/nats/surveyor.yaml
@@ -57,16 +57,18 @@ spec:
               memory: 128Mi
           livenessProbe:
             httpGet:
-              path: /
+              path: /metrics
               port: http
-            initialDelaySeconds: 10
-            periodSeconds: 15
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /
+              path: /metrics
               port: http
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 10
+            failureThreshold: 3
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Closes #50

NATS Surveyor is a **Prometheus exporter** — it only exposes `/metrics`, not `/`. Both probes used `path: /` which returns 404, causing Kubernetes to restart the container continuously.

**Fix:** `path: /` → `path: /metrics` on both liveness and readiness probes.