### PR TITLE
fix(jaeger): upgrade Helm chart 3.x → 4.x, allInOne key, native OpenSearch backend

### DIFF
--- a/apps/platform/jaeger.yaml
+++ b/apps/platform/jaeger.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://jaegertracing.github.io/helm-charts
       chart: jaeger
-      targetRevision: "3.x"
+      targetRevision: "4.x"
       helm:
         releaseName: jaeger
         valueFiles:

--- a/platform/base/jaeger/values.yaml
+++ b/platform/base/jaeger/values.yaml
@@ -1,26 +1,23 @@
-# Jaeger Helm Values — Jaeger v2 (chart 3.x, OTEL Collector architecture)
-# Docs: https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config.yaml
-# Chart: https://github.com/jaegertracing/helm-charts/blob/main/charts/jaeger/values.yaml
+# Jaeger Helm Values — Jaeger v2 (chart 4.x, OTEL Collector architecture)
+# Docs: https://www.jaegertracing.io/docs/2.17/deployment/kubernetes/
+# Chart: https://github.com/jaegertracing/helm-charts/tree/v2/charts/jaeger
+# OpenSearch backend: https://www.jaegertracing.io/docs/2.17/storage/opensearch/
 #
-# NOTE: Jaeger v2 uses the OpenTelemetry Collector framework as a single binary.
-# All Jaeger-specific config goes under `userconfig:` (OTEL Collector YAML).
-# The old v1 schema (allInOne, collector, query, storage.type for pods) does NOT apply.
-#
-# IMPORTANT: The chart 3.x deploys the `jaegertracing/jaeger` image (v2 binary).
-# We pin the tag explicitly to avoid falling back to v1 images.
+# NOTE: Chart 4.x uses `allInOne:` (not `jaeger:`) for the single-binary deployment.
+# All pod-level settings (image, extraEnv, resources) must be under `allInOne:`.
+# The full OTEL Collector config goes under `userconfig:`.
 
 # =============================================================================
-# Jaeger v2 Deployment
+# Jaeger v2 All-in-One Deployment (Chart 4.x key: allInOne)
 # =============================================================================
-jaeger:
+allInOne:
   enabled: true
   replicas: 1
 
   image:
     repository: jaegertracing/jaeger
-    # Pin to stable Jaeger v2 release — single binary with OTEL Collector framework.
-    # This ensures the chart does NOT deploy legacy v1 collector/query pods.
-    tag: "2.6.0"
+    # Empty tag = Chart uses appVersion (2.17.0) as default.
+    tag: ""
     pullPolicy: IfNotPresent
 
   # Inject OpenSearch admin password into Jaeger via environment variable.
@@ -40,25 +37,8 @@ jaeger:
       cpu: 500m
       memory: 512Mi
 
-  # Expose OTLP + Prometheus metrics + Query UI ports via the service
-  service:
-    extraPorts:
-      - name: otlp-grpc
-        port: 4317
-        targetPort: 4317
-        protocol: TCP
-      - name: otlp-http
-        port: 4318
-        targetPort: 4318
-        protocol: TCP
-      - name: metrics
-        port: 8888
-        targetPort: 8888
-        protocol: TCP
-      - name: jaeger-query
-        port: 16686
-        targetPort: 16686
-        protocol: TCP
+  # Chart 4.x allInOne service exposes OTLP (4317/4318) and Query UI (16686)
+  # by default via the standard service definition. No extraPorts needed.
 
 # =============================================================================
 # Jaeger v2 OTEL Collector Configuration (userconfig)
@@ -100,16 +80,36 @@ userconfig:
     jaeger_storage:
       backends:
         primary_store:
