### PR TITLE
fix: Remove proxy-prefix and cookie-path from NATS oauth2-proxy

### DIFF
--- a/platform/base/nats/oauth2-proxy.yaml
+++ b/platform/base/nats/oauth2-proxy.yaml
@@ -32,12 +32,11 @@ spec:
             - --redirect-url=https://digiorg.local/nats/oauth2/callback
             - --upstream=http://nats-surveyor.messaging.svc.cluster.local:7777
             - --http-address=0.0.0.0:4180
-            # Sub-path prefix — oauth2-proxy runs at /nats, not /
-            # Prevents redirect loop: callback path must be within proxy-prefix
-            - --proxy-prefix=/nats/oauth2
+            # After Ingress rewrite-target /$2, oauth2-proxy sees paths without /nats prefix.
+            # Default proxy-prefix /oauth2 matches the rewritten /oauth2/callback path.
+            # Do NOT set --proxy-prefix=/nats/oauth2 (that was the pre-rewrite path).
             - --cookie-secure=true
             - --cookie-samesite=lax
-            - --cookie-path=/nats
             - --email-domain=*
             - --skip-provider-button=true
             - --pass-access-token=false


### PR DESCRIPTION
Closes #58

## Problem

After the Ingress rewrite (`/nats/...` → `/...`), the oauth2-proxy settings conflicted:

| Setting | Value | Problem |
|---------|-------|---------|
| `--proxy-prefix=/nats/oauth2` | Expects callback at `/nats/oauth2/callback` | But receives `/oauth2/callback` after rewrite |
| `--cookie-path=/nats` | Cookie scoped to `/nats` | But rewritten paths are at `/` |

Result: oauth2-proxy never recognizes its own callback → infinite redirect loop.

## Fix

Remove both settings. oauth2-proxy defaults are correct after the Ingress rewrite:
- Default `proxy-prefix`: `/oauth2` → matches rewritten `/oauth2/callback` ✅
- Default `cookie-path`: `/` → matches all rewritten paths ✅
- `redirect-url` stays `https://digiorg.local/nats/oauth2/callback` (browser-facing, before rewrite) ✅