### PR TITLE
feat(sonarqube): deploy SonarQube Community Build to Core Platform

### DIFF
--- a/apps/platform/sonarqube.yaml
+++ b/apps/platform/sonarqube.yaml
@@ -1,0 +1,50 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sonarqube
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 2: Code Quality tier — depends on PostgreSQL (wave 0) + Keycloak (wave 1)
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: default
+
+  sources:
+    # SonarQube Community Build Helm chart
+    - repoURL: https://SonarSource.github.io/helm-chart-sonarqube
+      chart: sonarqube
+      targetRevision: "10.*"
+      helm:
+        releaseName: sonarqube
+        valueFiles:
+          - $values/platform/base/sonarqube/values.yaml
+
+    # Reference to values file in Git repo
+    - repoURL: https://github.com/digiorg/core.git
+      targetRevision: HEAD
+      ref: values
+
+    # Namespace + additional manifests via Kustomize
+    - repoURL: https://github.com/digiorg/core.git
+      targetRevision: HEAD
+      path: platform/base/sonarqube
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: code-quality
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 5m

--- a/platform/base/ingress/digiorg-ingress.yaml
+++ b/platform/base/ingress/digiorg-ingress.yaml
@@ -77,6 +77,14 @@ spec:
                 name: jaeger-oauth2-proxy
                 port:
                   number: 4180
+          # SonarQube Code Quality — no URL rewriting needed (sonarWebContext=/sonarqube handles subpath natively)
+          - path: /sonarqube(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: sonarqube
+                port:
+                  number: 9000
           # Landing Page (root path - must be last due to catch-all)
           - path: /
             pathType: Prefix
@@ -219,6 +227,17 @@ spec:
   externalName: jaeger-oauth2-proxy.tracing.svc.cluster.local
   ports:
     - port: 4180
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sonarqube
+  namespace: ingress-nginx
+spec:
+  type: ExternalName
+  externalName: sonarqube.code-quality.svc.cluster.local
+  ports:
+    - port: 9000
 ---
 apiVersion: v1
 kind: Service

--- a/platform/base/keycloak/digiorg-core-platform-realm.json
+++ b/platform/base/keycloak/digiorg-core-platform-realm.json
@@ -236,6 +236,71 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "sonarqube",
+      "name": "SonarQube",
+      "description": "SonarQube Code Quality — Keycloak SSO via SAML",
+      "enabled": true,
+      "protocol": "saml",
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "fullScopeAllowed": true,
+      "frontchannelLogout": true,
+      "attributes": {
+        "saml.authn.statement": "true",
+        "saml.client.signature": "false",
+        "saml.force.post.binding": "true",
+        "saml.server.signature": "true",
+        "saml_force_name_id_format": "true",
+        "saml.assertion.signature": "false",
+        "saml_name_id_format": "username",
+        "saml.signature.algorithm": "RSA_SHA256"
+      },
+      "rootUrl": "https://digiorg.local",
+      "baseUrl": "/sonarqube",
+      "redirectUris": [
+        "https://digiorg.local/sonarqube/oauth2/callback/saml",
+        "https://digiorg.local/sonarqube/*"
+      ],
+      "webOrigins": [
+        "https://digiorg.local/sonarqube"
+      ],
+      "protocolMappers": [
+        {
+          "name": "login",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "attribute.nameformat": "Basic",
+            "attribute.name": "login",
+            "user.attribute": "username"
+          }
+        },
+        {
+          "name": "email",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "attribute.nameformat": "Basic",
+            "attribute.name": "email",
+            "user.attribute": "email"
+          }
+        },
+        {
+          "name": "name",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "attribute.nameformat": "Basic",
+            "attribute.name": "name",
+            "user.attribute": "firstName"
+          }
+        }
+      ]
     }
   ],
   "roles": {

--- a/platform/base/landingpage/services-configmap.yaml
+++ b/platform/base/landingpage/services-configmap.yaml
@@ -69,5 +69,15 @@ data:
         "category": "observability",
         "requiresAuth": true,
         "displayOrder": 6
+      },
+      {
+        "id": "sonarqube",
+        "name": "Code Quality & Security",
+        "description": "Static analysis, bugs, vulnerabilities",
+        "path": "/sonarqube",
+        "icon": "code-quality",
+        "category": "devsecops",
+        "requiresAuth": true,
+        "displayOrder": 7
       }
     ]

