### PR TITLE
fix: Remove Ingress rewrite for NATS, use native oauth2-proxy prefix handling

### DIFF
--- a/platform/base/ingress/digiorg-ingress.yaml
+++ b/platform/base/ingress/digiorg-ingress.yaml
@@ -142,22 +142,20 @@ spec:
                 port:
                   number: 3000
 ---
-# NATS Surveyor UI needs URL rewriting (via oauth2-proxy for SSO)
-# /nats/foo -> /foo on oauth2-proxy -> /foo on Surveyor upstream
+# NATS Surveyor UI (via oauth2-proxy for SSO)
+# NO rewrite-target — oauth2-proxy handles /nats prefix natively.
+# Previous attempts with rewrite-target caused redirect loops because
+# oauth2-proxy lost the /nats prefix in state/cookie/redirect calculations.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: nats-ingress
   namespace: ingress-nginx
   annotations:
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     cert-manager.io/cluster-issuer: "digiorg-local-ca-issuer"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    # Pass original path prefix so oauth2-proxy (--reverse-proxy) redirects to /nats after login
-    nginx.ingress.kubernetes.io/x-forwarded-prefix: "/nats"
 spec:
   ingressClassName: nginx
   tls:
@@ -168,8 +166,8 @@ spec:
     - host: digiorg.local
       http:
         paths:
-          - path: /nats(/|$)(.*)
-            pathType: ImplementationSpecific
+          - path: /nats
+            pathType: Prefix
             backend:
               service:
                 name: nats-oauth2-proxy

--- a/platform/base/nats/oauth2-proxy.yaml
+++ b/platform/base/nats/oauth2-proxy.yaml
@@ -30,13 +30,12 @@ spec:
             - --oidc-issuer-url=https://digiorg.local/keycloak/realms/digiorg-core-platform
             - --client-id=nats-surveyor
             - --redirect-url=https://digiorg.local/nats/oauth2/callback
-            - --upstream=http://nats-surveyor.messaging.svc.cluster.local:7777
+            # Trailing / tells oauth2-proxy to strip the matched prefix when forwarding
+            - --upstream=http://nats-surveyor.messaging.svc.cluster.local:7777/
             - --http-address=0.0.0.0:4180
-            # After Ingress rewrite-target /$2, oauth2-proxy sees paths without /nats prefix.
-            # Default proxy-prefix /oauth2 matches the rewritten /oauth2/callback path.
-            # --reverse-proxy ensures oauth2-proxy uses X-Forwarded-* headers for redirect
-            # calculation, so it redirects to the original /nats path, not the rewritten /
-            - --reverse-proxy=true
+            # No Ingress rewrite — oauth2-proxy receives full /nats/... paths.
+            # proxy-prefix identifies the oauth2 callback path within the /nats sub-path.
+            - --proxy-prefix=/nats/oauth2
             - --cookie-secure=true
             - --cookie-samesite=lax
             - --cookie-path=/nats


### PR DESCRIPTION
Closes #64

## The Core Problem

Every previous fix tried to make `rewrite-target: /$2` work with oauth2-proxy. This is fundamentally broken because oauth2-proxy stores the **rewritten** path (`/`) as the post-login redirect target, sending the user to the landing page.

## New Approach: No Rewrite

| | Before (broken) | After (correct) |
|-|--------|-------|
| Ingress | `rewrite-target: /$2` strips `/nats` | `pathType: Prefix` passes `/nats/...` as-is |
| oauth2-proxy sees | `GET /` | `GET /nats` |
| State stores | `/` (landing page) | `/nats` (correct) |
| proxy-prefix | `/oauth2` (default) | `/nats/oauth2` |
| upstream | `http://surveyor:7777` | `http://surveyor:7777/` (trailing / strips prefix) |
| Post-login redirect | `/` → landing page ❌ | `/nats` → Surveyor ✅ |

## Changes

### `digiorg-ingress.yaml` (nats-ingress)
- Removed `rewrite-target`, `use-regex`, `x-forwarded-prefix`
- Changed to `pathType: Prefix` with `path: /nats`

### `oauth2-proxy.yaml`
- Added `--proxy-prefix=/nats/oauth2`
- Changed `--upstream` to have trailing `/` (strips prefix on forward)
- Removed `--reverse-proxy=true` (no longer needed)
- Kept `--cookie-path=/nats` and `--cookie-name=_oauth2_proxy_nats`