### PR TITLE
fix(sonarqube): correct SAML property names and automate serverBaseURL via API

### DIFF
--- a/platform/base/sonarqube/values.yaml
+++ b/platform/base/sonarqube/values.yaml
@@ -156,8 +156,11 @@ prometheusMonitoring:
 #
 # The IdP certificate must be stored in the sonarqube-saml-secret Secret
 # (see README.md for how to obtain it from Keycloak).
+#
+# NOTE: sonar.core.serverBaseURL is NOT a system property and cannot be set here.
+# It is a database-stored setting that must be configured via the SonarQube Web API
+# after startup. This is handled automatically by local-setup.nu.
 sonarProperties:
-  sonar.core.serverBaseURL: "https://digiorg.local/sonarqube"
   sonar.auth.saml.enabled: "true"
   sonar.auth.saml.applicationId: "sonarqube"
   sonar.auth.saml.providerName: "Keycloak"
@@ -165,11 +168,11 @@ sonarProperties:
   sonar.auth.saml.providerId: "https://digiorg.local/keycloak/realms/digiorg-core-platform"
   # Keycloak SAML SSO endpoint
   sonar.auth.saml.loginUrl: "https://digiorg.local/keycloak/realms/digiorg-core-platform/protocol/saml"
-  # SAML attribute mappings (must match Keycloak protocol mappers in realm JSON)
-  sonar.auth.saml.userLogin: "login"
-  sonar.auth.saml.userName: "name"
-  sonar.auth.saml.userEmail: "email"
-  sonar.auth.saml.group: "groups"
+  # SAML attribute mappings — correct system property names (dots, not camelCase)
+  sonar.auth.saml.user.login: "login"
+  sonar.auth.saml.user.name: "name"
+  sonar.auth.saml.user.email: "email"
+  sonar.auth.saml.group.name: "groups"
   # Allow users to sign up via SSO on first login
   sonar.auth.saml.allowUsersToSignUp: "true"
 

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -66,6 +66,9 @@ def "main up" [] {
     # Configure Gitea OIDC integration with Keycloak
     configure_gitea_oidc
 
+    # Set SonarQube Server Base URL via Web API (not a system property, must be set post-startup)
+    configure_sonarqube_base_url
+
     # Create SonarQube SAML secret from Keycloak realm certificate
     configure_sonarqube_saml
 
@@ -697,6 +700,59 @@ def configure_gitea_oidc [] {
 }
 
 # Print instructions for the manual SonarQube SAML certificate setup.
+# Configure SonarQube Server Base URL via Web API.
+# sonar.core.serverBaseURL is NOT a system property and cannot be set via sonarProperties
+# in values.yaml — it is a database-stored setting that must be pushed via the API.
+# Required for correct SAML ACS URL construction in SAML AuthnRequests.
+def configure_sonarqube_base_url [] {
+    print ""
+    print $"(ansi cyan_bold)Configuring SonarQube Server Base URL(ansi reset)"
+    print "────────────────────────────────────"
+
+    let sonar_url = "https://digiorg.local/sonarqube"
+    let admin_pass = (do -i { kubectl get secret sonarqube-admin-secret -n code-quality -o jsonpath='{.data.password}' } | complete)
+
+    # Derive admin password: prefer sonarqube-admin-secret, fall back to env
+    let password = if $admin_pass.exit_code == 0 {
+        $admin_pass.stdout | str trim | decode base64
+    } else {
+        ($env.SONARQUBE_ADMIN_PASSWORD? | default "admin")
+    }
+
+    # Wait for SonarQube to be ready (up to 5 min)
+    mut sonar_ready = false
+    for attempt in 1..30 {
+        let status = (do -i {
+            curl --noproxy "*" -sk -u $"admin:($password)" $"($sonar_url)/api/system/status"
+        } | complete)
+        if $status.exit_code == 0 and ($status.stdout | str contains '"status":"UP"') {
+            $sonar_ready = true
+            break
+        }
+        print $"    Waiting for SonarQube... [attempt ($attempt)/30]"
+        sleep 10sec
+    }
+
+    if not $sonar_ready {
+        print $"(ansi yellow)Warning: SonarQube not ready, skipping Server Base URL configuration(ansi reset)"
+        return
+    }
+
+    # Set sonar.core.serverBaseURL via Settings API
+    let result = (do -i {
+        curl --noproxy "*" -sk -u $"admin:($password)" -X POST
+            $"($sonar_url)/api/settings/set"
+            --data-urlencode "key=sonar.core.serverBaseURL"
+            --data-urlencode $"value=($sonar_url)"
+    } | complete)
+
+    if $result.exit_code == 0 {
+        print $"  (ansi green)✓ SonarQube Server Base URL set to ($sonar_url)(ansi reset)"
+    } else {
+        print $"  (ansi red)✗ Failed to set Server Base URL: ($result.stderr)(ansi reset)"
+    }
+}
+
 # sonarSecretProperties is intentionally not used (see issue #109) — the
 # SonarQube Pod has no Secret volume dependency and starts without it.
 # The IdP cert must be entered once via the Admin UI after first startup.


### PR DESCRIPTION
## Problem

Zwei Fehler verhinderten, dass die SAML-Konfiguration beim Deployment korrekt übernommen wurde:

### 1. Falsche Property-Namen (camelCase statt dot-notation)

SonarQube ignoriert unbekannte Properties **still** — kein Fehler, keine Warnung. Dadurch wurden die SAML Attribut-Mappings nie gesetzt:

| Alt (fehlerhaft) | Korrekt |
|---|---|
| `sonar.auth.saml.userLogin` | `sonar.auth.saml.user.login` |
| `sonar.auth.saml.userName` | `sonar.auth.saml.user.name` |
| `sonar.auth.saml.userEmail` | `sonar.auth.saml.user.email` |
| `sonar.auth.saml.group` | `sonar.auth.saml.group.name` |

### 2. `sonar.core.serverBaseURL` ist keine System-Property

`sonar.core.serverBaseURL` kann **nicht** über `sonarProperties` im Helm-Chart gesetzt werden — es ist eine datenbankgespeicherte Einstellung, die beim Start ignoriert wird. Fehlte diese URL, konstruierte SonarQube die ACS-URL aus `http://localhost:9000/sonarqube`, was zu **"Invalid redirect URI"** in Keycloak führte.

## Lösung

### `values.yaml`
- Property-Namen auf korrekte dot-notation korrigiert
- `sonar.core.serverBaseURL` entfernt (mit erklärendem Kommentar)

### `local-setup.nu`
- Neue Funktion `configure_sonarqube_base_url` die nach dem Cluster-Start automatisch `sonar.core.serverBaseURL` via SonarQube Settings API setzt
- Wartet auf SonarQube-Readiness (bis zu 5 Minuten) bevor der API-Call erfolgt
- Wird im Hauptablauf vor `configure_sonarqube_saml` ausgeführt

## Testergebnis

Nach dem Fix werden alle SAML-Properties beim Deployment korrekt übernommen und das SSO-Login via Keycloak funktioniert ohne manuellen Eingriff in der Admin-UI.

## References
- Analyse: [SonarQube Configuration Methods](https://docs.sonarsource.com/sonarqube-server/server-installation/system-properties/configuration-methods.md)
- [Overview of SAML support](https://docs.sonarsource.com/sonarqube-server/instance-administration/authentication/saml/overview.md)