--- a/platform/base/postgresql/statefulset.yaml
+++ b/platform/base/postgresql/statefulset.yaml
@@ -24,6 +24,10 @@ data:
         CREATE USER gitea WITH PASSWORD '${GITEA_DB_PASSWORD}';
         CREATE DATABASE gitea OWNER gitea;
         GRANT ALL PRIVILEGES ON DATABASE gitea TO gitea;
+
+        CREATE USER sonarqube WITH PASSWORD '${SONARQUBE_DB_PASSWORD}';
+        CREATE DATABASE sonarqube OWNER sonarqube;
+        GRANT ALL PRIVILEGES ON DATABASE sonarqube TO sonarqube;
     EOSQL
 
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname keycloak <<-EOSQL
@@ -36,6 +40,10 @@ data:
 
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname gitea <<-EOSQL
         GRANT ALL ON SCHEMA public TO gitea;
+    EOSQL
+
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname sonarqube <<-EOSQL
+        GRANT ALL ON SCHEMA public TO sonarqube;
     EOSQL
 ---
 apiVersion: apps/v1
@@ -85,6 +93,11 @@ spec:
                 secretKeyRef:
                   name: postgresql-secrets
                   key: GITEA_DB_PASSWORD
+            - name: SONARQUBE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-secrets
+                  key: SONARQUBE_DB_PASSWORD
             # Set PGDATA to a subdirectory to avoid "lost+found" issues
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata

