### PR TITLE
feat(jaeger): Deploy Jaeger Distributed Tracing to Core Platform (#77)

### DIFF
--- a/apps/platform/jaeger.yaml
+++ b/apps/platform/jaeger.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: jaeger
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: default
+  sources:
+    - repoURL: https://jaegertracing.github.io/helm-charts
+      chart: jaeger
+      targetRevision: "3.x"
+      helm:
+        releaseName: jaeger
+        valueFiles:
+          - $values/platform/base/jaeger/values.yaml
+    - repoURL: https://github.com/digiorg/core.git
+      targetRevision: HEAD
+      ref: values
+    - repoURL: https://github.com/digiorg/core.git
+      targetRevision: HEAD
+      path: platform/base/jaeger
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tracing
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/docs/adr/005-tracing-backend-jaeger.md
+++ b/docs/adr/005-tracing-backend-jaeger.md
@@ -1,0 +1,90 @@
+# ADR-005: Tracing Backend — Jaeger
+
+**Status:** Accepted  
+**Date:** 2026-04-30  
+**Deciders:** @simon-itstudio  
+
+## Context
+
+The DigiOrg Core Platform has two of the three observability pillars in place:
+- **Metrics**: Prometheus + Grafana (kube-prometheus-stack)
+- **Logs**: planned
+
+To complete the observability story, we need a **distributed tracing** backend that can:
+- Receive traces from services instrumented with OpenTelemetry
+- Provide a UI to explore traces and identify latency bottlenecks
+- Integrate as a data source in Grafana
+- Be deployable locally (KinD) with minimal resource overhead
+- Be production-ready with a persistent storage backend path
+
+## Decision
+
+We adopt **Jaeger v2** (Helm chart `jaeger` from `jaegertracing.github.io/helm-charts`) as the distributed tracing backend.
+
+For local development we deploy in **all-in-one** mode with in-memory storage. For production, OpenSearch will be used as the storage backend with separate collector and query deployments.
+
+## Rationale
+
+### Why Jaeger over alternatives
+
+| Criterion | Jaeger | Grafana Tempo | Zipkin |
+|-----------|--------|---------------|--------|
+| CNCF status | Graduated | Sandbox | — |
+| Native OTLP | Yes (v2) | Yes | Partial |
+| Grafana datasource | Yes | Yes (native) | Yes |
+| All-in-one mode | Yes | No | Yes |
+| Storage options | Memory, OpenSearch, Cassandra | Object storage (S3/GCS) | In-memory, Elasticsearch |
+| License | Apache 2.0 | AGPL (Grafana OSS) | Apache 2.0 |
+| UI | Built-in | Grafana only | Built-in |
+| Kubernetes-native | Yes | Yes | No |
+
+**Jaeger** was chosen because:
+
+1. **CNCF Graduated**: Battle-tested at scale, strong community and long-term support commitment.
+2. **Native OTLP support**: Jaeger v2 accepts OTLP natively on ports 4317 (gRPC) and 4318 (HTTP) — no translation layer needed.
+3. **Grafana datasource**: First-class Grafana integration for correlating traces with metrics.
+4. **All-in-one mode**: Single container for local dev keeps resource usage low and setup simple.
+5. **Apache 2.0 license**: No AGPL restrictions; compatible with our licensing requirements.
+6. **OpenSearch storage path**: Integrates with OpenSearch (already on the platform roadmap) for production persistence.
+
+**Grafana Tempo** was considered but rejected:
+- Requires object storage (S3/GCS) even for local dev — adds operational complexity.
+- No standalone UI; depends entirely on Grafana, making standalone debugging harder.
+- Sandbox status at time of decision.
+
+**Zipkin** was considered but rejected:
+- Not CNCF; smaller community.
+- Incomplete native OTLP support requires an extra OpenTelemetry Collector layer.
+- No Kubernetes-native deployment story.
+
+## Consequences
+
+### Positive
+
+- Completes the three observability pillars on the platform.
+- OTLP endpoint available to all services at `jaeger-query.tracing.svc.cluster.local:4317` (gRPC) and `:4318` (HTTP).
+- Jaeger UI accessible at `https://digiorg.local/jaeger` without additional ingress configuration overhead.
+- Prometheus scraping via ServiceMonitor on the admin port (`/metrics`).
+- Trace correlation in Grafana via the Jaeger datasource.
+
+### Negative
+
+- In-memory storage means all trace data is lost on pod restart in local dev.
+- No authentication on the Jaeger UI — acceptable for local dev, must be addressed before production exposure.
+- Additional resource consumption (~128Mi RAM minimum).
+
+### Migration path to production
+
+1. Provision OpenSearch cluster (or reuse existing if available).
+2. Update `storage.type: opensearch` and add connection config to values.yaml.
+3. Disable `allInOne`, enable separate `collector` and `query` deployments.
+4. Add OAuth2 proxy (Keycloak) in front of the query service.
+5. Configure adaptive sampling in the collector.
+
+## References
+
+- [Jaeger Documentation](https://www.jaegertracing.io/docs/)
+- [Jaeger Helm Chart](https://github.com/jaegertracing/helm-charts)
+- [OpenTelemetry OTLP Specification](https://opentelemetry.io/docs/specs/otlp/)
+- [Grafana Jaeger Datasource](https://grafana.com/docs/grafana/latest/datasources/jaeger/)
+- [CNCF Jaeger Project](https://www.cncf.io/projects/jaeger/)

--- a/platform/base/grafana/values.yaml
+++ b/platform/base/grafana/values.yaml
@@ -31,6 +31,16 @@ grafana:
       # Remove in production (use proper CA trust instead)
       tls_skip_verify_insecure: true
 
+  additionalDataSources:
+    - name: Jaeger
+      type: jaeger
+      url: http://jaeger-query.tracing.svc.cluster.local:16686/jaeger
+      access: proxy
+      isDefault: false
+      jsonData:
+        tracesToLogsV2:
+          datasourceUid: prometheus
+
 prometheus:
   prometheusSpec:
     retention: 1d

--- a/platform/base/ingress/digiorg-ingress.yaml
+++ b/platform/base/ingress/digiorg-ingress.yaml
@@ -17,6 +17,7 @@
 # - https://digiorg.local/grafana    → Grafana Monitoring
 # - https://digiorg.local/backstage  → Backstage Developer Portal
 # - https://digiorg.local/gitea      → Gitea Git Service
+# - https://digiorg.local/jaeger     → Jaeger Distributed Tracing
 # =============================================================================
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -67,6 +68,14 @@ spec:
                 name: prometheus-grafana
                 port:
                   number: 80
+          # Jaeger Distributed Tracing
+          - path: /jaeger(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: jaeger-query
+                port:
+                  number: 16686
           # Landing Page (root path - must be last due to catch-all)
           - path: /
             pathType: Prefix
@@ -198,6 +207,17 @@ spec:
   externalName: gitea-http.gitea.svc.cluster.local
   ports:
     - port: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger-query
+  namespace: ingress-nginx
+spec:
+  type: ExternalName
+  externalName: jaeger-query.tracing.svc.cluster.local
+  ports:
+    - port: 16686
 ---
 apiVersion: v1
 kind: Service

--- a/platform/base/jaeger/README.md
+++ b/platform/base/jaeger/README.md
@@ -1,0 +1,71 @@
+# Jaeger Distributed Tracing
+
+## What is Jaeger?
+
+Jaeger is an open-source, end-to-end distributed tracing platform. It helps monitor and troubleshoot transactions in complex distributed systems by tracking requests as they flow through multiple services. Jaeger is a CNCF graduated project and provides native support for OpenTelemetry (OTLP).
+
+In the DigiOrg Core Platform, Jaeger completes the **three pillars of observability**:
+- **Metrics** — Prometheus/Grafana (already deployed)
+- **Logs** — planned
+- **Traces** — Jaeger (this component)
+
+## Architecture
+
+This deployment uses the **all-in-one** mode, which runs the collector, query, and UI in a single container backed by in-memory storage. This is suitable for local development.
+
+```
+Application (OTLP) ──► Jaeger all-in-one ──► In-memory storage
+                              │
+                              └──► Jaeger UI (/jaeger)
+```
+
+## Ports
+
+| Port  | Protocol | Purpose                        |
+|-------|----------|--------------------------------|
+| 16686 | HTTP     | Jaeger UI and Query API        |
+| 4317  | gRPC     | OTLP trace ingestion (gRPC)    |
+| 4318  | HTTP     | OTLP trace ingestion (HTTP)    |
+| 14269 | HTTP     | Admin endpoint + /metrics      |
+
+## Accessing the UI
+
+Jaeger UI is accessible at: **https://digiorg.local/jaeger**
+
+The `--query.base-path=/jaeger` flag configures Jaeger to serve all assets and API calls under the `/jaeger` prefix, so no nginx URL rewriting is required.
+
+## Configuration Overview (values.yaml)
+
+| Setting | Value | Notes |
+|---------|-------|-------|
+| `allInOne.enabled` | `true` | Single-binary deployment |
+| `collector.enabled` | `false` | Disabled (all-in-one handles it) |
+| `query.enabled` | `false` | Disabled (all-in-one handles it) |
+| `storage.type` | `memory` | In-memory, data lost on restart |
+| `service.type` | `ClusterIP` | Accessed via ingress |
+| `ingress.enabled` | `false` | We use the platform ingress |
+
+## Instrumentation
+
+Services send traces to Jaeger using the OpenTelemetry SDK:
+
+```
+OTLP gRPC: jaeger-query.tracing.svc.cluster.local:4317
+OTLP HTTP: jaeger-query.tracing.svc.cluster.local:4318
+```
+
+## Production Considerations
+
+For production deployments the following changes are recommended:
+
+1. **Storage**: Replace in-memory with OpenSearch (or Elasticsearch/Cassandra). Set `storage.type: opensearch` and configure the connection.
+
+2. **Separate components**: Disable `allInOne` and enable `collector` and `query` separately for independent scaling.
+
+3. **Authentication**: Add an OAuth2 proxy (Keycloak) in front of the Jaeger query service. The UI has no built-in authentication.
+
+4. **Sampling**: Configure adaptive sampling in the collector to control trace volume at scale.
+
+5. **Resource limits**: Increase CPU/memory limits and add HPA based on observed usage.
+
+6. **Retention**: Configure index TTL in OpenSearch to match your retention policy.

--- a/platform/base/jaeger/kustomization.yaml
+++ b/platform/base/jaeger/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tracing
+resources:
+  - namespace.yaml
+  - servicemonitor.yaml

--- a/platform/base/jaeger/namespace.yaml
+++ b/platform/base/jaeger/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tracing
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    platform.digiorg.io/component: observability

--- a/platform/base/jaeger/servicemonitor.yaml
+++ b/platform/base/jaeger/servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: jaeger
+  namespace: tracing
+  labels:
+    release: prometheus
+spec:
+  namespaceSelector:
+    matchNames:
+      - tracing
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: jaeger
+  endpoints:
+    - port: admin-http
+      path: /metrics
+      interval: 30s

--- a/platform/base/jaeger/values.yaml
+++ b/platform/base/jaeger/values.yaml
@@ -1,0 +1,33 @@
+# Jaeger Helm Values — all-in-one for local dev
+allInOne:
+  enabled: true
+  image:
+    tag: latest
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  extraArgs:
+    - "--query.base-path=/jaeger"
+  extraPorts:
+    - name: otlp-grpc
+      containerPort: 4317
+      protocol: TCP
+    - name: otlp-http
+      containerPort: 4318
+      protocol: TCP
+collector:
+  enabled: false
+query:
+  enabled: false
+storage:
+  type: memory
+service:
+  type: ClusterIP
+serviceMonitor:
+  enabled: false
+ingress:
+  enabled: false

--- a/platform/base/landingpage/services-configmap.yaml
+++ b/platform/base/landingpage/services-configmap.yaml
@@ -59,5 +59,15 @@ data:
         "category": "monitoring",
         "requiresAuth": true,
         "displayOrder": 5
+      },
+      {
+        "id": "jaeger",
+        "name": "Jaeger",
+        "description": "Distributed Tracing",
+        "path": "/jaeger",
+        "icon": "tracing",
+        "category": "observability",
+        "requiresAuth": true,
+        "displayOrder": 6
       }
     ]


### PR DESCRIPTION
## Summary

Implements Issue #77 — adds Jaeger v2 distributed tracing to the DigiOrg Core Platform, completing the three pillars of observability (Metrics ✅, Logs 🔜, Traces ✅).

## Changes

### New Files
- `apps/platform/jaeger.yaml` — ArgoCD Application (sync wave 2)
- `platform/base/jaeger/namespace.yaml` — tracing namespace
- `platform/base/jaeger/values.yaml` — Helm values (all-in-one, in-memory for local dev)
- `platform/base/jaeger/servicemonitor.yaml` — Prometheus scrape config
- `platform/base/jaeger/kustomization.yaml` — Kustomize entry point
- `platform/base/jaeger/README.md` — deployment documentation
- `docs/adr/005-tracing-backend-jaeger.md` — ADR for tracing backend decision

### Modified Files
- `platform/base/ingress/digiorg-ingress.yaml` — added /jaeger path + ExternalName service
- `platform/base/grafana/values.yaml` — added Jaeger datasource
- `platform/base/landingpage/services-configmap.yaml` — registered Jaeger in platform portal

## Acceptance Criteria
- [x] ArgoCD Application at sync wave 2
- [x] Jaeger UI accessible at https://digiorg.local/jaeger
- [x] OTLP ingestion on ports 4317 (gRPC) and 4318 (HTTP)
- [x] ServiceMonitor for Prometheus scraping
- [x] Jaeger datasource in Grafana
- [x] Landing page registration
- [x] README documentation
- [x] ADR for tracing backend decision

Closes #77