### PR TITLE
fix(opensearch): move vm.max_map_count from initContainer to KinD node bootstrap

### DIFF
--- a/platform/base/opensearch/README.md
+++ b/platform/base/opensearch/README.md
@@ -83,7 +83,7 @@ curl http://opensearch-cluster-master.platform-db.svc.cluster.local:9200/_cat/in
 | `opensearchJavaOpts` | `-Xmx512M -Xms512M` | JVM heap |
 | `DISABLE_SECURITY_PLUGIN` | `true` | Local dev only — remove in production |
 | Storage | 8Gi PVC | Default provisioner (standard on KinD) |
-| `vm.max_map_count` | 262144 | Set via privileged initContainer |
+| `vm.max_map_count` | 262144 | Set at KinD node level via `docker exec` in `local-setup.nu` |
 
 ## Jaeger Integration
 
@@ -131,6 +131,11 @@ OpenSearch is deployed in **Wave 0** — same wave as PostgreSQL — to ensure i
 4. **Index lifecycle:** Configure ISM (Index State Management) for automatic index rollover and deletion (e.g. 30-day retention).
 5. **Keycloak OIDC:** Enable OpenSearch Dashboards with Keycloak SSO for direct log/trace search UI.
 6. **Persistent volume:** Use a high-performance storage class (SSD-backed).
+7. **vm.max_map_count:** On non-KinD deployments, ensure `vm.max_map_count >= 262144` is set at the host level. Options:
+   - **DaemonSet:** Run a privileged init DaemonSet that sets the sysctl on each node.
+   - **Node tuning operator:** Use the OpenShift Node Tuning Operator or equivalent.
+   - **sysctl.d:** Add `vm.max_map_count=262144` to `/etc/sysctl.d/99-opensearch.conf` on each node.
+   - See: [OpenSearch Important Settings](https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/#important-settings)
 
 ## Troubleshooting
 

--- a/platform/base/opensearch/values.yaml
+++ b/platform/base/opensearch/values.yaml
@@ -80,15 +80,14 @@ config:
 # KinD bootstrap: vm.max_map_count
 # =============================================================================
 # OpenSearch requires vm.max_map_count >= 262144.
-# On KinD the Docker node doesn't inherit host sysctl settings, so we set it
-# via a privileged initContainer before OpenSearch starts.
-extraInitContainers:
-  - name: sysctl
-    image: busybox:1.36
-    imagePullPolicy: IfNotPresent
-    command: ["sysctl", "-w", "vm.max_map_count=262144"]
-    securityContext:
-      privileged: true
+# This is set at the KinD node level via `docker exec` in scripts/local-setup.nu
+# (Step 2, after cluster creation). This avoids a privileged initContainer that
+# fails on Docker Desktop for Windows/WSL2 due to nested-container sysctl
+# restrictions.
+#
+# For production (non-KinD) deployments, ensure vm.max_map_count is set at the
+# host level via a DaemonSet, node tuning operator, or sysctl.d configuration.
+# See: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/#important-settings
 
 # =============================================================================
 # Network

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -111,29 +111,35 @@ def "main bootstrap" [] {
     print "   Waiting for cluster nodes..."
     kubectl wait --for=condition=Ready nodes --all --timeout=120s
     
-    # 2. Install Gateway API CRDs
-    print "2. Installing Gateway API CRDs..."
+    # 2. Set vm.max_map_count on KinD node (required by OpenSearch)
+    print "2. Setting vm.max_map_count on KinD node..."
+    let kind_node = $"($CLUSTER_NAME)-control-plane"
+    docker exec $kind_node sysctl -w vm.max_map_count=262144
+    print $"(ansi green)✓ vm.max_map_count=262144 set on KinD node(ansi reset)"
+    
+    # 3. Install Gateway API CRDs
+    print "3. Installing Gateway API CRDs..."
     install_gateway_api
     
-    # 3. Install Ingress Controller
-    print "3. Installing NGINX Ingress Controller..."
+    # 4. Install Ingress Controller
+    print "4. Installing NGINX Ingress Controller..."
     install_ingress
     
-    # 4. Apply Platform Ingress rules
-    print "4. Installing Platform Ingress rules..."
+    # 5. Apply Platform Ingress rules
+    print "5. Installing Platform Ingress rules..."
     kubectl apply -k platform/base/ingress/
     print $"(ansi green)✓ Platform Ingress installed(ansi reset)"
     
-    # 5. Configure CoreDNS for digiorg.local
-    print "5. Configuring CoreDNS for digiorg.local..."
+    # 6. Configure CoreDNS for digiorg.local
+    print "6. Configuring CoreDNS for digiorg.local..."
     configure_coredns_digiorg_local
     
-    # 6. Create Platform Secrets (before ArgoCD!)
-    print "6. Creating Platform Secrets..."
+    # 7. Create Platform Secrets (before ArgoCD!)
+    print "7. Creating Platform Secrets..."
     create_platform_secrets
     
-    # 7. Install ArgoCD (Helm)
-    print "7. Installing ArgoCD (Helm)..."
+    # 8. Install ArgoCD (Helm)
+    print "8. Installing ArgoCD (Helm)..."
     install_argocd
     
     print ""


### PR DESCRIPTION
## Summary

Fixes #88 — sysctl initContainer fails on Docker Desktop (Windows/WSL2) with Permission denied.

## Changes

### 1. `platform/base/opensearch/values.yaml`
- Removed the privileged `extraInitContainers` sysctl block that set `vm.max_map_count=262144`
- Added comments explaining the new approach and production guidance

### 2. `scripts/local-setup.nu`
- Added Step 2 after cluster creation: `docker exec <kind-node> sysctl -w vm.max_map_count=262144`
- Renumbered subsequent steps (3-8)
- Uses the existing `CLUSTER_NAME` variable to derive the node name dynamically

### 3. `platform/base/opensearch/README.md`
- Updated configuration table to reflect new sysctl approach
- Added production guidance (DaemonSet, node tuning operator, sysctl.d)

## Root Cause

On Docker Desktop for Windows (WSL2), privileged containers inside KinD nodes cannot write to `/proc/sys/vm/max_map_count` due to nested container isolation. The fix moves the sysctl call to the KinD node container level via `docker exec`, which has full kernel access.

## Testing

- Verified branch compiles and values.yaml is valid YAML
- The fix aligns with the approach documented in the issue analysis