### PR TITLE
docs(keycloak): fix factual errors and expand README

### DIFF
--- a/platform/base/keycloak/README.md
+++ b/platform/base/keycloak/README.md
@@ -1,15 +1,19 @@
 # Keycloak Configuration
 
-Keycloak is the Identity Provider (IdP) for the platform, providing SSO for all services.
+Keycloak 26.0 (`quay.io/keycloak/keycloak:26.0`) is the Identity Provider (IdP) for the platform, providing SSO for all services via the `digiorg-core-platform` realm.
+
+> **Development mode notice**
+> This deployment runs Keycloak in `start-dev` mode (`args: [start-dev, --import-realm]`). HTTP is used internally; TLS is terminated at the NGINX ingress. This configuration is **not suitable for production** — there is no clustering, no HA, and no persistent session store. The `--import-realm` flag only imports the realm on first start **when the realm does not yet exist in the database**.
 
 ## Files
 
 | File | Description |
 |------|-------------|
-| `namespace.yaml` | Keycloak namespace |
-| `keycloak-deployment.yaml` | Keycloak server deployment |
-| `realm-configmap.yaml` | Pre-configured realm (`digiorg-core-platform`) |
-| `kustomization.yaml` | Kustomize entrypoint |
+| `keycloak-deployment.yaml` | Keycloak server deployment (Service + Deployment) |
+| `kustomization.yaml` | Kustomize entrypoint; generates realm ConfigMap from JSON files |
+| `values.yaml` | Helm/ArgoCD value overrides |
+| `digiorg-core-platform-realm.json` | Realm definition (clients, roles, groups) |
+| `digiorg-core-platform-users-0.json` | Pre-seeded realm users |
 
 **Note:** Keycloak uses the shared PostgreSQL instance in the `platform-db` namespace. Database credentials are provided via the `keycloak-db-credentials` Secret.
 
@@ -17,7 +21,19 @@ Keycloak is the Identity Provider (IdP) for the platform, providing SSO for all 
 
 | Environment | URL | Credentials |
 |-------------|-----|-------------|
-| Local (KinD) | http://digiorg.local/keycloak | admin / admin |
+| Local (KinD) | https://digiorg.local/keycloak | admin / admin |
+
+Admin Console: https://digiorg.local/keycloak/admin
+
+## Ports
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 8080 | HTTP | Keycloak application (internal) |
+| 9000 | HTTP | Health & management API (`KC_HEALTH_ENABLED=true`) |
+| 30100 | TCP | NodePort for local KinD cluster access |
+
+Health endpoint: `http://keycloak.keycloak.svc.cluster.local:9000/health/ready`
 
 ## Pre-configured Realm
 
@@ -27,23 +43,42 @@ The `digiorg-core-platform` realm is automatically imported on startup with:
 
 | Client ID | Service | Redirect URIs | Notes |
 |-----------|---------|---------------|-------|
-| `landingpage` | Landing Page | `http://digiorg.local/*`, `https://digiorg.local/*` | Public client (no secret) |
-| `argocd` | ArgoCD | `http://digiorg.local/argocd/auth/callback` | Auto-configured |
-| `grafana` | Grafana | `http://digiorg.local/grafana/login/generic_oauth` | Auto-configured |
-| `backstage` | Backstage | `http://digiorg.local/backstage/api/auth/oidc/handler/frame` | Auto-configured |
-| `gitea` | Gitea | `http://digiorg.local/gitea/user/oauth2/Keycloak/callback` | **Manual config in Gitea Admin UI** |
+| `landingpage` | Landing Page | `https://digiorg.local/*` | Public client (no secret), PKCE S256 |
+| `argocd` | ArgoCD | `https://digiorg.local/argocd/auth/callback` | Auto-configured |
+| `grafana` | Grafana | `https://digiorg.local/grafana/login/generic_oauth` | Auto-configured |
+| `backstage` | Backstage | `https://digiorg.local/backstage/api/auth/oidc/handler/frame`, `https://digiorg.local/backstage/*` | Auto-configured |
+| `gitea` | Gitea | `https://digiorg.local/gitea/user/oauth2/Keycloak/callback`, `https://digiorg.local/gitea/*` | **Manual config in Gitea Admin UI** |
+| `jaeger` | Jaeger | `https://digiorg.local/jaeger/oauth2/callback` | Protected via oauth2-proxy + Keycloak OIDC |
+| `sonarqube` | SonarQube | `https://digiorg.local/sonarqube/oauth2/callback/saml`, `https://digiorg.local/sonarqube/*` | SAML/OIDC callback |
+
+### Realm Roles
+
+| Role | Description |
+|------|-------------|
+| `platform-admin` | Full administrative access to the platform |
+| `platform-viewer` | Read-only access to the platform |
+| `developer` | Standard developer access |
 
 ### Default Users
 
