### PR TITLE
feat(platform): External Secrets Operator — Multi-Environment Secret Management via ArgoCD App-of-Apps

### DIFF
--- a/apps/platform/external-secrets.yaml
+++ b/apps/platform/external-secrets.yaml
@@ -1,0 +1,49 @@
+# =============================================================================
+# External Secrets Operator ArgoCD Application
+# Deploys ESO via official Helm chart with custom values
+# =============================================================================
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 0: CRD operator — must be ready before any ExternalSecret resources
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: default
+
+  sources:
+    # Source 1: External Secrets Operator Helm chart
+    - repoURL: https://charts.external-secrets.io
+      chart: external-secrets
+      targetRevision: "0.14.4"
+      helm:
+        releaseName: external-secrets
+        valueFiles:
+          - $values/platform/base/external-secrets/values.yaml
+
+    # Source 2: Values from Git repository
+    - repoURL: https://github.com/digiorg/core.git
+      targetRevision: HEAD
+      ref: values
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 5m

--- a/platform/base/external-secrets/README.md
+++ b/platform/base/external-secrets/README.md
@@ -1,0 +1,85 @@
+# External Secrets Operator
+
+Synchronises secrets from external backends (Azure Key Vault, HashiCorp Vault, …) into Kubernetes Secrets, eliminating the need to store sensitive values in Git.
+
+## Overview
+
+ESO introduces two CRDs used across the platform:
+
+| Resource | Scope | Purpose |
+|----------|-------|---------|
+| `ClusterSecretStore` | Cluster | Configures the secret backend (one per environment) |
+| `ExternalSecret` | Namespace | Declares which keys to fetch and which K8s Secret to create |
+
+## Dev vs. Production
+
+| Aspect | Local (KinD) | Production |
+|--------|-------------|------------|
+| Provider | `Fake` (static values, no backend) | Azure Key Vault / HashiCorp Vault |
+| ClusterSecretStore | `digiorg-dev-store` (this directory) | `digiorg-prod-store` (separate overlay) |
+| Credentials required | None | Service principal / Vault token |
+
+## Provider-Swap Pattern
+
+All `ExternalSecret` resources across the platform reference `digiorg-dev-store` by name. To switch environments, **only the `ClusterSecretStore` needs to be replaced** — no changes to any `ExternalSecret`:
+
+```
+Local dev   → digiorg-dev-store  (Fake provider)
+Production  → digiorg-prod-store (Azure KV / Vault)
+```
+
+Deploy the correct `ClusterSecretStore` for the target environment. Every `ExternalSecret` that references it will immediately resolve against the new backend.
+
+## Production ClusterSecretStore Examples
+
+### Azure Key Vault
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: digiorg-prod-store
+spec:
+  provider:
+    azurekv:
+      vaultUrl: https://digiorg-prod.vault.azure.net
+      authType: WorkloadIdentity
+      serviceAccountRef:
+        name: external-secrets
+        namespace: external-secrets
+```
+
+### HashiCorp Vault
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: digiorg-prod-store
+spec:
+  provider:
+    vault:
+      server: https://vault.example.com
+      path: secret
+      version: v2
+      auth:
+        kubernetes:
+          mountPath: kubernetes
+          role: external-secrets
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `values.yaml` | Helm chart values (resource-constrained for KinD) |
+| `cluster-secret-store-dev.yaml` | Fake provider store for local development |
+| `example-external-secret.yaml` | Example showing the ExternalSecret pattern |
+| `kustomization.yaml` | Kustomize entrypoint |
+
+## References
+
+- [ESO Documentation](https://external-secrets.io/latest/)
+- [Fake Provider](https://external-secrets.io/latest/provider/fake/)
+- [Azure Key Vault Provider](https://external-secrets.io/latest/provider/azure-key-vault/)
+- [HashiCorp Vault Provider](https://external-secrets.io/latest/provider/hashicorp-vault/)

--- a/platform/base/external-secrets/cluster-secret-store-dev.yaml
+++ b/platform/base/external-secrets/cluster-secret-store-dev.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: digiorg-dev-store
+spec:
+  provider:
+    # Fake provider for local development — no external secret backend required.
+    # Replace this ClusterSecretStore with an Azure KV or Vault equivalent in production.
+    fake:
+      data:
+        - key: /digiorg/gitea/admin-password
+          value: gitea_admin
+        - key: /digiorg/keycloak/admin-password
+          value: keycloak_admin
+        - key: /digiorg/sonarqube/admin-password
+          value: sonarqube_admin
+        - key: /digiorg/postgresql/password
+          value: postgresql_password

--- a/platform/base/external-secrets/example-external-secret.yaml
+++ b/platform/base/external-secrets/example-external-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: example-secret
+  namespace: external-secrets
+spec:
+  # How often ESO reconciles the secret from the backend
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: digiorg-dev-store
+    kind: ClusterSecretStore
+
+  target:
+    name: example-secret
+    creationPolicy: Owner
+
+  data:
+    # Each entry maps a backend key to a key in the resulting Kubernetes Secret.
+    # In production, change secretStoreRef.name to the production store
+    # (e.g. digiorg-prod-store) — no other changes required.
+    - secretKey: gitea-admin-password
+      remoteRef:
+        key: /digiorg/gitea/admin-password
+
+    - secretKey: keycloak-admin-password
+      remoteRef:
+        key: /digiorg/keycloak/admin-password

--- a/platform/base/external-secrets/kustomization.yaml
+++ b/platform/base/external-secrets/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cluster-secret-store-dev.yaml
+  - example-external-secret.yaml

--- a/platform/base/external-secrets/values.yaml
+++ b/platform/base/external-secrets/values.yaml
@@ -1,0 +1,40 @@
+# =============================================================================
+# External Secrets Operator Helm Chart Values
+# Chart: https://external-secrets.io/latest/introduction/getting-started/
+# =============================================================================
+
+# Install CRDs via Helm (preferred for ArgoCD-managed lifecycle)
+installCRDs: true
+
+# Operator
+replicaCount: 1
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+# Webhook
+webhook:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
+# Certificate controller
+certController:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi


### PR DESCRIPTION
## Summary

Implements #125 — integrates the [External Secrets Operator (ESO)](https://github.com/external-secrets/external-secrets) as a first-class platform component, deployed via the existing ArgoCD App-of-Apps pattern.

## Changes (6 new files, no existing files modified)

| File | Beschreibung |
|---|---|
| `apps/platform/external-secrets.yaml` | ArgoCD Application, Sync Wave 0, Helm Chart 0.14.4 |
| `platform/base/external-secrets/values.yaml` | KinD-optimierte Helm Values (installCRDs=true, replicaCount=1) |
| `platform/base/external-secrets/cluster-secret-store-dev.yaml` | `ClusterSecretStore` mit Fake-Provider für lokales Dev |
| `platform/base/external-secrets/example-external-secret.yaml` | Referenz-`ExternalSecret` als Pattern-Vorlage |
| `platform/base/external-secrets/kustomization.yaml` | Kustomization |
| `platform/base/external-secrets/README.md` | Dev/Prod Provider-Swap-Pattern, Azure KV + Vault Beispiele |

## Design-Entscheidungen

### ESO im KinD Dev-Cluster — Fake Provider
ESO wird auch im lokalen Dev-Setup deployed, nutzt aber den eingebauten **Fake-Provider** (). Das ermöglicht:
- Alle Plattform-Komponenten können konsistent `ExternalSecret`-CRDs verwenden
- Kein externer Vault im KinD-Cluster nötig
- **Dev/Prod-Parität**: Beim Wechsel zu Azure/AWS wird nur das `ClusterSecretStore`-Backend ausgetauscht — die `ExternalSecret`-Manifeste bleiben identisch

### Sync Wave 0
ESO installiert CRDs und muss vor allen `ExternalSecret`/`SecretStore`-Ressourcen bereit sein. Wave 0 (wie cert-manager).

### Provider-Swap-Pattern (Dev → Production)
```yaml
# Dev (Fake)              │  # Production (Azure KV)
spec:                      │  spec:
  provider:                │    provider:
    fake:                  │      azurekv:
      data: [...]          │        vaultUrl: https://digiorg-prod.vault.azure.net
                           │        authType: WorkloadIdentity
```
Nur der `ClusterSecretStore` wird ausgetauscht — alle `ExternalSecret`-Manifeste bleiben unverändert.

## Acceptance Criteria

- [x] ESO deployed via ArgoCD App-of-Apps, Sync Wave 0
- [x] `ClusterSecretStore` mit Fake-Provider für KinD
- [x] Beispiel `ExternalSecret` erstellt und dokumentiert
- [x] `installCRDs: true`, ressourcenschonende Limits für KinD
- [x] README dokumentiert Dev/Prod Provider-Swap Pattern mit Azure KV + Vault Beispielen
- [x] Production Overlay-Struktur im README beschrieben

Closes #125