### PR TITLE
refactor(jaeger): SSO via Keycloak oauth2-proxy, Landing Page Tile rename, Cassandra Sub-Chart entfernen

### DIFF
--- a/platform/base/ingress/digiorg-ingress.yaml
+++ b/platform/base/ingress/digiorg-ingress.yaml
@@ -17,7 +17,7 @@
 # - https://digiorg.local/grafana    → Grafana Monitoring
 # - https://digiorg.local/backstage  → Backstage Developer Portal
 # - https://digiorg.local/gitea      → Gitea Git Service
-# - https://digiorg.local/jaeger     → Jaeger Distributed Tracing
+# - https://digiorg.local/jaeger     → Jaeger UI (via oauth2-proxy → Keycloak SSO)
 # =============================================================================
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -68,14 +68,15 @@ spec:
                 name: prometheus-grafana
                 port:
                   number: 80
-          # Jaeger Distributed Tracing
+          # Jaeger Distributed Tracing — routed via oauth2-proxy for Keycloak SSO
+          # oauth2-proxy handles /jaeger and /jaeger/oauth2/callback (proxy-prefix)
           - path: /jaeger(/|$)(.*)
             pathType: ImplementationSpecific
             backend:
               service:
-                name: jaeger-query
+                name: jaeger-oauth2-proxy
                 port:
-                  number: 16686
+                  number: 4180
           # Landing Page (root path - must be last due to catch-all)
           - path: /
             pathType: Prefix
@@ -211,13 +212,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: jaeger-query
+  name: jaeger-oauth2-proxy
   namespace: ingress-nginx
 spec:
   type: ExternalName
-  externalName: jaeger-query.tracing.svc.cluster.local
+  externalName: jaeger-oauth2-proxy.tracing.svc.cluster.local
   ports:
-    - port: 16686
+    - port: 4180
 ---
 apiVersion: v1
 kind: Service

--- a/platform/base/jaeger/README.md
+++ b/platform/base/jaeger/README.md
@@ -11,15 +11,17 @@ In the DigiOrg Core Platform, Jaeger completes the **three pillars of observabil
 
 ## Architecture
 
-This deployment uses **Jaeger v2** (chart 3.x), which runs as a single binary based on the OpenTelemetry Collector framework. For local dev, in-memory storage is used.
+This deployment uses **Jaeger v2** (chart 3.x) with **OpenSearch** as persistent trace storage and **oauth2-proxy** for Keycloak SSO.
 
 ```
 Application (OTLP) ──gRPC:4317 / HTTP:4318──► Jaeger (single binary)
-                                                      │
-                                          ┌───────────┴───────────┐
-                                    In-memory store        Jaeger UI (/jaeger)
-                                                                   │
-                                                          Prometheus :8888/metrics
+                                                      │                  │
+                                               OpenSearch           Prometheus
+                                              (platform-db)       :8888/metrics
+
+Browser ──► NGINX /jaeger ──► oauth2-proxy:4180 ──► Keycloak OIDC
+                                      │ (authenticated)
+                                      ► Jaeger UI :16686/jaeger
 ```
 
 ## Ports
@@ -47,11 +49,12 @@ The relevant settings are under `userconfig:`:
 | Setting | Value | Notes |
 |---------|-------|-------|
 | `jaeger_query.base_path` | `/jaeger` | Required for subpath deployment |
-| `jaeger_storage.primary_store` | `memory` | In-memory, data lost on restart |
+| `jaeger_storage.primary_store` | `elasticsearch` | OpenSearch backend (platform-db) |
 | OTLP gRPC endpoint | `0.0.0.0:4317` | Trace ingestion |
 | OTLP HTTP endpoint | `0.0.0.0:4318` | Trace ingestion |
 | Prometheus metrics | `0.0.0.0:8888` | Scraped by ServiceMonitor |
 | `ingress.enabled` | `false` | Using unified platform ingress |