-| Username | Password | Realm Role |
-|----------|----------|------------|
-| admin | admin | Admin (Keycloak master realm) |
+#### Keycloak Master Admin
+
+| Username | Password | Scope |
+|----------|----------|-------|
+| `admin` | `admin` | Keycloak master realm (bootstrap only) |
+
+#### Pre-seeded Realm Users
+
+| Username | Password | Email | Realm Role |
+|----------|----------|-------|------------|
+| `digiorgadmin` | `digiorgadmin` | admin@digiorg.local | `platform-admin` |
+| `digiorgdeveloper` | `digiorgdeveloper` | developer@digiorg.local | `developer` |
 
 ## Architecture
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│                   Keycloak                          │
+│            Keycloak 26.0 (start-dev)                │
 │                                                     │
 │  ┌─────────────────────────────────────────────┐    │
 │  │         Realm: digiorg-core-platform        │    │
@@ -53,13 +88,16 @@ The `digiorg-core-platform` realm is automatically imported on startup with:
 │  │  ├── argocd (OIDC)                          │    │
 │  │  ├── grafana (OIDC)                         │    │
 │  │  ├── backstage (OIDC)                       │    │
-│  │  └── gitea (OIDC)*                          │    │
+│  │  ├── gitea (OIDC)*                          │    │
+│  │  ├── jaeger (OIDC, oauth2-proxy)            │    │
+│  │  └── sonarqube (SAML)                       │    │
 │  │                                             │    │
 │  │  * Gitea OIDC configured in Admin UI        │    │
 │  │                                             │    │
 │  │  Roles:                                     │    │
 │  │  ├── platform-admin                         │    │
-│  │  └── platform-viewer                        │    │
+│  │  ├── platform-viewer                        │    │
+│  │  └── developer                              │    │
 │  └─────────────────────────────────────────────┘    │
 │                       │                             │
 └───────────────────────┬─────────────────────────────┘
@@ -86,15 +124,32 @@ kubectl rollout status statefulset/postgresql -n platform-db
 kubectl rollout status deployment/keycloak -n keycloak
 ```
 
+### keycloak-db-credentials Secret
+
+Keycloak requires a `keycloak-db-credentials` Secret in the `keycloak` namespace before the pod can start:
+
+```bash
+kubectl create secret generic keycloak-db-credentials \
+  --namespace keycloak \
+  --from-literal=password=<your-db-password>
+```
+
+> **Note:** `local-setup.nu` handles this automatically for local development.
+
 ## Adding New OIDC Clients
 
-1. Edit `realm-configmap.yaml`
-2. Add new client under `clients` array
+1. Edit `digiorg-core-platform-realm.json`
+2. Add new client under the `clients` array
 3. Re-apply: `kubectl apply -k platform/base/keycloak/`
-4. Restart Keycloak to re-import realm
 
-Or use the Keycloak Admin Console:
-1. Go to http://digiorg.local/keycloak/admin
+> **Warning:** The `--import-realm` flag only imports the realm when it **does not yet exist** in the database. Modifying the JSON files and restarting Keycloak will **not** re-apply changes to an existing realm.
+>
+> To apply changes to an existing realm, either:
+> - Use the Admin Console directly at https://digiorg.local/keycloak/admin, **or**
+> - Delete the realm in the database and restart Keycloak (destructive — all realm data and user sessions are wiped)
+
+Or use the Keycloak Admin Console directly:
+1. Go to https://digiorg.local/keycloak/admin
 2. Select realm `digiorg-core-platform`
 3. Navigate to Clients → Create
 
@@ -119,7 +174,7 @@ kubectl exec -n platform-db postgresql-0 -- psql -U postgres -c "\l" | grep keyc
 
 ```bash
 # Check ConfigMap exists
