### PR TITLE
feat(platform-db): deploy OpenSearch as observability storage backend

### DIFF
--- a/apps/platform/opensearch.yaml
+++ b/apps/platform/opensearch.yaml
@@ -1,0 +1,50 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opensearch
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 0: Data layer — deployed alongside PostgreSQL, before Jaeger (Wave 2)
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: default
+
+  sources:
+    # OpenSearch via official Helm chart
+    - repoURL: https://helm.opensearch.org
+      chart: opensearch
+      targetRevision: "3.6.0"
+      helm:
+        releaseName: opensearch
+        valueFiles:
+          - $values/platform/base/opensearch/values.yaml
+
+    # Reference to values file in Git repo
+    - repoURL: https://github.com/digiorg/core.git
+      targetRevision: HEAD
+      ref: values
+
+    # ServiceMonitor and supplementary resources via Kustomize
+    - repoURL: https://github.com/digiorg/core.git
+      targetRevision: HEAD
+      path: platform/base/opensearch
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: platform-db
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/docs/adr/005-tracing-backend-jaeger.md
+++ b/docs/adr/005-tracing-backend-jaeger.md
@@ -1,6 +1,6 @@
 # ADR-005: Tracing Backend — Jaeger
 
-**Status:** Accepted  
+**Status:** Accepted (updated 2026-05-01)  
 **Date:** 2026-04-30  
 **Deciders:** @simon-itstudio  
 
@@ -75,11 +75,11 @@ For local development we deploy in **all-in-one** mode with in-memory storage. F
 
 ### Migration path to production
 
