### PR TITLE
fix: NATS SSO login - set emailVerified on Keycloak user, allow unverified in oauth2-proxy

### DIFF
--- a/platform/base/keycloak/realm-export.json
+++ b/platform/base/keycloak/realm-export.json
@@ -258,6 +258,7 @@
     {
       "username": "admin",
       "enabled": true,
+      "emailVerified": true,
       "email": "admin@example.com",
       "firstName": "Platform",
       "lastName": "Admin",

--- a/platform/base/nats/oauth2-proxy.yaml
+++ b/platform/base/nats/oauth2-proxy.yaml
@@ -47,6 +47,8 @@ spec:
             # Remove in production with trusted CA
             - --ssl-insecure-skip-verify=true
             - --oidc-extra-audience=nats-surveyor
+            # Allow unverified emails for local dev (Keycloak test users)
+            - --insecure-oidc-allow-unverified-email=true
           env:
             - name: OAUTH2_PROXY_CLIENT_SECRET
               valueFrom:


### PR DESCRIPTION
Closes #54

## Problem

oauth2-proxy rejected the OIDC callback:
```
email in id_token (admin@example.com) isn't verified
```

## Fix

Two changes:

1. **`realm-export.json`** — Added `"emailVerified": true` to the admin user
2. **`oauth2-proxy.yaml`** — Added `--insecure-oidc-allow-unverified-email=true` as safety net for local dev