+| `provisionDataStore.cassandra` | `false` | Sub-chart disabled — OpenSearch used instead |
 
 > **Note:** The old Jaeger v1 Helm schema (`allInOne:`, `collector:`, `query:`, `storage.type:`)
 > does not exist in chart 3.x and will be silently ignored. Always use `jaeger:` and `userconfig:`.
@@ -65,18 +68,27 @@ OTLP gRPC: jaeger-query.tracing.svc.cluster.local:4317
 OTLP HTTP: jaeger-query.tracing.svc.cluster.local:4318
 ```
 
+## Keycloak SSO
+
+Access to the Jaeger UI is protected by [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) and Keycloak OIDC:
+
+| Component | Detail |
+|-----------|--------|
+| oauth2-proxy Deployment | `jaeger-oauth2-proxy` in `tracing` namespace |
+| Keycloak Client | `jaeger` in realm `digiorg-core-platform` |
+| Callback URL | `https://digiorg.local/jaeger/oauth2/callback` |
+| Cookie scope | `/jaeger` |
+| Secret | `jaeger-oauth2-proxy-secrets` in `tracing` namespace |
+
+The secret is created by `scripts/local-setup.nu` and contains:
+- `client-secret`: Keycloak OIDC client secret (default: `jaeger-client-secret`)
+- `cookie-secret`: 32-byte base64 cookie encryption key
+
 ## Production Considerations
 
-For production deployments the following changes are recommended:
-
-1. **Storage**: Replace in-memory with OpenSearch via Crossplane. Update `jaeger_storage.backends.primary_store` to use the `elasticsearch` backend with your OpenSearch connection.
-
-2. **Authentication**: Add an OAuth2 proxy (Keycloak) in front of the Jaeger query service. The UI has no built-in authentication.
-
+1. **Authentication**: Rotate the `cookie-secret` and use a strong `client-secret` from a secrets manager.
+2. **TLS**: Remove `--ssl-insecure-skip-verify` from oauth2-proxy and configure proper CA trust.
 3. **Sampling**: Configure adaptive sampling strategies in the OTEL Collector pipeline.
-
 4. **Resource limits**: Increase CPU/memory limits and add HPA based on observed usage.
-
 5. **Retention**: Configure index TTL in OpenSearch to match your retention policy (e.g. 7 days).
-
 6. **Multi-tenancy**: Enable Jaeger multi-tenancy for separate trace namespaces per team.

--- a/platform/base/jaeger/kustomization.yaml
+++ b/platform/base/jaeger/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: tracing
 resources:
   - namespace.yaml
   - servicemonitor.yaml
+  - oauth2-proxy.yaml

