### PR TITLE
fix(opensearch): correct Helm repo URL to opensearch-project.github.io/helm-charts

### DIFF
--- a/apps/platform/opensearch.yaml
+++ b/apps/platform/opensearch.yaml
@@ -12,8 +12,8 @@ spec:
   project: default
 
   sources:
-    # OpenSearch via official Helm chart
-    - repoURL: https://helm.opensearch.org
+    # OpenSearch via official Helm chart (GitHub Pages — https://helm.opensearch.org does not exist)
+    - repoURL: https://opensearch-project.github.io/helm-charts
       chart: opensearch
       targetRevision: "3.6.0"
       helm:


### PR DESCRIPTION
## Fix\n\nKorrigiert die falsche Helm Repository-URL in `apps/platform/opensearch.yaml`.\n\n| | URL |\n|---|---|\n| ❌ Vorher | `https://helm.opensearch.org` (DNS existiert nicht) |\n| ✅ Nachher | `https://opensearch-project.github.io/helm-charts` (HTTP 200, v3.6.0 verfügbar) |\n\n**Änderung:** 1 Zeile in `apps/platform/opensearch.yaml`\n\nFixes #86