### PR TITLE
fix(jaeger): Rewrite values.yaml to Jaeger v2 schema — fixes blank UI page (#80)

### DIFF
--- a/platform/base/jaeger/README.md
+++ b/platform/base/jaeger/README.md
@@ -11,39 +11,50 @@ In the DigiOrg Core Platform, Jaeger completes the **three pillars of observabil
 
 ## Architecture
 
-This deployment uses the **all-in-one** mode, which runs the collector, query, and UI in a single container backed by in-memory storage. This is suitable for local development.
+This deployment uses **Jaeger v2** (chart 3.x), which runs as a single binary based on the OpenTelemetry Collector framework. For local dev, in-memory storage is used.
 
 ```
-Application (OTLP) ──► Jaeger all-in-one ──► In-memory storage
-                              │
-                              └──► Jaeger UI (/jaeger)
+Application (OTLP) ──gRPC:4317 / HTTP:4318──► Jaeger (single binary)
+                                                      │
+                                          ┌───────────┴───────────┐
+                                    In-memory store        Jaeger UI (/jaeger)
+                                                                   │
+                                                          Prometheus :8888/metrics
 ```
 
 ## Ports
 
-| Port  | Protocol | Purpose                        |
-|-------|----------|--------------------------------|
-| 16686 | HTTP     | Jaeger UI and Query API        |
-| 4317  | gRPC     | OTLP trace ingestion (gRPC)    |
-| 4318  | HTTP     | OTLP trace ingestion (HTTP)    |
-| 14269 | HTTP     | Admin endpoint + /metrics      |
+| Port  | Protocol | Purpose                              |
+|-------|----------|--------------------------------------|
+| 16686 | HTTP     | Jaeger UI and Query API              |
+| 4317  | gRPC     | OTLP trace ingestion (gRPC)          |
+| 4318  | HTTP     | OTLP trace ingestion (HTTP)          |
+| 14269 | HTTP     | Health check endpoint                |
+| 8888  | HTTP     | Prometheus metrics (`/metrics`)      |
 
 ## Accessing the UI
 
 Jaeger UI is accessible at: **https://digiorg.local/jaeger**
 
-The `--query.base-path=/jaeger` flag configures Jaeger to serve all assets and API calls under the `/jaeger` prefix, so no nginx URL rewriting is required.
+`jaeger_query.base_path: /jaeger` (set in `values.yaml` via `userconfig:`) ensures Jaeger
+serves all static assets under the `/jaeger` prefix. No NGINX URL rewriting is required.
 
 ## Configuration Overview (values.yaml)
 
+Jaeger v2 uses the OpenTelemetry Collector YAML format for all configuration.
+The relevant settings are under `userconfig:`:
+
 | Setting | Value | Notes |
 |---------|-------|-------|
-| `allInOne.enabled` | `true` | Single-binary deployment |
-| `collector.enabled` | `false` | Disabled (all-in-one handles it) |
-| `query.enabled` | `false` | Disabled (all-in-one handles it) |
-| `storage.type` | `memory` | In-memory, data lost on restart |
-| `service.type` | `ClusterIP` | Accessed via ingress |
-| `ingress.enabled` | `false` | We use the platform ingress |
+| `jaeger_query.base_path` | `/jaeger` | Required for subpath deployment |
+| `jaeger_storage.primary_store` | `memory` | In-memory, data lost on restart |
+| OTLP gRPC endpoint | `0.0.0.0:4317` | Trace ingestion |
+| OTLP HTTP endpoint | `0.0.0.0:4318` | Trace ingestion |
+| Prometheus metrics | `0.0.0.0:8888` | Scraped by ServiceMonitor |
+| `ingress.enabled` | `false` | Using unified platform ingress |
+
+> **Note:** The old Jaeger v1 Helm schema (`allInOne:`, `collector:`, `query:`, `storage.type:`)
+> does not exist in chart 3.x and will be silently ignored. Always use `jaeger:` and `userconfig:`.
 
 ## Instrumentation
 
@@ -58,14 +69,14 @@ OTLP HTTP: jaeger-query.tracing.svc.cluster.local:4318
 
 For production deployments the following changes are recommended:
 
-1. **Storage**: Replace in-memory with OpenSearch (or Elasticsearch/Cassandra). Set `storage.type: opensearch` and configure the connection.
+1. **Storage**: Replace in-memory with OpenSearch via Crossplane. Update `jaeger_storage.backends.primary_store` to use the `elasticsearch` backend with your OpenSearch connection.
 
-2. **Separate components**: Disable `allInOne` and enable `collector` and `query` separately for independent scaling.
+2. **Authentication**: Add an OAuth2 proxy (Keycloak) in front of the Jaeger query service. The UI has no built-in authentication.
 
-3. **Authentication**: Add an OAuth2 proxy (Keycloak) in front of the Jaeger query service. The UI has no built-in authentication.
+3. **Sampling**: Configure adaptive sampling strategies in the OTEL Collector pipeline.
 
-4. **Sampling**: Configure adaptive sampling in the collector to control trace volume at scale.
+4. **Resource limits**: Increase CPU/memory limits and add HPA based on observed usage.
 
-5. **Resource limits**: Increase CPU/memory limits and add HPA based on observed usage.
+5. **Retention**: Configure index TTL in OpenSearch to match your retention policy (e.g. 7 days).
 
-6. **Retention**: Configure index TTL in OpenSearch to match your retention policy.
+6. **Multi-tenancy**: Enable Jaeger multi-tenancy for separate trace namespaces per team.

--- a/platform/base/jaeger/servicemonitor.yaml
+++ b/platform/base/jaeger/servicemonitor.yaml
@@ -4,7 +4,7 @@ metadata:
   name: jaeger
   namespace: tracing
   labels:
-    release: prometheus
+    release: prometheus    # Required: kube-prometheus-stack discovers by this label
 spec:
   namespaceSelector:
     matchNames:
@@ -13,6 +13,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: jaeger
   endpoints:
-    - port: admin-http
+    - port: metrics        # Jaeger v2 Prometheus metrics via OTEL reader (:8888/metrics)
       path: /metrics
       interval: 30s

--- a/platform/base/jaeger/values.yaml
+++ b/platform/base/jaeger/values.yaml
@@ -1,8 +1,13 @@
-# Jaeger Helm Values — all-in-one for local dev
-allInOne:
-  enabled: true
-  image:
-    tag: latest
+# Jaeger Helm Values — Jaeger v2 (chart 3.x)
+# Docs: https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config.yaml
+# Chart: https://github.com/jaegertracing/helm-charts/blob/main/charts/jaeger/values.yaml
+#
+# NOTE: Jaeger v2 uses the OpenTelemetry Collector framework.
+# All Jaeger-specific config goes under `userconfig:` (OTEL Collector YAML).
+# The old v1 schema (allInOne, collector, query, storage.type) does NOT exist in chart 3.x.
+
+# Resource limits for the Jaeger pod
+jaeger:
   resources:
     requests:
       cpu: 50m
@@ -10,24 +15,72 @@ allInOne:
     limits:
       cpu: 500m
       memory: 512Mi
-  extraArgs:
-    - "--query.base-path=/jaeger"
-  extraPorts:
-    - name: otlp-grpc
-      containerPort: 4317
-      protocol: TCP
-    - name: otlp-http
-      containerPort: 4318
-      protocol: TCP
-collector:
-  enabled: false
-query:
-  enabled: false
-storage:
-  type: memory
-service:
-  type: ClusterIP
-serviceMonitor:
-  enabled: false
+  # Expose OTLP + Prometheus metrics ports via the service
+  service:
+    extraPorts:
+      - name: otlp-grpc
+        port: 4317
+        targetPort: 4317
+        protocol: TCP
+      - name: otlp-http
+        port: 4318
+        targetPort: 4318
+        protocol: TCP
+      - name: metrics
+        port: 8888
+        targetPort: 8888
+        protocol: TCP
+
+# Jaeger v2 OTEL Collector config
+# base_path: /jaeger is required for correct static asset routing behind NGINX subpath
+userconfig:
+  service:
+    extensions: [jaeger_storage, jaeger_query, healthcheckv2]
+    pipelines:
+      traces:
+        receivers: [otlp]
+        exporters: [jaeger_storage_exporter]
+    telemetry:
+      resource:
+        service.name: jaeger
+      metrics:
+        level: basic
+        readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: 0.0.0.0
+                  port: 8888
+
+  extensions:
+    healthcheckv2:
+      use_v2: true
+      http:
+        endpoint: 0.0.0.0:14269
+
+    jaeger_query:
+      base_path: /jaeger
+      storage:
+        traces: primary_store
+
+    jaeger_storage:
+      backends:
+        primary_store:
+          memory:
+            max_traces: 100000  # in-memory storage for local dev
+
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+  exporters:
+    jaeger_storage_exporter:
+      trace_storage: primary_store
+
+# Ingress managed via unified platform ingress (platform/base/ingress/digiorg-ingress.yaml)
 ingress:
   enabled: false


### PR DESCRIPTION
## Problem

Navigating to `https://digiorg.local/jaeger` shows a blank page with 404 errors for static assets:

```
GET https://digiorg.local/static/index-*.js   → 404
GET https://digiorg.local/static/index-*.css  → 404
```

## Root Cause

The `values.yaml` introduced in #79 used the **Jaeger v1 Helm schema**, but the ArgoCD Application targets chart `3.x` which ships **Jaeger v2** (a complete rewrite based on the OpenTelemetry Collector framework).

All v1 keys (`allInOne:`, `collector:`, `query:`, `storage.type:`, `extraArgs:`) are **silently ignored** by the v2 chart. As a result:
- `jaeger_query.base_path` was never set → defaulted to `/`
- Jaeger served the UI with `<base href="/">`  
- Static assets resolved to `/static/...` (root path)
- NGINX has no route for `/static/...` → 404 blank page

## Fix

| File | Change |
|------|--------|
| `platform/base/jaeger/values.yaml` | Full rewrite: v1 schema → correct v2 `jaeger:` + `userconfig:` format |
| `platform/base/jaeger/servicemonitor.yaml` | Port `admin-http` → `metrics` (:8888, OTEL Prometheus reader) |
| `platform/base/jaeger/README.md` | Updated architecture docs + v1-vs-v2 schema warning |

### Key change in values.yaml

```yaml
# Before (v1 schema — silently ignored by chart 3.x)
allInOne:
  enabled: true
  extraArgs:
    - "--query.base-path=/jaeger"   # v1 CLI flag, not valid in v2

# After (v2 schema)
userconfig:
  extensions:
    jaeger_query:
      base_path: /jaeger             # correctly sets <base href="/jaeger/">
    jaeger_storage:
      backends:
        primary_store:
          memory:
            max_traces: 100000
```

## Acceptance Criteria

- [x] `https://digiorg.local/jaeger` loads without blank page
- [x] No `/static/...` 404 errors in browser DevTools
- [x] OTLP ingestion on ports 4317 (gRPC) and 4318 (HTTP)
- [x] Prometheus metrics endpoint on :8888/metrics
- [x] ServiceMonitor scrapes correct port

Fixes #80