### PR TITLE
docs(sonarqube): fix factual errors and expand README

### DIFF
--- a/platform/base/sonarqube/README.md
+++ b/platform/base/sonarqube/README.md
@@ -10,6 +10,18 @@ Static code analysis platform for the DigiOrg Core Platform.
 
 ---
 
+## Files
+
+| File | Purpose |
+|------|---------|
+| `namespace.yaml` | Namespace `code-quality` |
+| `values.yaml` | SonarQube Helm Chart values (edition, DB, probes, resources, SAML, Prometheus) |
+| `kustomization.yaml` | Kustomize entrypoint — manages only `namespace.yaml`; SonarQube itself is deployed via Helm by ArgoCD (`apps/platform/sonarqube.yaml`) |
+
+> **Note:** `kubectl apply -k .` from this directory only creates the `code-quality` namespace. SonarQube is not deployed by Kustomize.
+
+---
+
 ## Required Secrets
 
 Three Kubernetes Secrets must exist in namespace `code-quality` before ArgoCD deploys SonarQube. Create them via `local-setup.nu` or manually:
@@ -42,7 +54,9 @@ Use a random string, e.g.: `openssl rand -hex 32`
 
 ### 3. `sonarqube-saml-secret` — Keycloak IdP certificate
 
-Contains the Keycloak realm signing certificate for SAML signature verification.
+Contains the Keycloak realm signing certificate used for SAML signature verification. This Secret is **not mounted as a properties file** — `sonarSecretProperties` is intentionally left unset. Setting it would create a required Secret volume mount with no `optional: true` in the chart, preventing the pod from starting on fresh clusters where the Secret may not yet exist (see [issue #109](https://github.com/digiorg/core/issues/109)).
+
+> **Note:** `sonar.auth.saml.*` settings are database-stored, not system properties. They are silently ignored in both `sonarProperties` and `sonarSecretProperties`. SAML is configured exclusively via the SonarQube Settings API.
 
 **Step 1 — Obtain the certificate from Keycloak:**
 
@@ -64,6 +78,10 @@ kubectl create secret generic sonarqube-saml-secret \
   --from-literal="sonar.auth.saml.certificate.secured=${CERT}" \
   -n code-quality
 ```
+
+**Step 3 — Configure SAML:**
+
+SAML is configured automatically by `local-setup.nu` (function: `configure_sonarqube_saml`), which reads the certificate from this Secret and applies all `sonar.auth.saml.*` settings via the SonarQube Settings API after first startup. To configure manually instead, use **Administration → Security → SAML** in the Admin UI.
 
 > **Note:** The certificate must be recreated whenever Keycloak realm keys rotate or the cluster is rebuilt.
 
@@ -88,6 +106,14 @@ The SonarQube SAML client is defined in `platform/base/keycloak/digiorg-core-pla
 
 ---
 
+## Configuration Notes
+
+### `sonar.core.serverBaseURL`
+
+`sonar.core.serverBaseURL` is **not a system property** and cannot be set via `sonarProperties` or `sonarSecretProperties`. It is a database-stored setting applied via the SonarQube Settings API by `local-setup.nu` (function: `configure_sonarqube_base_url`). No manual action is required.
+
+---
+
 ## First Login
 
 After deployment:
@@ -98,7 +124,144 @@ After deployment:
 
 ---
 
+## Deployment
+
+- **Type:** StatefulSet (single replica)
+- **Service:** ClusterIP on port `9000`
+- **Persistence:** 5 Gi PVC (`ReadWriteOnce`) — stores plugins and temporary files
+- **Web context:** `/sonarqube` (set via `sonarWebContext`; injected automatically as `SONAR_WEB_CONTEXT`)
+
+---
+
+## Resources
+
+SonarQube is the most resource-intensive component in the platform due to its embedded Elasticsearch instance.
+
+| | CPU | Memory |
+|-|-----|--------|
+| Request | `200m` | `2Gi` |
+| Limit | `2000m` | `4Gi` |
+
+> **Warning:** SonarQube + embedded Elasticsearch requires **at least 2 Gi of memory** to start. Scheduling on a node with insufficient available memory results in OOMKill or a pod stuck in `Pending`.
+
+---
+
+## Probes
+
+SonarQube can take 2–3 minutes to start (Elasticsearch initialisation + DB schema migrations on first run).
+
+| Probe | Initial Delay | Period | Failure Threshold | Budget |
+|-------|--------------|--------|-------------------|--------|
+| Startup | 30s | 10s | 24 | ~4 min |
+| Liveness | 120s | 30s | 6 | — |
+| Readiness | 120s | 30s | 6 | — |
+
+> **Important:** Helm chart 10.x generates probe scripts using `wget`, but the SonarQube Community Build image ships only `curl`. The probe `exec.command` is overridden in `values.yaml` to use `curl` explicitly (see [issue #111](https://github.com/digiorg/core/issues/111)).
+
+---
+
+## Embedded Elasticsearch
+
+SonarQube runs an embedded Elasticsearch instance in-process. This is **not** the platform OpenSearch deployment — they are completely separate.
+
+**Local KinD (default `values.yaml`):**
+
+`vm.max_map_count` enforcement is disabled because KinD nodes do not support sysctl changes:
+
+```yaml
+elasticsearch:
+  bootstrapChecks: false
+initSysctl:
+  enabled: false
+```
+
+**Production clusters:**
+
+`vm.max_map_count` must be set to at least `262144` on every node that may run SonarQube. Enable the init container to apply it:
+
+```yaml
+elasticsearch:
+  bootstrapChecks: true
+initSysctl:
+  enabled: true   # requires privileged node access
+```
+
+Failure to set `vm.max_map_count` in production causes Elasticsearch to abort with:
+`max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]`
+
+---
+
+## Prometheus Monitoring
+
+A `PodMonitor` is enabled in `values.yaml`:
+
+```yaml
+prometheusMonitoring:
+  podMonitor:
+    enabled: true
+    interval: 30s
+    labels:
+      release: prometheus   # required for kube-prometheus-stack discovery
+```
+
+The `release: prometheus` label is required for `kube-prometheus-stack` to discover the `PodMonitor`. Removing or changing this label causes metrics to stop being scraped.
+
+---
+
+## Security Context
+
+| Setting | Value |
+|---------|-------|
+| `runAsUser` | `1000` |
+| `runAsGroup` | `0` |
+| `fsGroup` | `0` |
+| `allowPrivilegeEscalation` | `false` |
+| `capabilities.drop` | `["ALL"]` |
+| `seccompProfile` | `RuntimeDefault` |
+
+---
+
 ## Upgrading Community Build Version
 
 Update `community.buildNumber` in `values.yaml` to the desired Community Build version.
 Find available versions at [SonarQube Downloads](https://www.sonarsource.com/products/sonarqube/downloads/).
+
+---
+
+## Architecture
+
+```
+Browser → NGINX /sonarqube → SonarQube:9000 (code-quality ns, StatefulSet)
+                                   ├── Embedded Elasticsearch (in-process, not platform OpenSearch)
+                                   ├── PostgreSQL :5432 (platform-db ns) — analysis data
+                                   ├── 5Gi PVC — plugins, temp files
+                                   └── Keycloak SAML (settings configured via API)
+```
+
+---
+
+## Troubleshooting
+
+**Check pod status:**
+
+```bash
+kubectl get pods -n code-quality
+```
+
+**Inspect logs** (pod name follows the StatefulSet pattern, e.g. `sonarqube-sonarqube-0`):
+
+```bash
+kubectl logs -n code-quality <pod-name>
+```
+
+**Check persistent storage:**
+
+```bash
+kubectl get pvc -n code-quality
+```
+
+**Startup time:** SonarQube takes 2–3 minutes to initialise on first boot (Elasticsearch startup + DB migrations). The UI is unavailable until the pod reports `Ready`. Monitor progress with:
+
+```bash
+kubectl get pods -n code-quality -w
+```


### PR DESCRIPTION
## Summary

Fixes all factual errors and adds missing information identified in #153 for the SonarQube README at `platform/base/sonarqube/README.md`.

All changes derived directly from `values.yaml` and `kustomization.yaml`. The most significant fix corrects a misleading description of the SAML secret mechanism that could cause hours of debugging.

---

## 🔴 Corrections (factual errors fixed)

**1. Files table added**
- All 3 files listed with purpose and Kustomize-scope clarification

**2. SAML secret mechanism — rewritten**
- Previous README implied `sonarqube-saml-secret` was mounted via `sonarSecretProperties` → this is wrong
- `sonarSecretProperties` is intentionally NOT set (see issue #109 — would break fresh cluster deployments)
- `sonar.auth.saml.*` are database-stored settings, silently ignored in properties files
- Added Step 3 documenting actual flow: `local-setup.nu` configures SAML via Settings API; manual alternative is Admin UI

**3. Resource requirements added (highest in the platform)**
- CPU: 200m request / 2000m limit
- Memory: **2Gi request / 4Gi limit**
- OOMKill warning added

**4. Embedded Elasticsearch documented**
- SonarQube uses an in-process Elasticsearch (not platform OpenSearch)
- KinD: `bootstrapChecks: false`, `initSysctl: false`
- Production: `vm.max_map_count >= 262144` required; exact error message included

**5. Kustomize scope clarified**
- `kubectl apply -k .` only creates the namespace, not SonarQube

---

## 🟡 Additions (missing information)

**6. Prometheus Monitoring** — PodMonitor (enabled, 30s interval, `release: prometheus` label)

**7. Deployment section** — StatefulSet, ClusterIP:9000, 5Gi PVC (ReadWriteOnce)

**8. Probes section** — startup budget 4 min (24×10s), liveness/readiness 120s delay; `curl`-over-`wget` override (issue #111)

**9. Configuration Notes** — `sonar.core.serverBaseURL` not a system property, set via API by `local-setup.nu`

**10. Architecture section** — ASCII diagram: Browser → NGINX → SonarQube → PostgreSQL, embedded ES, PVC, Keycloak SAML

**11. Troubleshooting section** — pod/logs/PVC commands; startup time warning (2–3 min)

**12. Security Context table** — runAsUser 1000, fsGroup 0, allowPrivilegeEscalation false, all capabilities dropped

---

Closes #153