--- a/platform/base/jaeger/oauth2-proxy.yaml
+++ b/platform/base/jaeger/oauth2-proxy.yaml
@@ -1,0 +1,112 @@
+# =============================================================================
+# oauth2-proxy — Keycloak SSO gateway for Jaeger UI
+#
+# Flow:
+#   Browser → NGINX (/jaeger) → oauth2-proxy:4180 → Keycloak OIDC → Jaeger UI
+#
+# The proxy-prefix /jaeger/oauth2 scopes the callback within the /jaeger sub-path.
+# Jaeger itself handles /jaeger natively via base_path — no NGINX URL rewriting needed.
+#
+# Secret: jaeger-oauth2-proxy-secrets (created by local-setup.nu)
+#   - client-secret  : Keycloak client secret for the "jaeger" OIDC client
+#   - cookie-secret  : 32-byte random base64 string for session cookie encryption
+# =============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger-oauth2-proxy
+  namespace: tracing
+  labels:
+    app.kubernetes.io/name: jaeger-oauth2-proxy
+    app.kubernetes.io/component: auth-proxy
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: jaeger-oauth2-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: jaeger-oauth2-proxy
+        app.kubernetes.io/component: auth-proxy
+    spec:
+      containers:
+        - name: oauth2-proxy
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+          args:
+            - --provider=oidc
+            - --oidc-issuer-url=https://digiorg.local/keycloak/realms/digiorg-core-platform
+            - --client-id=jaeger
+            - --redirect-url=https://digiorg.local/jaeger/oauth2/callback
+            # Jaeger handles /jaeger natively (base_path: /jaeger) — pass full path upstream.
+            - --upstream=http://jaeger-query.tracing.svc.cluster.local:16686/
+            - --http-address=0.0.0.0:4180
+            # proxy-prefix scopes the OAuth2 callback within the /jaeger sub-path
+            - --proxy-prefix=/jaeger/oauth2
+            - --cookie-secure=true
+            - --cookie-samesite=lax
+            - --cookie-path=/jaeger
+            - --cookie-name=_oauth2_proxy_jaeger
+            - --email-domain=*
+            - --skip-provider-button=true
+            - --pass-access-token=false
+            - --pass-authorization-header=false
+            - --set-xauthrequest=false
+            # Skip TLS verification for self-signed cert (local dev only — remove in production)
+            - --ssl-insecure-skip-verify=true
+            - --oidc-extra-audience=jaeger
+            # Allow unverified emails for local dev Keycloak test users
+            - --insecure-oidc-allow-unverified-email=true
+          env:
+            - name: OAUTH2_PROXY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: jaeger-oauth2-proxy-secrets
+                  key: client-secret
+            - name: OAUTH2_PROXY_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: jaeger-oauth2-proxy-secrets
+                  key: cookie-secret
+          ports:
+            - name: http
+              containerPort: 4180
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger-oauth2-proxy
+  namespace: tracing
+  labels:
+    app.kubernetes.io/name: jaeger-oauth2-proxy
+    app.kubernetes.io/component: auth-proxy
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: jaeger-oauth2-proxy
+  ports:
+    - name: http
+      port: 4180
+      targetPort: http

--- a/platform/base/jaeger/values.yaml
+++ b/platform/base/jaeger/values.yaml
@@ -103,3 +103,11 @@ userconfig:
 # Ingress managed via unified platform ingress (platform/base/ingress/digiorg-ingress.yaml)
 ingress:
   enabled: false
+
+# Disable Cassandra sub-chart — OpenSearch (platform-db) is the active storage backend.
+# The chart 3.x default is provisionDataStore.cassandra: true which deploys an unused
+# Cassandra StatefulSet. Explicitly disabled here.
+provisionDataStore:
+  cassandra: false
+  elasticsearch: false
+  kafka: false

