### PR TITLE
fix(sonarqube): correct ExternalName FQDN (sonarqube → sonarqube-sonarqube)

### DIFF
--- a/platform/base/ingress/digiorg-ingress.yaml
+++ b/platform/base/ingress/digiorg-ingress.yaml
@@ -235,7 +235,9 @@ metadata:
   namespace: ingress-nginx
 spec:
   type: ExternalName
-  externalName: sonarqube.code-quality.svc.cluster.local
+  # SonarQube chart fullname = "{release}-{chart}" = sonarqube-sonarqube
+  # (no deduplication logic unlike e.g. Jaeger — see issue #113)
+  externalName: sonarqube-sonarqube.code-quality.svc.cluster.local
   ports:
     - port: 9000
 ---


### PR DESCRIPTION
## Fixes #113

## Problem

`https://digiorg.local/sonarqube` gab HTTP 503 zurück obwohl SonarQube-Pod läuft.

**Ursache:** ExternalName verwies auf nicht-existierenden Service:
```
sonarqube.code-quality.svc.cluster.local       ← existiert nicht
sonarqube-sonarqube.code-quality.svc.cluster.local  ← korrekt ✅
```

## Warum `sonarqube-sonarqube`?

Das SonarQube Chart bildet den Namen immer als `{release}-{chart}` ohne Duplikat-Prüfung. Mit Release `sonarqube` + Chart `sonarqube` → `sonarqube-sonarqube`.

Bestätigt via `kubectl get svc -n code-quality`:
```
NAME                  TYPE        CLUSTER-IP     PORT(S)
sonarqube-sonarqube   ClusterIP   10.96.145.21   9000/TCP
```

## Änderung

`platform/base/ingress/digiorg-ingress.yaml` — eine Zeile:
```yaml
# VORHER:
externalName: sonarqube.code-quality.svc.cluster.local
# NACHHER:
externalName: sonarqube-sonarqube.code-quality.svc.cluster.local
```