-kubectl get configmap keycloak-realm -n keycloak
+kubectl get configmap keycloak-realm-import -n keycloak
 
 # Verify realm import
 kubectl logs -n keycloak -l app=keycloak | grep -i realm


### PR DESCRIPTION
## Summary

Fixes all factual errors and adds missing information identified in #143 for the Keycloak README at `platform/base/keycloak/README.md`.

Changes were derived directly from the actual source files (`keycloak-deployment.yaml`, `kustomization.yaml`, `digiorg-core-platform-realm.json`, `digiorg-core-platform-users-0.json`) — not from assumptions.

---

## 🔴 Corrections (factual errors fixed)

**1. Files table — replaced non-existent files**
- Removed `namespace.yaml` (does not exist) and `realm-configmap.yaml` (does not exist)
- Added actual files: `values.yaml`, `digiorg-core-platform-realm.json`, `digiorg-core-platform-users-0.json`
- Updated `kustomization.yaml` description to mention ConfigMap generation

**2. OIDC Clients — 2 missing clients + wrong URIs**
- Added missing `jaeger` client (`https://digiorg.local/jaeger/oauth2/callback`)
- Added missing `sonarqube` client (SAML/OIDC callbacks)
- Fixed all redirect URIs: `http://` → `https://` (aligned with `realm.json`)
- Fixed `backstage` redirect URIs to include the wildcard entry from realm.json

**3. Default Users — incomplete**
- Split into `#### Keycloak Master Admin` (admin/admin, bootstrap only) and `#### Pre-seeded Realm Users`
- Added `digiorgadmin / digiorgadmin` (role: platform-admin, email: admin@digiorg.local)
- Added `digiorgdeveloper / digiorgdeveloper` (role: developer, email: developer@digiorg.local)

**4. Realm Roles — missing `developer` role**
- Added new `### Realm Roles` table with all three roles and their descriptions from `realm.json`
- Updated Architecture diagram to include `developer` role

**5. Access URLs — http → https**
- All occurrences of `http://digiorg.local/keycloak` corrected to `https://`
- Added explicit Admin Console URL: `https://digiorg.local/keycloak/admin`

**6. Troubleshooting — wrong ConfigMap name**
- `keycloak-realm` → `keycloak-realm-import` (matches `kustomization.yaml` configMapGenerator name)

---

## 🟡 Additions (missing information)

**7. Keycloak version**
- Version `26.0` and image `quay.io/keycloak/keycloak:26.0` added to intro and Architecture header

**8. Dev mode notice**
- Prominent blockquote explaining `start-dev` mode, HTTP-only internal networking, no-production suitability, and one-shot import behavior

**9. Ports section**
- New `## Ports` table: 8080 (app), 9000 (health/management), 30100 (NodePort)
- In-cluster health endpoint URL

**10. `keycloak-db-credentials` Secret creation**
- `kubectl create secret` snippet under `## Local Development`
- Note that `local-setup.nu` handles this automatically for local dev

**11. Realm import warning**
- Replaced misleading "Restart Keycloak to re-import realm" with accurate warning block
- Documents that `--import-realm` only runs when realm doesn't exist in DB
- Lists two valid alternatives: Admin Console or DB-delete + restart

**12. Architecture diagram**
- Added `jaeger (OIDC, oauth2-proxy)` and `sonarqube (SAML)` to client list

---

Closes #143