-1. Provision OpenSearch cluster (or reuse existing if available).
-2. Update `storage.type: opensearch` and add connection config to values.yaml.
-3. Disable `allInOne`, enable separate `collector` and `query` deployments.
-4. Add OAuth2 proxy (Keycloak) in front of the query service.
-5. Configure adaptive sampling in the collector.
+1. ~~Provision OpenSearch cluster (or reuse existing if available).~~ ✅ **Done** — OpenSearch deployed in `platform-db` namespace (see [ADR-006](006-observability-storage-opensearch.md) and issue #83).
+2. ~~Update `storage.type: opensearch` and add connection config to values.yaml.~~ ✅ **Done** — `jaeger_storage.backends.primary_store` switched to `elasticsearch` backend pointing to `opensearch-cluster-master.platform-db.svc.cluster.local:9200`.
+3. Disable `allInOne`, enable separate `collector` and `query` deployments. _(planned for production scale-out)_
+4. Add OAuth2 proxy (Keycloak) in front of the query service. _(tracked in issue #82)_
+5. Configure adaptive sampling in the collector. _(planned)_
 
 ## References
 

--- a/docs/adr/006-observability-storage-opensearch.md
+++ b/docs/adr/006-observability-storage-opensearch.md
@@ -1,0 +1,111 @@
+# ADR-006: Observability Storage Backend — OpenSearch
+
+**Status:** Accepted  
+**Date:** 2026-05-01  
+**Deciders:** @simon-itstudio  
+**Related:** [ADR-005](005-tracing-backend-jaeger.md), [Issue #82](https://github.com/digiorg/core/issues/82), [Issue #83](https://github.com/digiorg/core/issues/83)
+
+## Context
+
+ADR-005 introduced Jaeger v2 as the distributed tracing backend with in-memory storage, explicitly deferring persistent storage to a later decision. The migration path in ADR-005 identified OpenSearch as the preferred production storage backend.
+
+Additionally, the platform has only two of the three observability pillars complete:
+
+| Pillar | Tool | Storage | Status |
+|--------|------|---------|--------|
+| Metrics | Prometheus + Grafana | Prometheus PVC | ✅ Deployed |
+| Traces | Jaeger v2 | In-memory → **OpenSearch** | ✅ Migrated |
+| Logs | planned | **OpenSearch** | 🔲 Planned |
+
+A dedicated, persistent, scalable storage backend is needed for traces (immediately) and logs (future). Issue #82 analysed options (PostgreSQL, Cassandra, OpenSearch) and recommended OpenSearch. This ADR records that decision.
+
+## Decision
+
+We deploy **OpenSearch** (via the official `opensearch-project/opensearch` Helm chart) in the `platform-db` namespace as the shared observability storage backend.
+
+- Helm Chart: `opensearch-project/opensearch` v3.6.0
+- Repo: `https://helm.opensearch.org`
+- Mode: single-node for local dev, 3-node cluster for production
+- ArgoCD Sync Wave: 0 (data layer, before all application services)
+
+## Rationale
+
+### Why OpenSearch over alternatives
+
+| Criterion | OpenSearch | Cassandra | PostgreSQL |
+|-----------|-----------|-----------|------------|
+| Jaeger native support | ✅ Official (1.x–3.x) | ✅ Official (4.x–5.x) | ❌ Community-only |
+| Init job required | ❌ No | ✅ Schema script needed | ❌ N/A |
+| Log aggregation support | ✅ Yes (future Fluent Bit) | ❌ No | ❌ No |
+| Grafana datasource | ✅ Elasticsearch type | ❌ No | ✅ PostgreSQL type |
+| Index TTL / rollover | ✅ ISM built-in | ✅ TTL per table | ❌ Manual |
+| Full-text search | ✅ Yes | ❌ No | ⚠️ Limited |
+| Kubernetes Helm chart | ✅ Official | ✅ Bitnami | ✅ Custom |
+| License | ✅ Apache 2.0 | ✅ Apache 2.0 | ✅ PostgreSQL |
+| Resource overhead | ⚠️ Medium (512 MB+) | ⚠️ High (1 GB+) | ✅ Low |
+| ADR-005 recommendation | ✅ Explicitly preferred | ⚠️ Fallback | ❌ Rejected |
+
+**OpenSearch** was chosen because:
+
+1. **Official Jaeger support:** Versions 1.x, 2.x, 3.x are all supported with no additional init steps. Index creation is automatic on first trace write.
+2. **Elasticsearch API compatibility:** OpenSearch exposes the ES 7.10.2 REST API — Grafana, Jaeger, Fluent Bit and other tools integrate natively without additional adapters.
+3. **Observability convergence:** OpenSearch is the only option that covers both traces (now) and logs (future). Deploying it once establishes the full observability storage infrastructure.
+4. **No schema maintenance:** Unlike Cassandra (CQL schema init) or PostgreSQL, OpenSearch requires no upfront schema work — indices are created dynamically.
+5. **ISM for retention:** The built-in Index State Management provides automatic index rollover and deletion policies without external cron jobs.
+6. **Apache 2.0 license:** Fully open-source, no AGPL or proprietary restrictions.
+7. **ADR-005 alignment:** Explicitly called out as the preferred production backend in the Jaeger ADR migration path.
+
+**Cassandra** was considered but not chosen:
+- No benefit over OpenSearch for trace storage at this scale.
+- Heavier resource requirements (multi-GB RAM for cluster formation).
+- No log aggregation support — a second storage backend would still be needed.
+- Schema init required via `cqlsh` script.
+
+**PostgreSQL** was ruled out:
+- No official Jaeger support (community gRPC adapter only, unmaintained risk).
+- No suitable for full-text search or time-series log retention.
+
+## Namespace Placement
+
+OpenSearch is placed in the existing `platform-db` namespace alongside PostgreSQL. This is consistent with the platform principle of centralizing all persistent data services in one namespace, making backup, access control, and network policies uniform.
+
+```
+platform-db namespace
+├── postgresql     ← Keycloak, Backstage, Gitea databases
+└── opensearch     ← Jaeger traces, future log aggregation
+```
+
+## Consequences
+
+### Positive
+
+- Jaeger traces are now **persistent across pod restarts**.
+- Grafana gains an Elasticsearch-compatible datasource for direct trace searching alongside the Jaeger datasource.
+- Foundation is laid for the third observability pillar (logs via Fluent Bit → OpenSearch).
+- Index TTL/rollover is configurable via ISM — no external cleanup jobs needed.
+
+### Negative
+
+- Additional resource consumption: ~512 MB RAM minimum (single-node dev), ~3 × 2 GB in production.
+- `vm.max_map_count=262144` must be set on each Kubernetes node — handled via privileged `initContainer` for KinD.
+- Security plugin is disabled in local dev — must be enabled and configured for production.
+- KinD clusters may be slower to initialize due to the OpenSearch startup time (~30–60 s).
+
+### Production Migration Path
+
+1. Set `singleNode: false`, `replicas: 3` in `values.yaml`.
+2. Remove `DISABLE_SECURITY_PLUGIN`, configure TLS via cert-manager and RBAC.
+3. Integrate Keycloak OIDC with OpenSearch Security plugin for SSO.
+4. Configure ISM policy for index rollover (e.g. 30-day retention, max 50 GB per index).
+5. Deploy OpenSearch Dashboards (separate Helm chart) for direct log/trace UI with Keycloak SSO.
+6. Set `vm.max_map_count=262144` via node-level DaemonSet or cloud provider node pool configuration.
+7. Use a high-performance StorageClass (SSD-backed) for the PVC.
+
+## References
+
+- [OpenSearch Helm Charts](https://github.com/opensearch-project/helm-charts)
+- [Jaeger OpenSearch Storage Docs](https://www.jaegertracing.io/docs/latest/opensearch/)
+- [OpenSearch Index State Management](https://docs.opensearch.org/latest/im-plugin/ism/index/)
+- [ADR-005: Tracing Backend Jaeger](005-tracing-backend-jaeger.md)
+- [Issue #82: Jaeger Refactoring Analysis](https://github.com/digiorg/core/issues/82)
+- [Issue #83: OpenSearch Feature](https://github.com/digiorg/core/issues/83)

--- a/platform/base/grafana/values.yaml
+++ b/platform/base/grafana/values.yaml
@@ -41,6 +41,21 @@ grafana:
         tracesToLogsV2:
           datasourceUid: prometheus
 
+    # OpenSearch as Elasticsearch-compatible datasource for direct trace/log search.
+    # Uses the jaeger-span-* index pattern written by Jaeger.
+    - name: OpenSearch (Traces)
+      type: elasticsearch
+      url: http://opensearch-cluster-master.platform-db.svc.cluster.local:9200
+      access: proxy
+      isDefault: false
+      jsonData:
+        esVersion: "70"          # OpenSearch is compatible with ES 7.10.2 API
+        timeField: startTimeMillis
+        logMessageField: operationName
+        logLevelField: tags.level
+      # Index pattern: jaeger-span-YYYY-MM-DD (daily rotation by Jaeger)
+      database: "jaeger-span-*"
+
 prometheus:
   prometheusSpec:
     retention: 1d

--- a/platform/base/jaeger/values.yaml
+++ b/platform/base/jaeger/values.yaml
@@ -8,6 +8,15 @@
 
 # Resource limits for the Jaeger pod
 jaeger:
+  # Inject OpenSearch admin password into Jaeger via environment variable.
+  # The jaeger-opensearch-credentials secret is created by local-setup.nu.
+  extraEnv:
+    - name: OPENSEARCH_ADMIN_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: jaeger-opensearch-credentials
+          key: password
+
   resources:
     requests:
       cpu: 50m
@@ -66,8 +75,18 @@ userconfig:
     jaeger_storage:
       backends:
         primary_store:
-          memory:
-            max_traces: 100000  # in-memory storage for local dev
+          elasticsearch:
+            # OpenSearch is Elasticsearch 7.10.2 API-compatible — use elasticsearch backend type.
+            # OpenSearch deployed in platform-db namespace (Wave 0, ready before Jaeger).
+            server_urls: http://opensearch-cluster-master.platform-db.svc.cluster.local:9200
+            index_prefix: jaeger
+            # Credentials reference the jaeger-opensearch-credentials secret (created by local-setup.nu)
+            username: admin
+            password: "${OPENSEARCH_ADMIN_PASSWORD}"
+            # Self-signed cert in local dev — disable host verification
+            # Remove tls section in production and configure proper CA trust
+            tls:
+              skip_host_verify: true
 
   receivers:
     otlp:

--- a/platform/base/opensearch/README.md
+++ b/platform/base/opensearch/README.md
@@ -1,0 +1,151 @@
+# OpenSearch — Observability Data Backend
+
+## What is OpenSearch?
+
+OpenSearch is an open-source, Apache 2.0-licensed search and analytics engine forked from Elasticsearch 7.10.2. It serves as the **persistent observability storage backend** for the DigiOrg Core Platform.
+
+## Role in the Platform
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                   Observability Stack                                │
+│                                                                      │
+│  Services (OTLP)                                                     │
+│      │                                                               │
+│      ▼ gRPC:4317 / HTTP:4318                                         │
+│  ┌──────────┐   writes traces   ┌─────────────────────────────────┐  │
+│  │  Jaeger  │ ────────────────► │  OpenSearch                     │  │
+│  │  (tracing│                   │  platform-db namespace          │  │
+│  │   ns)    │ ◄──── queries ─── │  opensearch-cluster-master:9200 │  │
+│  └──────────┘                   └─────────────────────────────────┘  │
+│       │                                      │                       │
+│       ▼                                      ▼                       │
+│  Jaeger UI (/jaeger)              Grafana Elasticsearch datasource   │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+| Observability Pillar | Tool | Storage |
+|---------------------|------|---------|
+| **Metrics** | Prometheus + Grafana | In-cluster (Prometheus PVC) |
+| **Traces** | Jaeger v2 | **OpenSearch** (this component) |
+| **Logs** | planned | **OpenSearch** (future) |
+
+## Architecture
+
+This deployment uses the **official OpenSearch Helm chart** (`opensearch-project/opensearch`) in single-node mode for local development.
+
+```
+platform-db namespace
+├── postgresql (StatefulSet)   ← Keycloak, Backstage, Gitea databases
+└── opensearch (StatefulSet)   ← Jaeger traces, future logs
+    └── Service: opensearch-cluster-master:9200 (ClusterIP)
+```
+
+## Deployment Parameters
+
+| Parameter | Local Dev | Production |
+|-----------|-----------|------------|
+| `singleNode` | `true` | `false` |
+| Replicas | 1 | 3 |
+| Heap | `-Xmx512M` | `-Xmx2G` or higher |
+| Storage | 8Gi | 100Gi+ |
+| Security Plugin | disabled | enabled (TLS + RBAC) |
+
+## Ports
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 9200 | HTTP | REST API (Jaeger, Grafana, admin) |
+| 9300 | TCP | Cluster transport (inter-node) |
+| 9600 | HTTP | Performance Analyzer metrics |
+
+## Accessing OpenSearch
+
+From within the cluster:
+
+```bash
+# REST API
+http://opensearch-cluster-master.platform-db.svc.cluster.local:9200
+
+# Health check
+curl http://opensearch-cluster-master.platform-db.svc.cluster.local:9200/_cluster/health
+
+# List indices (Jaeger creates these automatically)
+curl http://opensearch-cluster-master.platform-db.svc.cluster.local:9200/_cat/indices?v
+```
+
+## Configuration Overview (values.yaml)
+
+| Setting | Value | Notes |
+|---------|-------|-------|
+| `clusterName` | `opensearch-cluster` | Cluster identity |
+| `singleNode` | `true` | Local dev; set `false` in production |
+| `opensearchJavaOpts` | `-Xmx512M -Xms512M` | JVM heap |
+| `DISABLE_SECURITY_PLUGIN` | `true` | Local dev only — remove in production |
+| Storage | 8Gi PVC | Default provisioner (standard on KinD) |
+| `vm.max_map_count` | 262144 | Set via privileged initContainer |
+
+## Jaeger Integration
+
+Jaeger connects to OpenSearch via the `elasticsearch` backend type (OpenSearch is API-compatible with ES 7.10.2):
+
+```
+OTLP endpoint:  jaeger-query.tracing.svc.cluster.local:4317 (gRPC)
+Storage write:  opensearch-cluster-master.platform-db.svc.cluster.local:9200
+Index pattern:  jaeger-span-YYYY-MM-DD  (daily rotation)
+```
+
+Jaeger creates indices automatically on first trace ingest — no schema initialization needed.
+
+## Grafana Integration
+
+OpenSearch is available as a Grafana datasource using the built-in Elasticsearch datasource type:
+
+- **Name:** OpenSearch (Traces)
+- **URL:** `http://opensearch-cluster-master.platform-db.svc.cluster.local:9200`
+- **Index:** `jaeger-span-*`
+- **Time field:** `startTimeMillis`
+
+## Secrets
+
+| Namespace | Secret | Key | Used By |
+|-----------|--------|-----|---------|
+| `platform-db` | `opensearch-secrets` | `OPENSEARCH_ADMIN_PASSWORD` | OpenSearch admin bootstrap |
+
+Secret is created by `scripts/local-setup.nu` before ArgoCD sync.
+
+## ArgoCD Sync Wave
+
+OpenSearch is deployed in **Wave 0** — same wave as PostgreSQL — to ensure it is available before Jaeger (Wave 2) starts.
+
+| Wave | Services |
+|------|---------|
+| 0 | cert-manager, postgresql, nats, **opensearch** |
+| 2 | jaeger (connects to opensearch), grafana, backstage, landingpage |
+
+## Production Considerations
+
+1. **Enable Security Plugin:** Remove `DISABLE_SECURITY_PLUGIN`, configure TLS certificates and RBAC.
+2. **Scale out:** Set `singleNode: false`, `replicas: 3` for HA.
+3. **Heap sizing:** Increase to `-Xmx2G` or higher based on trace ingest volume.
+4. **Index lifecycle:** Configure ISM (Index State Management) for automatic index rollover and deletion (e.g. 30-day retention).
+5. **Keycloak OIDC:** Enable OpenSearch Dashboards with Keycloak SSO for direct log/trace search UI.
+6. **Persistent volume:** Use a high-performance storage class (SSD-backed).
+
+## Troubleshooting
+
+```bash
+# Pod status
+kubectl get pods -n platform-db -l app.kubernetes.io/name=opensearch
+
+# Logs
+kubectl logs -n platform-db opensearch-cluster-master-0
+
+# Cluster health
+kubectl exec -n platform-db opensearch-cluster-master-0 -- \
+  curl -s http://localhost:9200/_cluster/health | jq .
+
+# List Jaeger indices
+kubectl exec -n platform-db opensearch-cluster-master-0 -- \
+  curl -s 'http://localhost:9200/_cat/indices/jaeger-*?v'
+```

--- a/platform/base/opensearch/kustomization.yaml
+++ b/platform/base/opensearch/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: platform-db
+
+resources:
+  - servicemonitor.yaml
+
+# Note: OpenSearch itself is deployed via Helm by the ArgoCD Application.
+# See: apps/platform/opensearch.yaml
+# This kustomization provides supplementary resources (ServiceMonitor, etc.)

--- a/platform/base/opensearch/servicemonitor.yaml
+++ b/platform/base/opensearch/servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: opensearch
+  namespace: platform-db
+  labels:
+    release: prometheus    # Required: kube-prometheus-stack discovers by this label
+spec:
+  namespaceSelector:
+    matchNames:
+      - platform-db
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+  endpoints:
+    - port: http            # OpenSearch HTTP port (9200) — exposes /_prometheus/metrics
+      path: /_prometheus/metrics
+      interval: 30s

--- a/platform/base/opensearch/values.yaml
+++ b/platform/base/opensearch/values.yaml
@@ -1,0 +1,106 @@
+# OpenSearch Helm Values — Single-node for local dev / KinD
+# Chart:   opensearch-project/opensearch v3.6.0
+# Repo:    https://helm.opensearch.org
+# Docs:    https://docs.opensearch.org/latest/install-and-configure/install-opensearch/helm/
+#
+# Role: Observability data backend
+#   - Primary trace storage for Jaeger (replaces in-memory)
+#   - Foundation for future log aggregation (OpenSearch + Fluent Bit)
+#   - Grafana Elasticsearch-compatible datasource
+#
+# Production notes:
+#   - Set singleNode: false, replicas: 3
+#   - Remove DISABLE_SECURITY_PLUGIN and configure TLS + RBAC
+#   - Increase heap to -Xmx2G or higher depending on ingest volume
+#   - Add Keycloak OIDC via OpenSearch Security plugin
+
+# =============================================================================
+# Cluster identity
+# =============================================================================
+clusterName: "opensearch-cluster"
+nodeGroup: "master"
+
+# Single-node mode: disables bootstrap checks and forces replicas=1.
+# Required for KinD / local dev — set to false in production.
+singleNode: true
+replicas: 1
+
+# =============================================================================
+# Java Heap
+# =============================================================================
+# Keep Xms == Xmx to avoid heap resize overhead.
+# 512 MB is sufficient for trace-only workloads on local dev.
+opensearchJavaOpts: "-Xmx512M -Xms512M"
+
+# =============================================================================
+# Environment — admin password + security plugin
+# =============================================================================
+extraEnvs:
+  # Required since OpenSearch 2.12: strong admin password must be provided
+  - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: opensearch-secrets
+        key: OPENSEARCH_ADMIN_PASSWORD
+  # Disable the security plugin for local dev (no TLS / RBAC required).
+  # Remove this env var in production and configure the security plugin properly.
+  - name: DISABLE_SECURITY_PLUGIN
+    value: "true"
+
+# =============================================================================
+# Resources
+# =============================================================================
+resources:
+  requests:
+    cpu: "250m"
+    memory: "512Mi"
+  limits:
+    cpu: "1000m"
+    memory: "1Gi"
+
+# =============================================================================
+# Persistent storage
+# =============================================================================
+persistence:
+  enabled: true
+  size: 8Gi
+  # storageClass: "" — uses cluster default (standard on KinD)
+
+# =============================================================================
+# OpenSearch configuration
+# =============================================================================
+config:
+  opensearch.yml: |
+    cluster.name: opensearch-cluster
+    network.host: 0.0.0.0
+    # Single-node: suppresses bootstrap checks (multi-node cluster formation disabled)
+    discovery.type: single-node
+
+# =============================================================================
+# KinD bootstrap: vm.max_map_count
+# =============================================================================
+# OpenSearch requires vm.max_map_count >= 262144.
+# On KinD the Docker node doesn't inherit host sysctl settings, so we set it
+# via a privileged initContainer before OpenSearch starts.
+extraInitContainers:
+  - name: sysctl
+    image: busybox:1.36
+    imagePullPolicy: IfNotPresent
+    command: ["sysctl", "-w", "vm.max_map_count=262144"]
+    securityContext:
+      privileged: true
+
+# =============================================================================
+# Network
+# =============================================================================
+# No direct external ingress needed — accessed internally by Jaeger and Grafana.
+# Service is ClusterIP by default.
+ingress:
+  enabled: false
+
+# =============================================================================
+# RBAC / ServiceAccount
+# =============================================================================
+rbac:
+  create: false
+  serviceAccountName: ""

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -151,7 +151,7 @@ def deploy_root_app [] {
     print ""
     print "ArgoCD Sync Waves:"
     print "  Wave -1: root-app (just deployed)"
-    print "  Wave  0: cert-manager (TLS), postgresql (shared database)"
+    print "  Wave  0: cert-manager (TLS), postgresql (shared database), opensearch (observability backend), nats (messaging)"
     print "  Wave  1: keycloak (IdP), argocd (self-managed GitOps)"
     print "  Wave  2: landingpage, backstage, gitea, grafana"
     print "  Wave  3: crossplane, kyverno"
@@ -165,7 +165,7 @@ def wait_for_argocd_apps [] {
     print ""
     
     # Apps to wait for (in wave order)
-    let apps = ["cert-manager", "postgresql", "keycloak", "gitea", "landingpage", "backstage", "grafana", "crossplane", "kyverno"]
+    let apps = ["cert-manager", "postgresql", "opensearch", "keycloak", "gitea", "landingpage", "backstage", "grafana", "crossplane", "kyverno"]
     
     mut all_healthy = false
     mut attempts = 0
@@ -480,6 +480,19 @@ def create_platform_secrets [] {
     # Messaging namespace (for NATS server + Surveyor)
     kubectl create namespace messaging --dry-run=client -o yaml | kubectl apply -f -
     print $"(ansi green)✓ Messaging namespace created(ansi reset)"
+
+    # OpenSearch secret (admin password for observability backend)
+    let opensearch_admin_password = ($env.OPENSEARCH_ADMIN_PASSWORD? | default (generate_password))
+    # Secret in platform-db namespace (for OpenSearch itself)
+    (kubectl create secret generic opensearch-secrets -n platform-db
+        --from-literal=OPENSEARCH_ADMIN_PASSWORD=($opensearch_admin_password)
+        --dry-run=client -o yaml | kubectl apply -f -)
+    # Secret in tracing namespace (for Jaeger to authenticate against OpenSearch)
+    kubectl create namespace tracing --dry-run=client -o yaml | kubectl apply -f -
+    (kubectl create secret generic jaeger-opensearch-credentials -n tracing
+        --from-literal=password=($opensearch_admin_password)
+        --dry-run=client -o yaml | kubectl apply -f -)
+    print $"(ansi green)✓ OpenSearch secrets created [platform-db + tracing](ansi reset)"
 }
 
 def install_argocd [] {


### PR DESCRIPTION
## Summary

Implements [#83](https://github.com/digiorg/core/issues/83) — deploys **OpenSearch** as the persistent observability storage backend in the `platform-db` namespace, migrates Jaeger from in-memory to OpenSearch, and adds OpenSearch as a Grafana datasource.

---

## Changes

### New: OpenSearch Deployment (`Wave 0`)

| File | Description |
|------|-------------|
| `apps/platform/opensearch.yaml` | ArgoCD Application — Helm chart `opensearch-project/opensearch` v3.6.0, Wave 0 |
| `platform/base/opensearch/values.yaml` | Helm values: single-node, 512 MB heap, 8Gi PVC, security plugin disabled for local dev |
| `platform/base/opensearch/kustomization.yaml` | Kustomize entrypoint for supplementary resources |
| `platform/base/opensearch/servicemonitor.yaml` | Prometheus ServiceMonitor for `/_prometheus/metrics` |
| `platform/base/opensearch/README.md` | Architecture, port reference, troubleshooting |

### Updated: Jaeger Storage Migration

`platform/base/jaeger/values.yaml`
- `jaeger_storage.backends.primary_store`: **`memory` → `elasticsearch`** (OpenSearch-compatible)
- Endpoint: `opensearch-cluster-master.platform-db.svc.cluster.local:9200`
- Index prefix: `jaeger`
- Credentials injected via `jaeger-opensearch-credentials` secret (env var `OPENSEARCH_ADMIN_PASSWORD`)

### Updated: Grafana Datasource

`platform/base/grafana/values.yaml`
- New `additionalDataSources` entry: **OpenSearch (Traces)** — Elasticsearch type, `jaeger-span-*` index pattern

### Updated: local-setup.nu

`scripts/local-setup.nu`
- Creates `opensearch-secrets` secret in `platform-db` namespace
- Creates `jaeger-opensearch-credentials` secret in `tracing` namespace
- Adds `opensearch` to the apps wait-list
- Updates Wave 0 description

### Updated: ADRs

| File | Change |
|------|--------|
| `docs/adr/005-tracing-backend-jaeger.md` | Migration steps 1+2 marked ✅ Done |
| `docs/adr/006-observability-storage-opensearch.md` | **New** — records OpenSearch storage decision |

---

## Architecture After This PR

```
Services (OTLP)
    │ gRPC:4317 / HTTP:4318
    ▼
Jaeger (tracing ns)  ──writes──►  OpenSearch (platform-db ns)
                     ◄─queries──  opensearch-cluster-master:9200
         │                                │
         ▼                                ▼
   Jaeger UI (/jaeger)       Grafana: OpenSearch datasource
                                      jaeger-span-* index
```

---

## Test Checklist

- [ ] `nu scripts/local-setup.nu up` succeeds
- [ ] OpenSearch pod healthy: `kubectl get pods -n platform-db`
- [ ] Jaeger connects to OpenSearch (no storage errors in logs)
- [ ] Traces visible in Jaeger UI at `https://digiorg.local/jaeger`
- [ ] OpenSearch datasource queryable in Grafana

---

Closes #83