--- a/platform/base/keycloak/digiorg-core-platform-realm.json
+++ b/platform/base/keycloak/digiorg-core-platform-realm.json
@@ -200,6 +200,42 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "jaeger",
+      "name": "Jaeger",
+      "description": "Jaeger Distributed Tracing UI — Keycloak SSO via oauth2-proxy",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "jaeger-client-secret",
+      "redirectUris": [
+        "https://digiorg.local/jaeger/oauth2/callback"
+      ],
+      "webOrigins": [
+        "https://digiorg.local/jaeger"
+      ],
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": true,
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "false",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
     }
   ],
   "roles": {

--- a/platform/base/landingpage/services-configmap.yaml
+++ b/platform/base/landingpage/services-configmap.yaml
@@ -62,8 +62,8 @@ data:
       },
       {
         "id": "jaeger",
-        "name": "Jaeger",
-        "description": "Distributed Tracing",
+        "name": "Tracing & Observing",
+        "description": "Distributed Tracing & Observing",
         "path": "/jaeger",
         "icon": "tracing",
         "category": "observability",

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -481,6 +481,15 @@ def create_platform_secrets [] {
     kubectl create namespace messaging --dry-run=client -o yaml | kubectl apply -f -
     print $"(ansi green)✓ Messaging namespace created(ansi reset)"
 
+    # Jaeger oauth2-proxy secret (Keycloak OIDC client + cookie encryption)
+    let jaeger_oidc_secret = ($env.JAEGER_OIDC_CLIENT_SECRET? | default "jaeger-client-secret")
+    let jaeger_cookie_secret = ($env.JAEGER_COOKIE_SECRET? | default (generate_password | str substring 0..31 | encode base64))
+    (kubectl create secret generic jaeger-oauth2-proxy-secrets -n tracing
+        --from-literal=client-secret=($jaeger_oidc_secret)
+        --from-literal=cookie-secret=($jaeger_cookie_secret)
+        --dry-run=client -o yaml | kubectl apply -f -)
+    print $"(ansi green)✓ Jaeger oauth2-proxy secrets created [tracing](ansi reset)"
+
     # OpenSearch secret (admin password for observability backend)
     let opensearch_admin_password = ($env.OPENSEARCH_ADMIN_PASSWORD? | default (generate_password))
     # Secret in platform-db namespace (for OpenSearch itself)


### PR DESCRIPTION
## Summary

Implements the remaining open phases of issue #82.

| Phase | Status | Beschreibung |
|-------|--------|-------------|
| **Phase 1** | done | Landing Page Tile: "Jaeger" → "Tracing & Observing" |
| **Phase 2** | done | Keycloak SSO via oauth2-proxy |
| Phase 3 | done via #84 | OpenSearch Storage |
| Phase 4 | done via #84 | ADR |
| **Phase 5** | done | Cassandra Sub-Chart deaktiviert |

---

## Changes

### Phase 1 — Landing Page Tile

`platform/base/landingpage/services-configmap.yaml`
- name: "Jaeger" -> "Tracing & Observing"
- description: "Distributed Tracing & Observing"

---

### Phase 2 — Keycloak SSO via oauth2-proxy

**`platform/base/jaeger/oauth2-proxy.yaml`** (new)
- Deployment: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
- OIDC provider: keycloak/realms/digiorg-core-platform
- client-id: jaeger, proxy-prefix: /jaeger/oauth2
- upstream: jaeger-query.tracing.svc.cluster.local:16686
- Cookie scoped to /jaeger
- Service: jaeger-oauth2-proxy:4180 in tracing namespace

**`platform/base/jaeger/kustomization.yaml`**
- oauth2-proxy.yaml zu resources hinzugefuegt

**`platform/base/ingress/digiorg-ingress.yaml`**
- /jaeger route: jaeger-query:16686 -> jaeger-oauth2-proxy:4180
- ExternalName Service auf jaeger-oauth2-proxy.tracing:4180 aktualisiert

**`platform/base/keycloak/digiorg-core-platform-realm.json`**
- Neuer OIDC-Client "jaeger" (confidential, redirect: /jaeger/oauth2/callback)

**`scripts/local-setup.nu`**
- Secret jaeger-oauth2-proxy-secrets im tracing Namespace (client-secret + cookie-secret)

**`platform/base/jaeger/README.md`**
- Architektur-Diagram, SSO-Sektion, Config-Tabelle aktualisiert

---

### Phase 5 — Cassandra Sub-Chart entfernen

**`platform/base/jaeger/values.yaml`**

provisionDataStore.cassandra: false

Chart 3.x Default war true und deployte seit PR #77 einen ungenutzten Cassandra-StatefulSet.
ArgoCD prune entfernt ihn automatisch beim naechsten Sync.

---

## Architecture After This PR

Browser -> NGINX /jaeger -> oauth2-proxy:4180 -> Keycloak OIDC
                                  | (authenticated)
                           Jaeger UI :16686/jaeger
                                  |
                           OpenSearch (platform-db)

---

## Test Checklist

- [ ] local-setup.nu up — jaeger-oauth2-proxy-secrets Secret wird erstellt
- [ ] ArgoCD sync: Cassandra StatefulSet im tracing Namespace wird entfernt (prune)
- [ ] https://digiorg.local/jaeger -> leitet auf Keycloak Login weiter
- [ ] Nach Login: Jaeger UI sichtbar und Traces querybar
- [ ] Landing Page: Tile zeigt "Tracing & Observing"

---

Closes #82