### PR TITLE
fix: Complete NATS Surveyor fix - system account, auth, probes, redirect loop

### DIFF
--- a/platform/base/nats/oauth2-proxy.yaml
+++ b/platform/base/nats/oauth2-proxy.yaml
@@ -32,8 +32,12 @@ spec:
             - --redirect-url=https://digiorg.local/nats/oauth2/callback
             - --upstream=http://nats-surveyor.messaging.svc.cluster.local:7777
             - --http-address=0.0.0.0:4180
+            # Sub-path prefix — oauth2-proxy runs at /nats, not /
+            # Prevents redirect loop: callback path must be within proxy-prefix
+            - --proxy-prefix=/nats/oauth2
             - --cookie-secure=true
             - --cookie-samesite=lax
+            - --cookie-path=/nats
             - --email-domain=*
             - --skip-provider-button=true
             - --pass-access-token=false

--- a/platform/base/nats/surveyor.yaml
+++ b/platform/base/nats/surveyor.yaml
@@ -1,7 +1,9 @@
 # =============================================================================
-# NATS Surveyor UI — Read-only observability dashboard
+# NATS Surveyor — Prometheus metrics exporter for NATS
 # Protected by oauth2-proxy (Keycloak SSO)
-# Accessible internally only — external access via oauth2-proxy at /nats
+# Accessible externally via oauth2-proxy at /nats
+#
+# Requires NATS system account ($SYS) to be configured — see values.yaml
 # =============================================================================
 apiVersion: apps/v1
 kind: Deployment
@@ -23,23 +25,18 @@ spec:
         app.kubernetes.io/name: nats-surveyor
         app.kubernetes.io/component: observability
     spec:
-      initContainers:
-        - name: wait-for-nats
-          image: busybox:1.36
-          command:
-            - sh
-            - -c
-            - |
-              until wget -q -O /dev/null http://nats-headless:8222/healthz 2>/dev/null; do
-                echo "Waiting for NATS monitoring endpoint..."; sleep 2
-              done
-              echo "NATS is ready"
+      # No initContainer — Kubernetes restart handles the NATS startup race.
+      # Previous initContainers using nc/wget had DNS, TCP, and headless service issues.
       containers:
         - name: nats-surveyor
           image: natsio/nats-surveyor:latest
           args:
             - --servers
             - nats://nats.messaging.svc.cluster.local:4222
+            - --user
+            - sys
+            - --password
+            - sys_password
             - --port
             - "7777"
             - --count
@@ -55,19 +52,22 @@ spec:
             limits:
               cpu: 200m
               memory: 128Mi
+          # Surveyor exposes only /metrics (Prometheus exporter)
           livenessProbe:
             httpGet:
               path: /metrics
               port: http
-            initialDelaySeconds: 15
-            periodSeconds: 20
-            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /metrics
               port: http
-            initialDelaySeconds: 10
-            periodSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
             failureThreshold: 3
 ---
 apiVersion: v1

--- a/platform/base/nats/values.yaml
+++ b/platform/base/nats/values.yaml
@@ -19,6 +19,19 @@ config:
   monitor:
     port: 8222
 
+  # System account required by NATS Surveyor for $SYS subject access
+  # https://docs.nats.io/nats-server/configuration/sys_accounts
+  merge:
+    accounts:
+      $SYS:
+        users:
+          - user: sys
+            password: sys_password
+      APP:
+        jetstream: enabled
+        users:
+          - user: app
+
 # Disable nats-box utility container (not needed)
 natsBox:
   enabled: false


### PR DESCRIPTION
Closes #52

## Three problems, one PR

### 1. NATS System Account (`values.yaml`)

Surveyor requires `$SYS` subject access. Added system account:

```yaml
config:
  merge:
    accounts:
      $SYS:
        users:
          - user: sys
            password: sys_password
```

### 2. Surveyor Pod (`surveyor.yaml`)

| Before | After |
|--------|-------|
| initContainer with `nc`/`wget` (always failed) | Removed — Kubernetes restart handles NATS race |
| No auth (→ `503: No responders`) | `--user sys --password sys_password` |
| Probes: 10-15s initialDelay, 3 failures | 30s initialDelay, 5s timeout, 5 failures |

### 3. oauth2-proxy Redirect Loop (`oauth2-proxy.yaml`)

| Before | After |
|--------|-------|
| No `--proxy-prefix` (default `/oauth2`) | `--proxy-prefix=/nats/oauth2` |
| No `--cookie-path` | `--cookie-path=/nats` |

The redirect loop happened because oauth2-proxy at sub-path `/nats` didn't know its own prefix. The callback URL `/nats/oauth2/callback` was treated as an upstream request instead of a callback, triggering infinite Keycloak redirects with exponentially growing `state` parameters.