### PR TITLE
fix(keycloak): rename realm import file to follow Keycloak naming con…

### DIFF
--- a/platform/base/keycloak/digiorg-core-platform-realm.json
+++ b/platform/base/keycloak/digiorg-core-platform-realm.json
@@ -221,51 +221,21 @@
   "groups": [
     {
       "name": "platform-admins",
-      "realmRoles": ["platform-admin"]
+      "realmRoles": [
+        "platform-admin"
+      ]
     },
     {
       "name": "platform-viewers",
-      "realmRoles": ["platform-viewer"]
+      "realmRoles": [
+        "platform-viewer"
+      ]
     },
     {
       "name": "developers",
-      "realmRoles": ["developer"]
-    }
-  ],
-  "users": [
-    {
-      "username": "digiorgadmin",
-      "enabled": true,
-      "emailVerified": true,
-      "email": "admin@digiorg.local",
-      "firstName": "Admin",
-      "lastName": "DigiOrg",
-      "credentials": [
-        {
-          "type": "password",
-          "value": "digiorgadmin",
-          "temporary": false
-        }
-      ],
-      "realmRoles": ["platform-admin"],
-      "groups": ["platform-admins"]
-    },
-    {
-      "username": "digiorgdeveloper",
-      "enabled": true,
-      "emailVerified": true,
-      "email": "developer@digiorg.local",
-      "firstName": "Developer",
-      "lastName": "DigiOrg",
-      "credentials": [
-        {
-          "type": "password",
-          "value": "digiorgdeveloper",
-          "temporary": false
-        }
-      ],
-      "realmRoles": ["developer"],
-      "groups": ["developers"]
+      "realmRoles": [
+        "developer"
+      ]
     }
   ]
 }

--- a/platform/base/keycloak/digiorg-core-platform-users-0.json
+++ b/platform/base/keycloak/digiorg-core-platform-users-0.json
@@ -1,0 +1,47 @@
+{
+  "realm": "digiorg-core-platform",
+  "users": [
+    {
+      "username": "digiorgadmin",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "admin@digiorg.local",
+      "firstName": "Admin",
+      "lastName": "DigiOrg",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "digiorgadmin",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "platform-admin"
+      ],
+      "groups": [
+        "platform-admins"
+      ]
+    },
+    {
+      "username": "digiorgdeveloper",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "developer@digiorg.local",
+      "firstName": "Developer",
+      "lastName": "DigiOrg",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "digiorgdeveloper",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "developer"
+      ],
+      "groups": [
+        "developers"
+      ]
+    }
+  ]
+}

--- a/platform/base/keycloak/kustomization.yaml
+++ b/platform/base/keycloak/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 configMapGenerator:
   - name: keycloak-realm-import
     files:
-      - realm-export.json
+      - digiorg-core-platform-realm.json
+      - digiorg-core-platform-users-0.json
     options:
       disableNameSuffixHash: true


### PR DESCRIPTION
…vention and split users

Keycloak's --import-realm requires realm files to follow the naming convention <realm-name>-realm.json. User files must be named <realm-name>-users-<n>.json. The previous filename realm-export.json caused Keycloak to import realm config (clients, roles, groups) but silently skip the users array.

Changes:
- Rename realm-export.json → digiorg-core-platform-realm.json
- Extract users into digiorg-core-platform-users-0.json
- Update kustomization.yaml to include both files in ConfigMap

Ref: https://www.keycloak.org/server/importExport#_import_file_naming_conventions