### PR TITLE
docs(scripts): fix factual errors, add Phase 3, expand README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,8 @@ This directory contains automation scripts for the DigiOrg Core Platform.
 - [Helm](https://helm.sh/) >= 3.12
 - [KinD](https://kind.sigs.k8s.io/) >= 0.20
 
+> **Note:** `check_prerequisites` only validates `kind`, `kubectl`, and `helm`. Docker and Nushell (`nu`) are also required but not auto-checked — ensure they are installed before running.
+
 ## Scripts
 
 ### local-setup.nu
@@ -35,25 +37,31 @@ nu scripts/local-setup.nu bootstrap
 
 ## Architecture
 
-The setup follows a two-phase approach:
+The setup follows a three-phase approach:
 
 ### Phase 1: Bootstrap (Setup Script)
 
 The script installs only the minimal infrastructure needed to run ArgoCD:
 
 1. **KinD Cluster** (`digiorg-core-dev`)
-2. **Gateway API CRDs**
-3. **NGINX Ingress Controller**
-4. **Platform Ingress** (unified routing via `digiorg.local`)
-5. **CoreDNS Patch** (internal `digiorg.local` resolution)
-6. **Platform Secrets** (shared PostgreSQL credentials + per-service secrets)
+2. **vm.max_map_count=262144** set on the KinD node via `docker exec` (required by OpenSearch's embedded Elasticsearch)
+3. **Gateway API CRDs**
+4. **NGINX Ingress Controller**
+5. **Platform Ingress** (unified routing via `digiorg.local`)
+6. **CoreDNS Patch** (internal `digiorg.local` resolution)
+7. **Platform Secrets** (shared PostgreSQL credentials + per-service secrets)
    - `platform-db/postgresql-secrets`: Shared PostgreSQL superuser and per-database passwords
    - `backstage/backstage-secrets`: Bootstrap application secret
    - `keycloak/keycloak-db-credentials`: Keycloak PostgreSQL database credentials
    - `gitea/gitea-secrets`: PostgreSQL password, OIDC client secret
    - `gitea/gitea-admin-secret`: Admin username and randomly generated password
-7. **ArgoCD** (Helm install)
-8. **Root App** (triggers App-of-Apps)
+   - `code-quality/sonarqube-db-secret`: `SONAR_JDBC_PASSWORD`
+   - `code-quality/sonarqube-monitoring-secret`: `SONAR_WEB_SYSTEMPASSCODE`
+   - `tracing/jaeger-oauth2-proxy-secrets`: `client-secret`, `cookie-secret`
+   - `platform-db/opensearch-secrets`: `OPENSEARCH_ADMIN_PASSWORD`
+   - `tracing/jaeger-opensearch-credentials`: `password` (Jaeger → OpenSearch auth)
+8. **ArgoCD** (Helm install)
+9. **Root App** (triggers App-of-Apps)
 
 ### Phase 2: App-of-Apps (ArgoCD)
 
@@ -62,10 +70,38 @@ ArgoCD takes over and deploys all platform components via sync waves:
 | Wave | Applications | Description |
 |------|--------------|-------------|
 | -1 | root-app | Bootstrap (deployed by script) |
-| 0 | postgresql | Shared database (namespace: `platform-db`) |
-| 1 | keycloak, argocd | Core infrastructure (Keycloak depends on PostgreSQL; ArgoCD is also synced in this wave) |
-| 2 | gitea, backstage, monitoring | Platform services (depend on PostgreSQL + Keycloak) |
-| 3 | crossplane, kyverno | Extensions |
+| 0 | cert-manager, external-secrets, postgresql, opensearch, nats | Foundation services |
+| 1 | keycloak, argocd | Identity + self-managed ArgoCD |
+| 2 | landingpage, backstage, gitea, grafana, jaeger, sonarqube | Platform services |
+| 3 | crossplane, kyverno | Extensions and policy |
+
+ArgoCD deploys platform components as individual Application resources defined in `apps/platform/*.yaml`, not via an ApplicationSet CRD.
+
+The architecture flow is: **Root App → individual ArgoCD Applications → Platform Components**
+
+### Phase 3: Post-Deployment Configuration
+
+After all ArgoCD apps reach Healthy, the script runs three configuration steps:
+
+#### a) `configure_gitea`
+- Registers the self-signed CA cert in the Gitea container trust store
+- Adds Keycloak as an OIDC provider via `gitea admin auth add-oauth` CLI inside the pod
+- Creates initial realm users: `digiorgadmin` and `digiorgdeveloper`
+- Creates the `DigiOrg` organisation via the `tea` CLI (v0.9.2, downloaded into the pod)
+- Adds both users to the DigiOrg Owners team via the Gitea API
+
+#### b) `configure_sonarqube`
+- Waits for SonarQube to report status `UP`
+- Sets `sonar.core.serverBaseURL` via the Settings API
+- Fetches the Keycloak IdP X.509 certificate from the SAML metadata descriptor
+- Pushes all `sonar.auth.saml.*` settings via the Settings API
+- Enables SAML authentication
+
+#### c) `restart_oidc_dependent_pods`
+Restarts ArgoCD Server, Grafana, Backstage, and Landing Page to pick up Keycloak OIDC configuration.
+
+#### d) `patch_argocd_oidc_ca` (runs during Phase 2 wait)
+Embeds the self-signed CA certificate into the ArgoCD Helm release via `helm upgrade --reuse-values` so ArgoCD self-sync does not overwrite it. The cert is also saved to `./digiorg-local-ca.crt` for local trust store import.
 
 ## Service Access
 
@@ -73,13 +109,58 @@ After `up` completes, access services via:
 
 | Service | URL | Credentials |
 |---------|-----|-------------|
-| Keycloak | http://digiorg.local/keycloak | admin / admin |
-| ArgoCD | http://digiorg.local/argocd | Login via Keycloak |
-| Grafana | http://digiorg.local/grafana | Login via Keycloak |
-| Backstage | http://digiorg.local/backstage | Login via Keycloak or Guest |
-| Gitea | http://digiorg.local/gitea | `gitea_admin` (password from secret) |
+| Landing Page | https://digiorg.local/ | Login via Keycloak |
+| Keycloak | https://digiorg.local/keycloak | admin / admin |
+| ArgoCD | https://digiorg.local/argocd | Login via Keycloak |
+| Grafana | https://digiorg.local/grafana | Login via Keycloak |
+| Backstage | https://digiorg.local/backstage | Login via Keycloak |
+| Gitea | https://digiorg.local/gitea | `gitea_admin` / password from `gitea/gitea-admin-secret` |
+| SonarQube | https://digiorg.local/sonarqube | admin / admin — change immediately |
+| Jaeger | https://digiorg.local/jaeger | Login via Keycloak |
 
 **Note:** Requires `/etc/hosts` entry: `127.0.0.1 digiorg.local`
+
+## CA Certificate Trust
+
+The self-signed CA certificate is saved to `./digiorg-local-ca.crt` after `nu scripts/local-setup.nu up` completes. Import it into your OS trust store so browsers and CLI tools accept the platform's TLS certificates:
+
+**macOS:**
+```bash
+sudo security add-trusted-cert -d -r trustRoot \
+  -k /Library/Keychains/System.keychain digiorg-local-ca.crt
+```
+
+**Linux (Ubuntu/Debian):**
+```bash
+sudo cp digiorg-local-ca.crt /usr/local/share/ca-certificates/
+sudo update-ca-certificates
+```
+
+**Windows:**
+```cmd
+certutil -addstore -f ROOT digiorg-local-ca.crt
+```
+
+Restart your browser after importing the certificate.
+
+## Environment Variable Overrides
+
+All passwords and secrets used by the bootstrap script can be overridden by setting environment variables before running `nu scripts/local-setup.nu up`. Unset variables receive a random 24-character alphanumeric password.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `POSTGRES_PASSWORD` | random | PostgreSQL superuser password |
+| `KEYCLOAK_DB_PASSWORD` | random | Keycloak PostgreSQL database password |
+| `BACKSTAGE_DB_PASSWORD` | random | Backstage PostgreSQL database password |
+| `AUTH_SESSION_SECRET` | random | Backstage session secret |
+| `AUTH_OIDC_CLIENT_SECRET` | `backstage-client-secret` | Backstage OIDC client secret |
+| `GITEA_DB_PASSWORD` | random | Gitea PostgreSQL database password |
+| `GITEA_OIDC_CLIENT_SECRET` | `gitea-client-secret` | Gitea OIDC client secret |
+| `GITEA_ADMIN_PASSWORD` | random (preserved on re-runs) | Gitea admin password — only regenerated if not already set or explicitly overridden |
+| `SONARQUBE_DB_PASSWORD` | random | SonarQube PostgreSQL database password |
+| `SONARQUBE_MONITORING_PASSCODE` | random | SonarQube monitoring passcode |
+| `JAEGER_OIDC_CLIENT_SECRET` | `jaeger-client-secret` | Jaeger OAuth2 proxy OIDC client secret |
+| `OPENSEARCH_ADMIN_PASSWORD` | random | OpenSearch admin password |
 
 ## Cluster Name
 
@@ -112,7 +193,7 @@ nu scripts/local-setup.nu up
 
 ```bash
 # Check ArgoCD UI
-open http://digiorg.local/argocd
+open https://digiorg.local/argocd
 
 # Check app status
 kubectl get applications -n argocd


### PR DESCRIPTION
## Summary

Fixes all factual errors and adds missing information identified in #157 for the scripts README at `scripts/README.md`.

All changes derived directly from `local-setup.nu` (1066 lines, fully read). The most significant fix documents Phase 3 of the setup process which was completely absent from the README.

---

## 🔴 Corrections (factual errors fixed)

**1. Wave table — 7 missing apps + wrong app name**
- Wave 0: added cert-manager, external-secrets, opensearch, nats
- Wave 2: added landingpage, jaeger, sonarqube; fixed "monitoring" → "grafana"
- Added Wave -1 (root-app)

**2. Platform Secrets — 5 of 10 were undocumented**
- Added: `sonarqube-db-secret`, `sonarqube-monitoring-secret`, `jaeger-oauth2-proxy-secrets`, `opensearch-secrets`, `jaeger-opensearch-credentials`

**3. Service Access — all http:// → https://, 3 services missing**
- All URLs corrected to https://
- Added: Landing Page (https://digiorg.local/), SonarQube, Jaeger
- Fixed Gitea credentials to reference `gitea/gitea-admin-secret` (not a static password)

**4. Phase 3 — completely undocumented, now added**
- `configure_gitea`: CA cert registration, Keycloak OIDC via `gitea admin auth add-oauth`, users `digiorgadmin`+`digiorgdeveloper`, DigiOrg org via `tea` CLI v0.9.2, Gitea API org membership
- `configure_sonarqube`: waits for UP status, sets base URL, fetches Keycloak X.509 cert from SAML descriptor, pushes all `sonar.auth.saml.*` settings via API, enables SAML
- `restart_oidc_dependent_pods`: ArgoCD Server, Grafana, Backstage, Landing Page
- `patch_argocd_oidc_ca`: embeds CA cert in ArgoCD Helm release via `helm upgrade --reuse-values`

**5. Phase 1 Step 2 — vm.max_map_count missing**
- Inserted: `docker exec digiorg-core-dev-control-plane sysctl -w vm.max_map_count=262144`
- Required by OpenSearch; renumbered remaining steps 3–9

**6. Architecture terminology — ApplicationSet → individual Applications**
- Platform uses individual `Application` resources in `apps/platform/*.yaml`, not an `ApplicationSet` CRD

---

## 🟡 Additions (missing information)

**7. CA Certificate Trust section**
- macOS, Linux (Ubuntu/Debian), Windows import commands
- Note that cert is saved to `./digiorg-local-ca.crt`

**8. Environment Variable Overrides section**
- Full table of 12 overrideable variables with defaults and descriptions

**9. Prerequisites note**
- `check_prerequisites` only validates kind/kubectl/helm; Docker and nu are also required

---

Closes #157
