### PR TITLE
fix: Replace configuration-snippet with x-forwarded-prefix for NATS Ingress

### DIFF
--- a/platform/base/ingress/digiorg-ingress.yaml
+++ b/platform/base/ingress/digiorg-ingress.yaml
@@ -156,10 +156,8 @@ metadata:
     cert-manager.io/cluster-issuer: "digiorg-local-ca-issuer"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    # Pass the original pre-rewrite URI so oauth2-proxy can redirect back correctly
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header X-Original-URI $request_uri;
-      proxy_set_header X-Forwarded-Uri $request_uri;
+    # Pass original path prefix so oauth2-proxy (--reverse-proxy) redirects to /nats after login
+    nginx.ingress.kubernetes.io/x-forwarded-prefix: "/nats"
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
Closes #62

`configuration-snippet` is blocked by the NGINX Ingress admission webhook (disabled by default since v1.9, CVE-2021-25742).

Replaced with the native `x-forwarded-prefix: "/nats"` annotation which adds `X-Forwarded-Prefix: /nats` to proxied requests. oauth2-proxy with `--reverse-proxy=true` reads this header to reconstruct the original path for post-login redirect.