### PR TITLE
fix(jaeger): align healthcheckv2 port with Chart 4.x probes (14269 → 13133)

### DIFF
--- a/platform/base/jaeger/values.yaml
+++ b/platform/base/jaeger/values.yaml
@@ -70,7 +70,10 @@ userconfig:
     healthcheckv2:
       use_v2: true
       http:
-        endpoint: 0.0.0.0:14269
+        # Port 13133 = OTel Collector standard healthcheck port.
+        # Chart 4.x allinone-deploy.yaml hardcodes probes to port 13133 — must match.
+        # Port 14269 was the Jaeger v1 admin port and caused liveness/readiness failures.
+        endpoint: 0.0.0.0:13133
 
     jaeger_query:
       base_path: /jaeger


### PR DESCRIPTION
## Fixes #96

## Problem

Jaeger v2.17.0 startete erfolgreich, wurde aber nach ~75 Sekunden von Kubernetes beendet:

```
Everything is ready. Begin running and processing data.
[75s]
Received signal from OS  ← SIGTERM durch Kubernetes
```

**Ursache:** Port-Mismatch zwischen `userconfig` und Chart-Probes:

| | Chart-Probes (hardcoded) | userconfig (war) |
|---|---|---|
| Port | **13133** | **14269** ← Jaeger v1 Legacy |
| Pfad | `/status` | `/status` ✅ |

Das Chart 4.x Template (`allinone-deploy.yaml`) konfiguriert Liveness und Readiness Probes **hardcoded auf Port 13133** — dieser Wert ist nicht via values überschreibbar.

## Änderung

```yaml
# platform/base/jaeger/values.yaml
# VORHER:
healthcheckv2:
  http:
    endpoint: 0.0.0.0:14269   # Jaeger v1 admin port

# NACHHER:
healthcheckv2:
  http:
    endpoint: 0.0.0.0:13133   # OTel standard — aligned mit Chart probes
```

## Verifikation nach ArgoCD-Sync

- [ ] Pod bleibt dauerhaft im `Running`-Status
- [ ] Keine Probe-Fehler in `kubectl describe pod jaeger-xxx -n tracing`
- [ ] Traces werden in OpenSearch geschrieben
- [ ] Query UI erreichbar unter `/jaeger`

> **Hinweis:** Das Secret `jaeger-opensearch-credentials` muss im Namespace `tracing` existieren (`kubectl get secret jaeger-opensearch-credentials -n tracing`), sonst schlägt die OpenSearch-Authentifizierung lautlos fehl.