-          elasticsearch:
-            # OpenSearch is Elasticsearch 7.10.2 API-compatible — use elasticsearch backend type.
-            # OpenSearch deployed in platform-db namespace (Wave 0, ready before Jaeger).
-            server_urls: http://opensearch-cluster-master.platform-db.svc.cluster.local:9200
-            index_prefix: jaeger
+          # Native OpenSearch backend (Jaeger v2) — preferred over elasticsearch
+          # compatibility mode. Supports OpenSearch 1.x, 2.x, 3.x.
+          # Ref: https://www.jaegertracing.io/docs/2.17/storage/opensearch/
+          # Ref: https://github.com/jaegertracing/jaeger/blob/v2.17.0/cmd/jaeger/config-opensearch.yaml
+          opensearch:
+            # server_urls must be a list (not a single string)
+            server_urls:
+              - http://opensearch-cluster-master.platform-db.svc.cluster.local:9200
+            indices:
+              index_prefix: jaeger
+              spans:
+                date_layout: "2006-01-02"
+                rollover_frequency: day
+                shards: 5
+                replicas: 0   # single-node dev cluster — no replicas
+              services:
+                date_layout: "2006-01-02"
+                rollover_frequency: day
+                shards: 5
+                replicas: 0
+              dependencies:
+                date_layout: "2006-01-02"
+                rollover_frequency: day
+                shards: 5
+                replicas: 0
             # Credentials reference the jaeger-opensearch-credentials secret (created by local-setup.nu)
             username: admin
             password: "${OPENSEARCH_ADMIN_PASSWORD}"
-            # Self-signed cert in local dev — disable host verification
-            # Remove tls section in production and configure proper CA trust
+            # Self-signed cert in local dev — disable host verification.
+            # Remove tls section in production and configure proper CA trust.
             tls:
               skip_host_verify: true
 
@@ -147,7 +147,7 @@ esIndexCleaner:
   enabled: true
   image:
     repository: jaegertracing/jaeger-es-index-cleaner
-    tag: "2.6.0"
+    tag: "2.17.0"      # aligned with appVersion (was: 2.6.0)
     pullPolicy: IfNotPresent
   schedule: "55 23 * * *"
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
## Fixes #92

## Problem

Trotz Merge von PR #91 starteten die Jaeger-Pods weiterhin mit v1.53.0 (Legacy-Architektur), weil `targetRevision: "3.x"` auf Chart 3.3.1 auflöst (Jaeger v1), nicht auf die v2-Architektur.

## Änderungen

### `apps/platform/jaeger.yaml`
- `targetRevision: "3.x"` → `"4.x"`
  Chart 4.x deployed appVersion 2.17.0 (Jaeger v2, OTEL Collector Single Binary)

### `platform/base/jaeger/values.yaml`

| # | Änderung | Grund |
|---|---|---|
| 1 | `jaeger:` → `allInOne:` | Chart 4.x kennt keinen `jaeger:`-Key — alle Werte (extraEnv, resources, image) wurden bisher **stillschweigend ignoriert** |
| 2 | `image.tag: "2.6.0"` → `""` | Leerer Tag = Chart-Default (appVersion 2.17.0) |
| 3 | `service.extraPorts` entfernt | Chart 4.x `allInOne` exponiert OTLP (4317/4318) und Query UI (16686) nativ |
| 4 | `elasticsearch:` → `opensearch:` | Nativer OpenSearch Backend-Typ (Jaeger v2 Empfehlung gem. offizieller Doku) |
| 5 | `server_urls: string` → `server_urls: [list]` | Jaeger v2 erwartet zwingend eine Liste |
| 6 | `index_prefix:` → `indices:` Struktur | Korrekte OpenSearch-Backend-Konfiguration mit per-Typ Rollover-Einstellungen (`replicas: 0` für Single-Node Dev) |
| 7 | `esIndexCleaner.image.tag: "2.6.0"` → `"2.17.0"` | Aligned mit appVersion |

## Wichtigste Korrektur

Die kritischste Änderung ist `jaeger:` → `allInOne:`: Solange dieser Key falsch war, wurde das `OPENSEARCH_ADMIN_PASSWORD` Secret **nie in den Pod injiziert** — Jaeger hätte sich nicht gegen OpenSearch authentifizieren können, selbst wenn das Chart korrekt gewesen wäre.

## Verifikation nach ArgoCD-Sync

- [ ] Nur ein Jaeger-Pod (v2 Single Binary), kein separater Collector/Query
- [ ] Pod-Logs: `git-version=v2.17.x`
- [ ] Keine Auth-Fehler gegen OpenSearch
- [ ] OTEL-Pipeline aktiv: Traces werden in OpenSearch geschrieben
- [ ] Query UI erreichbar unter `/jaeger`

## Referenzen
- Issue: #92
- Jaeger v2 Kubernetes Deployment: https://www.jaegertracing.io/docs/2.17/deployment/kubernetes/
- OpenSearch Backend: https://www.jaegertracing.io/docs/2.17/storage/opensearch/
- Helm Chart v2: https://github.com/jaegertracing/helm-charts/tree/v2/charts/jaeger