### PR TITLE
fix(jaeger): correct oauth2-proxy upstream service name (jaeger-query → jaeger)

### DIFF
--- a/platform/base/jaeger/oauth2-proxy.yaml
+++ b/platform/base/jaeger/oauth2-proxy.yaml
@@ -40,7 +40,9 @@ spec:
             - --client-id=jaeger
             - --redirect-url=https://digiorg.local/jaeger/oauth2/callback
             # Jaeger handles /jaeger natively (base_path: /jaeger) — pass full path upstream.
-            - --upstream=http://jaeger-query.tracing.svc.cluster.local:16686/
+            # Chart 4.x allInOne creates a single 'jaeger' Service (not separate jaeger-query).
+            # 'jaeger-query' was the Jaeger v1 service name — does not exist in Chart 4.x.
+            - --upstream=http://jaeger.tracing.svc.cluster.local:16686/
             - --http-address=0.0.0.0:4180
             # proxy-prefix scopes the OAuth2 callback within the /jaeger sub-path
             - --proxy-prefix=/jaeger/oauth2


### PR DESCRIPTION
## Fixes #98

## Problem

`https://digiorg.local/jaeger` returned HTTP 502. Jaeger Pod und oauth2-proxy liefen korrekt.

**Ursache:** oauth2-proxy versuchte den authentifizierten Request an `jaeger-query.tracing.svc.cluster.local:16686` weiterzuleiten — dieser Service existiert in Chart 4.x nicht:

```bash
kubectl get svc -n tracing
# NAME                  TYPE        CLUSTER-IP       PORT(S)
# jaeger                ClusterIP   10.105.117.238   ...,16686/TCP,...   ← existiert
# jaeger-oauth2-proxy   ClusterIP   10.107.198.233   4180/TCP
# jaeger-query          ← EXISTIERT NICHT
```

Chart 4.x allInOne erstellt einen **einzigen** `jaeger` Service (ClusterIP) mit allen Ports — kein separater `jaeger-query` wie in Chart 3.x / Jaeger v1.

## Änderung

```yaml
# platform/base/jaeger/oauth2-proxy.yaml
# VORHER:
- --upstream=http://jaeger-query.tracing.svc.cluster.local:16686/

# NACHHER:
- --upstream=http://jaeger.tracing.svc.cluster.local:16686/
```

## Verifikation nach ArgoCD-Sync

- [ ] `https://digiorg.local/jaeger` lädt ohne 502
- [ ] oauth2-proxy Logs zeigen Browser-Requests (kein DNS upstream-Fehler)
- [ ] Jaeger UI zeigt Traces aus OpenSearch