### PR TITLE
fix(kyverno): disable policyReportsCleanup to fix ImagePullBackOff (#107)

### DIFF
--- a/apps/platform/kyverno.yaml
+++ b/apps/platform/kyverno.yaml
@@ -63,6 +63,11 @@ spec:
             limits:
               cpu: 100m
               memory: 128Mi
+        # Disabled: bitnami/kubectl:1.30.2 no longer available on Docker Hub
+        # Cleanup is only needed for Kyverno v1 -> v2 migrations (not applicable here)
+        # See: https://github.com/digiorg/core/issues/107
+        policyReportsCleanup:
+          enabled: false
 
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
## Summary

Fixes #107

## Problem

The Kyverno Helm post-upgrade hook `kyverno-clean-reports` fails on every ArgoCD sync with an `ImagePullBackOff` error because `bitnami/kubectl:1.30.2` is no longer available on Docker Hub (Bitnami removed all versioned `1.x.y` tags).

## Fix (Option A)

Disable `policyReportsCleanup` in `apps/platform/kyverno.yaml`:

```yaml
policyReportsCleanup:
  enabled: false
```

The cleanup job is only needed for Kyverno v1 → v2 migrations. Since this environment runs a fresh KinD dev cluster, it is not applicable here. Disabling it removes the broken image reference and allows ArgoCD syncs to succeed.

## Verification

After applying:
```bash
# No clean-reports job/pod should exist
kubectl get jobs -n kyverno | grep clean-reports

# ArgoCD app should be Healthy
kubectl get applications -n argocd kyverno -o jsonpath='{.status.health.status}'
# → Healthy
```