--- a/platform/base/sonarqube/README.md
+++ b/platform/base/sonarqube/README.md
@@ -1,0 +1,104 @@
+# SonarQube Community Build
+
+Static code analysis platform for the DigiOrg Core Platform.
+
+- **UI:** https://digiorg.local/sonarqube
+- **Namespace:** `code-quality`
+- **Helm Chart:** [SonarSource/helm-chart-sonarqube](https://github.com/SonarSource/helm-chart-sonarqube)
+- **Auth:** Keycloak SAML (native Community Build support)
+- **Database:** Shared PostgreSQL (`platform-db` namespace)
+
+---
+
+## Required Secrets
+
+Three Kubernetes Secrets must exist in namespace `code-quality` before ArgoCD deploys SonarQube. Create them via `local-setup.nu` or manually:
+
+### 1. `sonarqube-db-secret` — PostgreSQL credentials
+
+```bash
+kubectl create secret generic sonarqube-db-secret \
+  --from-literal=SONAR_JDBC_PASSWORD=<password> \
+  -n code-quality
+```
+
+The password must match `SONARQUBE_DB_PASSWORD` in the `postgresql-secrets` Secret (`platform-db` namespace).
+
+---
+
+### 2. `sonarqube-monitoring-secret` — Liveness probe passcode
+
+Required for the liveness probe (`/api/system/liveness`). Without this the pod never becomes Ready.
+
+```bash
+kubectl create secret generic sonarqube-monitoring-secret \
+  --from-literal=SONAR_WEB_SYSTEMPASSCODE=<random-passcode> \
+  -n code-quality
+```
+
+Use a random string, e.g.: `openssl rand -hex 32`
+
+---
+
+### 3. `sonarqube-saml-secret` — Keycloak IdP certificate
+
+Contains the Keycloak realm signing certificate for SAML signature verification.
+
+**Step 1 — Obtain the certificate from Keycloak:**
+
+```bash
+# Get realm's public key (X.509 certificate)
+kubectl exec -n keycloak deploy/keycloak -- \
+  curl -sk https://digiorg.local/keycloak/realms/digiorg-core-platform \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['public_key'])"
+```
+
+**Step 2 — Create the Secret:**
+
+```bash
+CERT=$(kubectl exec -n keycloak deploy/keycloak -- \
+  curl -sk https://digiorg.local/keycloak/realms/digiorg-core-platform \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['public_key'])")
+
+kubectl create secret generic sonarqube-saml-secret \
+  --from-literal="sonar.auth.saml.certificate.secured=${CERT}" \
+  -n code-quality
+```
+
+> **Note:** The certificate must be recreated whenever Keycloak realm keys rotate or the cluster is rebuilt.
+
+---
+
+## PostgreSQL Setup
+
+The shared PostgreSQL instance requires the `sonarqube` database and user. This is handled in two ways:
+
+- **New clusters:** `platform/base/postgresql/statefulset.yaml` init script creates the DB on first startup
+- **Existing clusters:** Run the one-time init Job (see [Step 7 in issue #78](https://github.com/digiorg/core/issues/78))
+
+The `SONARQUBE_DB_PASSWORD` env var must be added to the `postgresql-secrets` Secret in `platform-db`.
+
+---
+
+## Keycloak SAML Client
+
+The SonarQube SAML client is defined in `platform/base/keycloak/digiorg-core-platform-realm.json` and is imported automatically when Keycloak starts. No manual Keycloak configuration is needed.
+
+**SAML callback URL:** `https://digiorg.local/sonarqube/oauth2/callback/saml`
+
+---
+
+## First Login
+
+After deployment:
+1. Navigate to `https://digiorg.local/sonarqube`
+2. Log in with the default admin account: `admin` / `admin`
+3. Change the admin password immediately
+4. SAML SSO should be available via the "Log in with Keycloak" button
+
+---
+
+## Upgrading Community Build Version
+
+Update `community.buildNumber` in `values.yaml` to the desired Community Build version.
+Find available versions at [SonarQube Downloads](https://www.sonarsource.com/products/sonarqube/downloads/).

--- a/platform/base/sonarqube/kustomization.yaml
+++ b/platform/base/sonarqube/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: code-quality
+
+resources:
+  - namespace.yaml
+
+# SonarQube itself is deployed via Helm by the ArgoCD Application (apps/platform/sonarqube.yaml).
+# The following secrets must be created manually by local-setup.nu before ArgoCD sync:
+#   - sonarqube-db-secret          (SONAR_JDBC_PASSWORD)
+#   - sonarqube-monitoring-secret  (SONAR_WEB_SYSTEMPASSCODE)
+#   - sonarqube-saml-secret        (sonar.auth.saml.certificate.secured)
+# See platform/base/sonarqube/README.md for details.

--- a/platform/base/sonarqube/namespace.yaml
+++ b/platform/base/sonarqube/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: code-quality
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    platform.digiorg.io/component: code-quality

--- a/platform/base/sonarqube/values.yaml
+++ b/platform/base/sonarqube/values.yaml
@@ -1,0 +1,157 @@
+# =============================================================================
+# SonarQube Community Build — Helm Values
+# Chart:  https://github.com/SonarSource/helm-chart-sonarqube
+# Docs:   https://docs.sonarsource.com/sonarqube-server/latest/setup-and-upgrade/deploy-on-kubernetes/
+# Issue:  #78
+# =============================================================================
+
+# ── Edition: Community Build ──────────────────────────────────────────────────
+community:
+  enabled: true
+  # buildNumber pins the Community Build version (year.month.patch.buildid format).
+  # Update to the desired Community Build release.
+  buildNumber: "26.4.0.121862"
+
+# ── Deployment ─────────────────────────────────────────────────────────────────
+replicaCount: 1
+deploymentType: "StatefulSet"
+
+# ── Web Context (subpath for NGINX ingress) ────────────────────────────────────
+# SonarQube served under /sonarqube. The chart automatically injects this value
+# as SONAR_WEB_CONTEXT env var — do NOT also set it in the env section below.
+sonarWebContext: "/sonarqube"
+
+# ── Database: shared PostgreSQL in platform-db namespace ──────────────────────
+# Disable the built-in PostgreSQL sub-chart (we use the shared platform instance)
+postgresql:
+  enabled: false
+
+# External database — correct Helm key is jdbcOverwrite (not jdbcOverride)
+jdbcOverwrite:
+  enabled: true
+  jdbcUrl: "jdbc:postgresql://postgresql.platform-db.svc.cluster.local:5432/sonarqube"
+  jdbcUsername: sonarqube
+  # Password sourced from Kubernetes Secret (created by local-setup.nu)
+  jdbcSecretName: "sonarqube-db-secret"
+  jdbcSecretPasswordKey: "SONAR_JDBC_PASSWORD"
+
+# ── Monitoring Passcode (REQUIRED for liveness probe) ─────────────────────────
+# The liveness probe calls /api/system/liveness with X-Sonar-Passcode header.
+# Without this, the probe returns 401 → pod never becomes ready → restart loop.
+monitoringPasscodeSecretName: "sonarqube-monitoring-secret"
+monitoringPasscodeSecretKey: "SONAR_WEB_SYSTEMPASSCODE"
+
+# ── Elasticsearch (embedded) ───────────────────────────────────────────────────
+elasticsearch:
+  # Disable strict bootstrap checks — KinD doesn't support vm.max_map_count changes.
+  # Set to true in production and configure the sysctl init container.
+  bootstrapChecks: false
+
+# Init container for vm.max_map_count — disabled for local KinD dev.
+# Enable in production with privileged node access.
+initSysctl:
+  enabled: false
+
+# ── Security Context ───────────────────────────────────────────────────────────
+securityContext:
+  fsGroup: 0
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 0
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop: ["ALL"]
+
+# ── Service ────────────────────────────────────────────────────────────────────
+service:
+  type: ClusterIP
+  externalPort: 9000
+  internalPort: 9000
+
+# ── Ingress: managed via unified platform ingress ─────────────────────────────
+ingress:
+  enabled: false
+
+# ── Persistence ───────────────────────────────────────────────────────────────
+persistence:
+  enabled: true
+  size: 5Gi
+  accessMode: ReadWriteOnce
+
+# ── Resources ──────────────────────────────────────────────────────────────────
+# SonarQube + embedded Elasticsearch is memory-intensive.
+# Chart defaults: requests=2048M, limits=6144M — reduced here for local KinD dev.
+resources:
+  requests:
+    cpu: 200m
+    memory: 2Gi
+  limits:
+    cpu: 2000m
+    memory: 4Gi
+
+# ── Startup / Readiness / Liveness Probes ─────────────────────────────────────
+# SonarQube can take 2-3 minutes to start (Elasticsearch init + DB migrations).
+startupProbe:
+  initialDelaySeconds: 30
+  failureThreshold: 24   # 24 * 10s = 4 min total startup budget
+  periodSeconds: 10
+  timeoutSeconds: 1
+
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  failureThreshold: 6
+  timeoutSeconds: 10
+
+readinessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  failureThreshold: 6
+  timeoutSeconds: 10
+
+# ── Prometheus Monitoring ──────────────────────────────────────────────────────
+prometheusMonitoring:
+  podMonitor:
+    enabled: true
+    # namespace is deprecated — PodMonitor is created in the release namespace
+    interval: 30s
+    labels:
+      release: prometheus   # required for kube-prometheus-stack discovery
+
+# ── Authentication: Keycloak SAML ─────────────────────────────────────────────
+# SonarQube Community Build has native SAML support (no plugin required).
+# OIDC is NOT natively supported in Community Build — use SAML instead.
+#
+# Keycloak SAML client "sonarqube" is configured in:
+#   platform/base/keycloak/digiorg-core-platform-realm.json
+#
+# The IdP certificate must be stored in the sonarqube-saml-secret Secret
+# (see README.md for how to obtain it from Keycloak).
+sonarProperties:
+  sonar.auth.saml.enabled: "true"
+  sonar.auth.saml.applicationId: "sonarqube"
+  sonar.auth.saml.providerName: "Keycloak"
+  # Keycloak realm EntityID
+  sonar.auth.saml.providerId: "https://digiorg.local/keycloak/realms/digiorg-core-platform"
+  # Keycloak SAML SSO endpoint
+  sonar.auth.saml.loginUrl: "https://digiorg.local/keycloak/realms/digiorg-core-platform/protocol/saml"
+  # SAML attribute mappings (must match Keycloak protocol mappers in realm JSON)
+  sonar.auth.saml.userLogin: "login"
+  sonar.auth.saml.userName: "name"
+  sonar.auth.saml.userEmail: "email"
+  # Allow users to sign up via SSO on first login
+  sonar.auth.saml.allowUsersToSignUp: "true"
+
+# Keycloak IdP certificate — stored in Secret, appended to sonar.properties.
+# Secret key: sonar.auth.saml.certificate.secured=<base64-cert>
+# Created by local-setup.nu after Keycloak is up (see README.md).
+sonarSecretProperties: "sonarqube-saml-secret"
+
+# ── Plugins ────────────────────────────────────────────────────────────────────
+# No additional plugins needed — SAML is built-in for Community Build.
+plugins:
+  install: []


### PR DESCRIPTION
## Closes #78

## Was deployed

SonarQube Community Build im DigiOrg Core Platform mit:
- **PostgreSQL Backend** — shared Instanz in `platform-db` Namespace
- **Keycloak SAML SSO** — nativer Community Build Support (kein Plugin nötig)
- **Path-based Ingress** — `https://digiorg.local/sonarqube`
- **ArgoCD Sync Wave 2** — nach PostgreSQL (wave 0) und Keycloak (wave 1)

---

## Geänderte Dateien

### Neue Dateien
| Datei | Beschreibung |
|---|---|
| `apps/platform/sonarqube.yaml` | ArgoCD Application (multi-source: Helm + Git values + Kustomize) |
| `platform/base/sonarqube/values.yaml` | Helm values (alle Korrekturen aus Issue-Review) |
| `platform/base/sonarqube/namespace.yaml` | Namespace `code-quality` |
| `platform/base/sonarqube/kustomization.yaml` | Kustomize entry point |
| `platform/base/sonarqube/README.md` | Setup, Secrets, SAML-Konfiguration |

### Modifizierte Dateien
| Datei | Änderung |
|---|---|
| `platform/base/postgresql/statefulset.yaml` | `sonarqube` User + DB in Init-Script + `SONARQUBE_DB_PASSWORD` Env-Var |
| `platform/base/ingress/digiorg-ingress.yaml` | `/sonarqube` Ingress-Pfad + ExternalName Service (`sonarqube:9000`) |
| `platform/base/keycloak/digiorg-core-platform-realm.json` | SAML Client `sonarqube` mit login/email/name Protocol Mappern |
| `platform/base/landingpage/services-configmap.yaml` | SonarQube im Platform-Portal registriert (displayOrder: 7) |

---

## Korrekturen vs. Issue #78 Draft

| # | Problem (Draft) | Korrektur (dieser PR) |
|---|---|---|
| 1 | `jdbcOverride` (falscher Key) | `jdbcOverwrite` mit `jdbcUrl`, `jdbcUsername`, `jdbcSecretName` |
| 2 | `monitoringPasscode` fehlte | `monitoringPasscodeSecretName/Key` → Liveness Probe funktioniert |
| 3 | Service `sonarqube-sonarqube` | Service heißt `sonarqube` (Helm fullname = Release-Name) |
| 4 | OIDC (nicht in Community Build) | **SAML** via `sonarProperties` + `sonarSecretProperties` |
| 5 | Keycloak Client fehlte | SAML Client in `digiorg-core-platform-realm.json` eingefügt |
| 6 | `env.SONAR_WEB_CONTEXT` redundant | Entfernt — Chart injiziert via `sonarWebContext` automatisch |
| 7 | Deprecated `podMonitor.namespace` | Entfernt |
| 8 | Memory Request `1Gi` zu knapp | `2Gi` (Embedded Elasticsearch) |

---

## Voraussetzungen vor ArgoCD Sync

Drei Secrets müssen in Namespace `code-quality` erstellt werden (via `local-setup.nu`):

```bash
# 1. DB Credentials
kubectl create secret generic sonarqube-db-secret \
  --from-literal=SONAR_JDBC_PASSWORD=<password> -n code-quality

# 2. Monitoring Passcode (für Liveness Probe)
kubectl create secret generic sonarqube-monitoring-secret \
  --from-literal=SONAR_WEB_SYSTEMPASSCODE=$(openssl rand -hex 32) -n code-quality

# 3. Keycloak IdP Cert (nach Keycloak Start)
CERT=$(kubectl exec -n keycloak deploy/keycloak -- \
  curl -sk https://digiorg.local/keycloak/realms/digiorg-core-platform \
  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['public_key'])")
kubectl create secret generic sonarqube-saml-secret \
  --from-literal="sonar.auth.saml.certificate.secured=${CERT}" -n code-quality
```

Außerdem: `SONARQUBE_DB_PASSWORD` Key zu `postgresql-secrets` in `platform-db` hinzufügen.

> **Hinweis für bestehende Cluster:** Das PostgreSQL Init-Script läuft nur beim ersten Start. Für bestehende Cluster muss die `sonarqube` Datenbank manuell angelegt werden (siehe [Issue #78 Step 7](https://github.com/digiorg/core/issues/78)).