### PR TITLE
fix: NATS SSO redirect to correct path after login

### DIFF
--- a/platform/base/ingress/digiorg-ingress.yaml
+++ b/platform/base/ingress/digiorg-ingress.yaml
@@ -156,6 +156,10 @@ metadata:
     cert-manager.io/cluster-issuer: "digiorg-local-ca-issuer"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    # Pass the original pre-rewrite URI so oauth2-proxy can redirect back correctly
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header X-Original-URI $request_uri;
+      proxy_set_header X-Forwarded-Uri $request_uri;
 spec:
   ingressClassName: nginx
   tls:

--- a/platform/base/nats/oauth2-proxy.yaml
+++ b/platform/base/nats/oauth2-proxy.yaml
@@ -34,9 +34,13 @@ spec:
             - --http-address=0.0.0.0:4180
             # After Ingress rewrite-target /$2, oauth2-proxy sees paths without /nats prefix.
             # Default proxy-prefix /oauth2 matches the rewritten /oauth2/callback path.
-            # Do NOT set --proxy-prefix=/nats/oauth2 (that was the pre-rewrite path).
+            # --reverse-proxy ensures oauth2-proxy uses X-Forwarded-* headers for redirect
+            # calculation, so it redirects to the original /nats path, not the rewritten /
+            - --reverse-proxy=true
             - --cookie-secure=true
             - --cookie-samesite=lax
+            - --cookie-path=/nats
+            - --cookie-name=_oauth2_proxy_nats
             - --email-domain=*
             - --skip-provider-button=true
             - --pass-access-token=false


### PR DESCRIPTION
Closes #60

## Problem

After successful Keycloak SSO login, oauth2-proxy redirected the browser to `/` (landing page) instead of `/nats` (Surveyor UI). The Ingress rewrite (`/nats` → `/`) caused oauth2-proxy to store `/` as the post-login redirect target.

## Fix

### oauth2-proxy.yaml
```yaml
- --reverse-proxy=true        # Use X-Forwarded-* for redirect calculation
- --cookie-path=/nats          # Scope cookie to /nats path
- --cookie-name=_oauth2_proxy_nats  # Unique cookie name
```

### digiorg-ingress.yaml (nats-ingress)
```yaml
configuration-snippet: |
  proxy_set_header X-Original-URI $request_uri;
  proxy_set_header X-Forwarded-Uri $request_uri;
```

## Flow After Fix

```
1. Browser → /nats
2. NGINX: rewrite → /, set X-Original-URI: /nats, X-Forwarded-Uri: /nats
3. oauth2-proxy (--reverse-proxy): reads X-Forwarded headers → stores /nats as redirect target
4. Keycloak login → success
5. oauth2-proxy: set cookie (_oauth2_proxy_nats, path=/nats) → redirect to /nats
6. Browser at /nats → cookie sent (path matches) → Surveyor UI ✅
```