### PR TITLE
fix(sonarqube): remove sonarSecretProperties to unblock Pod startup

### DIFF
--- a/platform/base/sonarqube/values.yaml
+++ b/platform/base/sonarqube/values.yaml
@@ -146,10 +146,23 @@ sonarProperties:
   # Allow users to sign up via SSO on first login
   sonar.auth.saml.allowUsersToSignUp: "true"
 
-# Keycloak IdP certificate — stored in Secret, appended to sonar.properties.
-# Secret key: sonar.auth.saml.certificate.secured=<base64-cert>
-# Created by local-setup.nu after Keycloak is up (see README.md).
-sonarSecretProperties: "sonarqube-saml-secret"
+# sonarSecretProperties is intentionally NOT set.
+#
+# Setting it would create a required Secret volume mount (no optional:true in the
+# chart). If the Secret doesn't exist the Pod cannot start at all — causing a
+# hard dependency that breaks the deployment on fresh clusters (see issue #109).
+#
+# The Keycloak IdP certificate for SAML must be entered manually after first
+# startup via the SonarQube Admin UI:
+#   Administration → Security → SAML → X.509 Certificate (IdP)
+#
+# How to obtain the cert from Keycloak (run after cluster is ready):
+#   kubectl port-forward -n keycloak svc/keycloak 18080:8080 &
+#   curl -s http://localhost:18080/keycloak/realms/digiorg-core-platform \
+#     | python3 -c "import json,sys; print(json.load(sys.stdin)['public_key'])"
+#   kill %1
+#
+# See also: platform/base/sonarqube/README.md
 
 # ── Plugins ────────────────────────────────────────────────────────────────────
 # No additional plugins needed — SAML is built-in for Community Build.

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -501,7 +501,8 @@ def create_platform_secrets [] {
     # Code-quality namespace + SonarQube secrets
     # sonarqube-db-secret:         SONAR_JDBC_PASSWORD — PostgreSQL connection
     # sonarqube-monitoring-secret: SONAR_WEB_SYSTEMPASSCODE — required for liveness probe
-    # sonarqube-saml-secret:       created later by configure_sonarqube_saml (needs Keycloak)
+    # sonarqube-saml-secret:       NOT created here — no longer a volume dependency (see issue #109).
+    #                               The IdP cert is configured manually via SonarQube Admin UI post-startup.
     kubectl create namespace code-quality --dry-run=client -o yaml | kubectl apply -f -
     (kubectl create secret generic sonarqube-db-secret -n code-quality
         --from-literal=SONAR_JDBC_PASSWORD=($sonarqube_db_password)
@@ -695,48 +696,31 @@ def configure_gitea_oidc [] {
     print $"(ansi green)✓ Gitea OIDC integration configured(ansi reset)"
 }
 
-# Create sonarqube-saml-secret from the Keycloak realm signing certificate.
-# Must run AFTER Keycloak is ready (cert is only available then).
+# Print instructions for the manual SonarQube SAML certificate setup.
+# sonarSecretProperties is intentionally not used (see issue #109) — the
+# SonarQube Pod has no Secret volume dependency and starts without it.
+# The IdP cert must be entered once via the Admin UI after first startup.
 def configure_sonarqube_saml [] {
-    $env.KUBECONFIG = $KUBECONFIG_PATH
-
     print ""
-    print $"(ansi cyan_bold)Creating SonarQube SAML secret from Keycloak realm cert(ansi reset)"
+    print $"(ansi cyan_bold)SonarQube SAML — Manual Post-Setup Step(ansi reset)"
     print "────────────────────────────────────"
-
-    # Wait for Keycloak and fetch realm public key
-    mut cert = ""
-    for attempt in 1..30 {
-        # NOTE: kubectl exec -- <cmd> must be on ONE line in Nushell.
-        # A newline after '--' is parsed as end-of-expression, leaving
-        # kubectl exec without a container command → 'you must specify at
-        # least one command for the container' error. (see issue #103)
-        let result = (do {
-            kubectl exec -n keycloak deploy/keycloak -- curl -sk https://digiorg.local/keycloak/realms/digiorg-core-platform
-        } | complete)
-
-        if $result.exit_code == 0 {
-            let parsed = (do { $result.stdout | from json } | complete)
-            if $parsed.exit_code == 0 and ("public_key" in $parsed.value) {
-                $cert = $parsed.value.public_key
-                break
-            }
-        }
-        print $"  Waiting for Keycloak realm cert... [attempt ($attempt)/30]"
-        sleep 10sec
-    }
-
-    if ($cert | is-empty) {
-        print $"(ansi yellow)Warning: Could not fetch Keycloak realm cert — skipping sonarqube-saml-secret.(ansi reset)"
-        print $"(ansi yellow)  Create it manually after Keycloak is ready [see platform/base/sonarqube/README.md](ansi reset)"
-        return
-    }
-
-    (kubectl create secret generic sonarqube-saml-secret -n code-quality
-        --from-literal=$"sonar.auth.saml.certificate.secured=($cert)"
-        --dry-run=client -o yaml | kubectl apply -f -)
-
-    print $"(ansi green)✓ sonarqube-saml-secret created [code-quality](ansi reset)"
+    print ""
+    print $"(ansi yellow)The Keycloak IdP certificate must be added to SonarQube manually after"
+    print "the cluster is fully up. SonarQube starts without it (no Secret volume"
+    print $"dependency), but SAML login will not work until the cert is configured.(ansi reset)"
+    print ""
+    print "  1. Obtain the Keycloak realm certificate:"
+    print "       kubectl port-forward -n keycloak svc/keycloak 18080:8080 &"
+    print "       curl -s http://localhost:18080/keycloak/realms/digiorg-core-platform \\"
+    print "         | python3 -c \"import json,sys; print(json.load(sys.stdin)['public_key'])\""
+    print "       kill %1"
+    print ""
+    print "  2. Open SonarQube Admin UI:"
+    print "       https://digiorg.local/sonarqube"
+    print "       Administration → Security → SAML → X.509 Certificate (IdP)"
+    print ""
+    print "  See: platform/base/sonarqube/README.md"
+    print ""
 }
 
 # Restart pods that depend on OIDC/Keycloak


### PR DESCRIPTION
## Fixes #109
## Fixes #108

## Problem

SonarQube Pod startete nicht auf frischen Clustern:
```
MountVolume.SetUp failed for volume "secret-config" : secret "sonarqube-saml-secret" not found
```

**Ursache:** `sonarSecretProperties: "sonarqube-saml-secret"` erzeugt im Chart eine **required** Secret-Volume-Referenz (kein `optional: true`). Kubernetes verweigert den Pod-Start wenn das Secret fehlt.

Zwei weitere Bugs verhinderten außerdem die automatische Secret-Erstellung:
- `kubectl exec -- curl` schlägt fehl — Keycloak-Container hat kein curl (Issue #108)
- Falscher Key-Name: Chart erwartet Key `secret.properties`, nicht `sonar.auth.saml.certificate.secured`

## Änderungen

### `platform/base/sonarqube/values.yaml`
- `sonarSecretProperties` entfernt → kein Secret-Volume mehr → Pod startet zuverlässig
- Kommentar mit Begründung + Anleitung für manuelle Zertifikat-Konfiguration

### `scripts/local-setup.nu`
- Automatisierungsversuch in `configure_sonarqube_saml` entfernt (war kaputt, Issues #103 + #108)
- Ersetzt durch klare Ausgabe mit manuellen Post-Setup-Schritten für den Operator

## Ergebnis

SonarQube startet auf frischen Clustern ohne Voraussetzungen. SAML-Login funktioniert nach einmaliger manueller Konfiguration des Keycloak-Zertifikats:

```
Administration → Security → SAML → X.509 Certificate (IdP)
```

Anleitung zum Abrufen des Keycloak-Zertifikats wird beim `local-setup.nu up` ausgegeben.