### PR TITLE
docs(landingpage): fix factual errors and expand README

### DIFF
--- a/platform/base/landingpage/README.md
+++ b/platform/base/landingpage/README.md
@@ -1,6 +1,6 @@
 # Landing Page
 
-The DigiOrg Platform Landing Page serves as the central entry point for all platform services.
+The DigiOrg Platform Landing Page serves as the central entry point for all platform services. It is deployed in the `platform-apps` namespace.
 
 ## Features
 
@@ -23,25 +23,43 @@ The DigiOrg Platform Landing Page serves as the central entry point for all plat
 
 | Environment | URL |
 |-------------|-----|
-| Local (KinD) | http://digiorg.local/ |
+| Local (KinD) | https://digiorg.local/ |
+
+## Ports
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 8080 | HTTP | Application + health endpoint |
+
+Health: `GET /health` — used by liveness and readiness probes.  
+In-cluster: `http://landingpage.platform-apps.svc.cluster.local:8080`
 
 ## Configuration
 
 ### Runtime Configuration
 
-The landing page configuration is injected via ConfigMap:
+The landing page runtime configuration is injected via the `landingpage-config` ConfigMap, mounted as `/usr/share/nginx/html/config.js`:
 
 ```javascript
 window.__DIGIORG_CONFIG__ = {
-  baseUrl: "http://digiorg.local",
+  baseUrl: "https://digiorg.local",
   keycloak: {
-    url: "http://digiorg.local/keycloak",
+    url: "https://digiorg.local/keycloak",
     realm: "digiorg-core-platform",
     clientId: "landingpage"
   },
   servicesEndpoint: "/api/services"
 };
 ```
+
+> **Note:** `servicesEndpoint` is present in the config object but services are not fetched from an API. The service list is statically loaded from the `landingpage-services` ConfigMap, which is mounted as `/usr/share/nginx/html/services.json` and read directly by the frontend at startup.
+
+### ConfigMaps
+
+| ConfigMap | Key | Mount Path |
+|-----------|-----|------------|
+| `landingpage-config` | `config.js` | `/usr/share/nginx/html/config.js` |
+| `landingpage-services` | `services.json` | `/usr/share/nginx/html/services.json` |
 
 ### Service Registry
 
@@ -54,8 +72,41 @@ Platform services with UI are defined in `services-configmap.yaml`. Each service
 | `description` | Short description |
 | `path` | URL path (relative to base URL) |
 | `icon` | Icon name (key, git-branch, chart, code, git, etc.) |
-| `category` | Grouping (security, deployment, monitoring, developer) |
+| `category` | Grouping (`security`, `developer`, `deployment`, `monitoring`, `observability`, `devsecops`) |
 | `requiresAuth` | Whether authentication is required to access |
+| `displayOrder` | Render order of the service card in the UI |
+
+### Registered Services
+
+| displayOrder | ID | Name | Category | Path | requiresAuth |
+|---|---|---|---|---|---|
+| 1 | `keycloak` | Identities & Access | `security` | `/keycloak` | false |
+| 2 | `backstage` | Components & Catalog | `developer` | `/backstage` | true |
+| 3 | `gitea` | Repositories & Pipelines | `developer` | `/gitea` | true |
+| 4 | `argocd` | GitOps & Deployment | `deployment` | `/argocd` | true |
+| 5 | `grafana` | Logging & Monitoring | `monitoring` | `/grafana` | true |
+| 6 | `jaeger` | Tracing & Observing | `observability` | `/jaeger` | true |
+| 7 | `sonarqube` | Code Quality & Security | `devsecops` | `/sonarqube` | true |
+
+## Architecture
+
+```
+Browser → NGINX /  → landingpage:8080 (platform-apps namespace)
+                         ├── landingpage-config  (config.js)
+                         └── landingpage-services (services.json)
+                                   │
+                             Keycloak OIDC
+                          (public client, no secret)
+```
+
+## Resource Limits & Security
+
+|        | Request | Limit |
+|--------|---------|-------|
+| CPU    | 10m     | 100m  |
+| Memory | 32Mi    | 64Mi  |
+
+The container runs as a non-root user (UID 101) with `allowPrivilegeEscalation: false` and all Linux capabilities dropped.
 
 ## Dependencies
 
@@ -66,3 +117,4 @@ Platform services with UI are defined in `services-configmap.yaml`. Each service
 
 - **Repository:** https://github.com/digiorg/core-landingpage
 - **Image:** `ghcr.io/digiorg/core-landingpage:main`
+- **imagePullPolicy:** `Always` — image is pulled on every pod start


### PR DESCRIPTION
## Summary

Fixes all factual errors and adds missing information identified in #145 for the Landing Page README at `platform/base/landingpage/README.md`.

All changes derived directly from the actual source files (`deployment.yaml`, `service.yaml`, `configmap.yaml`, `services-configmap.yaml`, `kustomization.yaml`).

---

## 🔴 Corrections (factual errors fixed)

**1. URLs: http:// → https://**
- Access table: `http://digiorg.local/` → `https://digiorg.local/`
- Config block `baseUrl`: `http://` → `https://` (aligned with `configmap.yaml`)
- Config block `keycloak.url`: `http://` → `https://` (aligned with `configmap.yaml`)

**2. `displayOrder` field added to Service Registry schema**
- Missing field that controls render order of service cards in the UI
- Present in every entry of `services-configmap.yaml`

**3. Categories corrected**
- Was: `security, deployment, monitoring, developer`
- Now: `security, developer, deployment, monitoring, observability, devsecops` (all 6 actual values from `services-configmap.yaml`)

**4. `servicesEndpoint` clarified**
- Added note explaining services are loaded statically from the mounted `services.json` — not fetched from an API endpoint

---

## 🟡 Additions (missing information)

**5. Namespace `platform-apps`** — added to intro paragraph

**6. Registered Services table** — all 7 services from `services-configmap.yaml` with displayOrder, ID, name, category, path, requiresAuth

**7. Ports section** — port 8080, `/health` endpoint, in-cluster DNS address

**8. ConfigMaps table** — `landingpage-config` and `landingpage-services` with keys and mount paths made explicit

**9. Architecture section** — ASCII diagram showing Browser → NGINX → ConfigMaps → Keycloak OIDC flow

**10. `imagePullPolicy: Always`** — documented in Container Image section

**11. Resource Limits & Security** — CPU/Memory table + security context (non-root UID 101, no privilege escalation, all capabilities dropped)

---

Closes #145
