### PR TITLE
fix(jaeger): correct opensearch auth field path, remove invalid tls key

### DIFF
--- a/platform/base/jaeger/values.yaml
+++ b/platform/base/jaeger/values.yaml
@@ -105,13 +105,15 @@ userconfig:
                 rollover_frequency: day
                 shards: 5
                 replicas: 0
-            # Credentials reference the jaeger-opensearch-credentials secret (created by local-setup.nu)
-            username: admin
-            password: "${OPENSEARCH_ADMIN_PASSWORD}"
-            # Self-signed cert in local dev — disable host verification.
-            # Remove tls section in production and configure proper CA trust.
-            tls:
-              skip_host_verify: true
+            # Auth must be nested under auth.basic (Jaeger v2 / OTel strict-mode config schema).
+            # username/password directly under opensearch: are NOT valid keys (see issue #94).
+            # Uses ${env:...} OTel provider syntax for env var substitution.
+            # The jaeger-opensearch-credentials secret is created by local-setup.nu.
+            auth:
+              basic:
+                username: admin
+                password: "${env:OPENSEARCH_ADMIN_PASSWORD}"
+            # No tls: section needed — connection uses plain HTTP (http://)
 
   receivers:
     otlp:


### PR DESCRIPTION
## Fixes #94

## Problem

Jaeger v2.17.0 crashed sofort nach Start mit:

```
'opensearch' has invalid keys: password, username
'opensearch.tls' has invalid keys: skip_host_verify
```

Jaeger v2 verwendet den OTel Collector Config-Parser im **strict mode**. Die `escfg.Configuration`-Struct mapped Authentication unter `auth.basic` (nicht als direkte Felder) — `username`/`password` direkt unter `opensearch:` sind daher ungültige Schlüssel.

## Änderungen

### `platform/base/jaeger/values.yaml`

| # | Änderung | Grund |
|---|---|---|
| 1 | `username`/`password` → `auth.basic.username`/`auth.basic.password` | Korrekter mapstructure-Pfad laut `escfg.Configuration`-Struct (Jaeger v2 Quellcode) |
| 2 | `${OPENSEARCH_ADMIN_PASSWORD}` → `${env:OPENSEARCH_ADMIN_PASSWORD}` | OTel-Provider-Syntax für env var Substitution |
| 3 | `tls.skip_host_verify` entfernt | Kein gültiges Feld in `configtls.ClientConfig`; außerdem obsolet da HTTP-Verbindung (kein TLS) |

```yaml
# VORHER (ungültig):
opensearch:
  server_urls: [...]
  username: admin
  password: "${OPENSEARCH_ADMIN_PASSWORD}"
  tls:
    skip_host_verify: true

# NACHHER (korrekt):
opensearch:
  server_urls: [...]
  auth:
    basic:
      username: admin
      password: "${env:OPENSEARCH_ADMIN_PASSWORD}"
  # kein tls: — plain HTTP-Verbindung
```

## Verifikation nach ArgoCD-Sync

- [ ] Kein `"has invalid keys"`-Fehler in den Jaeger-Pod-Logs
- [ ] `OPENSEARCH_ADMIN_PASSWORD` env var im Pod sichtbar (`kubectl exec -n tracing <pod> -- env | grep OPENSEARCH`)
- [ ] Jaeger verbindet sich mit OpenSearch (keine Auth-Fehler)
- [ ] Traces werden geschrieben und sind in der UI unter `/jaeger` sichtbar

## Quellenangaben
- [escfg.Configuration struct](https://github.com/jaegertracing/jaeger/blob/v2.17.0/internal/storage/elasticsearch/config/config.go)
- [config_test.go — Authentication struct](https://github.com/jaegertracing/jaeger/blob/v2.17.0/internal/storage/elasticsearch/config/config_test.go)