### PR TITLE
docs(jaeger): expand README — retention, instrumentation, secret mgmt & multi-tenancy

### DIFF
--- a/platform/base/jaeger/README.md
+++ b/platform/base/jaeger/README.md
@@ -6,7 +6,7 @@ Jaeger is an open-source, end-to-end distributed tracing platform. It helps moni
 
 In the DigiOrg Core Platform, Jaeger completes the **three pillars of observability**:
 - **Metrics** — Prometheus/Grafana (already deployed)
-- **Logs** — planned
+- **Logs** — planned _(See issue #TBD for tracking progress on the logging component.)_
 - **Traces** — Jaeger (this component)
 
 ## Architecture
@@ -59,6 +59,21 @@ The relevant settings are under `userconfig:`:
 > **Note:** The old Jaeger v1 Helm schema (`allInOne:`, `collector:`, `query:`, `storage.type:`)
 > does not exist in chart 3.x and will be silently ignored. Always use `jaeger:` and `userconfig:`.
 
+## Data Retention
+
+Jaeger v2 (chart 3.x) ships an `esIndexCleaner` CronJob that deletes OpenSearch indices older than a configurable number of days. Enable and tune it in `values.yaml`:
+
+```yaml
+esIndexCleaner:
+  enabled: true
+  numberOfDays: 7
+  schedule: "55 23 * * *"
+```
+
+The job runs daily at 23:55 and removes any Jaeger index whose age exceeds `numberOfDays`. Adjust the schedule and retention window to match your SLA and storage budget.
+
+For more advanced rules (e.g. per-index size caps, rollover policies) you can instead define an [OpenSearch ISM policy](https://opensearch.org/docs/latest/im-plugin/ism/index/) targeting the `jaeger-*` index pattern. ISM policies and `esIndexCleaner` can coexist — use ISM for rollover and `esIndexCleaner` for final deletion.
+
 ## Instrumentation
 
 Services send traces to Jaeger using the OpenTelemetry SDK:
@@ -67,6 +82,24 @@ Services send traces to Jaeger using the OpenTelemetry SDK:
 OTLP gRPC: jaeger-query.tracing.svc.cluster.local:4317
 OTLP HTTP: jaeger-query.tracing.svc.cluster.local:4318
 ```
+
+### Kubernetes Deployment Example
+
+Add the following environment variables to any Kubernetes `Deployment` to enable OTLP trace export over gRPC:
+
+```yaml
+env:
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: "http://jaeger-query.tracing.svc.cluster.local:4317"
+  - name: OTEL_SERVICE_NAME
+    value: "my-service"
+  - name: OTEL_TRACES_EXPORTER
+    value: "otlp"
+  - name: OTEL_PROPAGATORS
+    value: "tracecontext,baggage"
+```
+
+Replace `my-service` with the logical name of your application. The SDK auto-detects the gRPC protocol from the `http://` scheme on port `4317`; use port `4318` with `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` if you prefer HTTP.
 
 ## Keycloak SSO
 
@@ -84,6 +117,32 @@ The secret is created by `scripts/local-setup.nu` and contains:
 - `client-secret`: Keycloak OIDC client secret (default: `jaeger-client-secret`)
 - `cookie-secret`: 32-byte base64 cookie encryption key
 
+### Secret Management
+
+Generate a cryptographically secure `cookie-secret`:
+
+```bash
+openssl rand -base64 32
+```
+
+To update or rotate the secret in-place without downtime, use the `--dry-run=client` pattern to preview the change before applying it:
+
+```bash
+kubectl create secret generic jaeger-oauth2-proxy-secrets \
+  --namespace tracing \
+  --from-literal=client-secret='<new-client-secret>' \
+  --from-literal=cookie-secret="$(openssl rand -base64 32)" \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+After applying, restart the oauth2-proxy deployment to pick up the new values:
+
+```bash
+kubectl rollout restart deployment/jaeger-oauth2-proxy -n tracing
+```
+
+> **Production note:** Do not store secrets in `values.yaml` or Git. Inject them at deploy time from a secrets manager such as [HashiCorp Vault](https://developer.hashicorp.com/vault) (via the Vault Agent Injector or the Secrets Store CSI driver) or [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets).
+
 ## Production Considerations
 
 1. **Authentication**: Rotate the `cookie-secret` and use a strong `client-secret` from a secrets manager.
@@ -91,4 +150,4 @@ The secret is created by `scripts/local-setup.nu` and contains:
 3. **Sampling**: Configure adaptive sampling strategies in the OTEL Collector pipeline.
 4. **Resource limits**: Increase CPU/memory limits and add HPA based on observed usage.
 5. **Retention**: Configure index TTL in OpenSearch to match your retention policy (e.g. 7 days).
-6. **Multi-tenancy**: Enable Jaeger multi-tenancy for separate trace namespaces per team.
+6. **Multi-tenancy**: Jaeger multi-tenancy allows a single Jaeger instance to serve multiple isolated tenants, each with their own trace namespace and access controls. This is useful when multiple teams or environments share the same Jaeger deployment. See the [Jaeger multi-tenancy documentation](https://www.jaegertracing.io/docs/latest/multi-tenancy/) for configuration details.


### PR DESCRIPTION
## Summary

Implements all improvements identified in #141 for the Jaeger README at `platform/base/jaeger/README.md`.

## Changes

### 🔴 High Priority

**1. Data Retention** (new `## Data Retention` section)
- Explains the `esIndexCleaner` CronJob shipped with the Jaeger Helm chart
- Provides a ready-to-use `values.yaml` snippet (enabled, 7 days, daily schedule)
- Notes OpenSearch ISM policies as an alternative for advanced rollover/retention rules

**2. Secret Management** (new `### Secret Management` subsection under Keycloak SSO)
- Shows how to generate a secure `cookie-secret` via `openssl rand -base64 32`
- Provides `kubectl create secret ... --dry-run=client | kubectl apply -f -` rotation pattern
- Includes `kubectl rollout restart` follow-up command
- Production note pointing to HashiCorp Vault and Sealed Secrets

### 🟡 Medium Priority

**3. Instrumentation Example** (new `### Kubernetes Deployment Example` subsection)
- Concrete Kubernetes `env:` block with all four required OTEL variables
- Covers gRPC (4317) as primary, notes HTTP (4318) alternative

**4. Multi-Tenancy** (expanded point 6 in Production Considerations)
- Added context explaining what Jaeger multi-tenancy provides
- Links to the official Jaeger multi-tenancy documentation

### 🟢 Low Priority

**5. Logging Placeholder** (inline note next to 'Logs — planned')
- Added `_(See issue #TBD for tracking progress on the logging component.)_`

## Related

Closes #141