### PR TITLE
fix(local-setup): sync app lists with actual platform apps (14 total)

### DIFF
--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -160,9 +160,9 @@ def deploy_root_app [] {
     print ""
     print "ArgoCD Sync Waves:"
     print "  Wave -1: root-app (just deployed)"
-    print "  Wave  0: cert-manager (TLS), postgresql (shared database), opensearch (observability backend), nats (messaging)"
-    print "  Wave  1: keycloak (IdP), argocd (self-managed GitOps)"
-    print "  Wave  2: landingpage, backstage, gitea, grafana"
+    print "  Wave  0: cert-manager, postgresql, opensearch, nats"
+    print "  Wave  1: keycloak, argocd (self-managed)"
+    print "  Wave  2: landingpage, backstage, gitea, grafana, jaeger, sonarqube"
     print "  Wave  3: crossplane, kyverno"
 }
 
@@ -173,8 +173,17 @@ def wait_for_argocd_apps [] {
     print "Waiting for ArgoCD applications to sync (this may take 10-15 minutes)..."
     print ""
     
-    # Apps to wait for (in wave order)
-    let apps = ["cert-manager", "postgresql", "opensearch", "keycloak", "gitea", "landingpage", "backstage", "grafana", "crossplane", "kyverno"]
+    # Apps to wait for (in wave order) — must match apps/platform/*.yaml exactly
+    let apps = [
+        # Wave 0
+        "cert-manager", "postgresql", "opensearch", "nats",
+        # Wave 1
+        "keycloak", "argocd",
+        # Wave 2
+        "landingpage", "backstage", "gitea", "grafana", "jaeger", "sonarqube",
+        # Wave 3
+        "crossplane", "kyverno"
+    ]
     
     mut all_healthy = false
     mut attempts = 0


### PR DESCRIPTION
## Fixes #105

## Problem

`deploy_root_app` und `wait_for_argocd_apps` enthielten veraltete App-Listen (10 Apps statt 14). `jaeger`, `sonarqube`, `nats` und `argocd` fehlten.

**Konsequenz:** Das Script meldete `✓ All ArgoCD applications are healthy!` obwohl 4 Apps noch nicht überwacht wurden — mögliche Race Conditions auf langsamen Setups.

## Änderungen

### `deploy_root_app` — Wave-Übersicht

```
# VORHER:
Wave 2: landingpage, backstage, gitea, grafana

# NACHHER:
Wave 2: landingpage, backstage, gitea, grafana, jaeger, sonarqube
```

### `wait_for_argocd_apps` — Health-Check Liste

| | Vorher (10) | Nachher (14) |
|---|---|---|
| Wave 0 | cert-manager, postgresql, opensearch | + **nats** |
| Wave 1 | keycloak | + **argocd** |
| Wave 2 | gitea, landingpage, backstage, grafana | + **jaeger**, **sonarqube** |
| Wave 3 | crossplane, kyverno | unverändert |