### PR TITLE
docs(guides): fix factual errors, add Phase 3, all missing components

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -44,24 +44,81 @@ Add to `/etc/hosts` (Linux/Mac) or `C:\Windows\System32\drivers\etc\hosts` (Wind
 nu scripts/local-setup.nu up
 ```
 
-This creates a KinD cluster (`digiorg-core-dev`) and installs:
-- **Keycloak** — Identity Provider (SSO for all services)
-- **ArgoCD** — GitOps Continuous Delivery
-- **Crossplane** — Infrastructure as Code
-- **Kyverno** — Policy Engine
-- **Prometheus + Grafana** — Monitoring
-- **Backstage** — Developer Portal
+This bootstraps the cluster in three phases:
+
+**Phase 1 — Bootstrap (this script):**
+
+| Step | Component | Notes |
+|------|-----------|-------|
+| 1.1 | KinD cluster (`digiorg-core-dev`) | Single-node local cluster |
+| 1.2 | `vm.max_map_count=262144` | Required by OpenSearch |
+| 1.3 | Gateway API CRDs | Kubernetes Gateway API |
+| 1.4 | NGINX Ingress Controller | Ingress for all services |
+| 1.5 | Platform Ingress rules | Routes for `digiorg.local/*` |
+| 1.6 | CoreDNS | Configured for `digiorg.local` |
+| 1.7 | Platform Secrets | 10 secrets across 7 namespaces |
+| 1.8 | ArgoCD | Deployed via Helm |
+
+**Phase 2 — ArgoCD App-of-Apps (ArgoCD manages these):**
+
+| Wave | Components |
+|------|-----------|
+| Wave 0 | cert-manager, external-secrets, nats, opensearch, postgresql |
+| Wave 1 | keycloak, argocd |
+| Wave 2 | backstage, gitea, grafana, jaeger, landingpage, sonarqube |
+| Wave 3 | crossplane, kyverno |
+
+**Phase 3 — Post-Deployment (automated by setup script):**
+
+- `configure_gitea` — OIDC auto-config, initial users, DigiOrg organisation
+- `configure_sonarqube` — SAML integration via Settings API
+- Restart OIDC-dependent pods
+
+> **Makefile shortcuts:** `make up` / `make down` / `make reset` / `make status` wrap the `nu scripts/local-setup.nu` commands above.
+
+### 3.5. Import CA Certificate
+
+After `nu scripts/local-setup.nu up` completes, a self-signed CA certificate is saved to `./digiorg-local-ca.crt` in the repository root. Import it into your OS trust store so the browser accepts `https://digiorg.local`:
+
+**macOS:**
+```bash
+sudo security add-trusted-cert -d -r trustRoot \
+  -k /Library/Keychains/System.keychain ./digiorg-local-ca.crt
+```
+
+**Linux:**
+```bash
+sudo cp ./digiorg-local-ca.crt /usr/local/share/ca-certificates/digiorg-local-ca.crt
+sudo update-ca-certificates
+```
+
+**Windows (PowerShell as Administrator):**
+```powershell
+certutil -addstore -f "ROOT" .\digiorg-local-ca.crt
+```
+
+Restart your browser after importing.
 
 ### 4. Access Services
 
-All services are available via `http://digiorg.local/<service>`:
+All services are available via `https://digiorg.local/<service>` (TLS via self-signed CA — see Step 3.5):
 
 | Service | URL | Login |
 |---------|-----|-------|
-| Keycloak | http://digiorg.local/keycloak | admin / admin |
-| ArgoCD | http://digiorg.local/argocd | via Keycloak |
-| Grafana | http://digiorg.local/grafana | via Keycloak |
-| Backstage | http://digiorg.local/backstage | via Keycloak or Guest |
+| Landing Page | https://digiorg.local/ | — |
+| Keycloak | https://digiorg.local/keycloak | admin / admin |
+| ArgoCD | https://digiorg.local/argocd | Login via Keycloak |
+| Grafana | https://digiorg.local/grafana | Login via Keycloak |
+| Backstage | https://digiorg.local/backstage | Login via Keycloak |
+| Gitea | https://digiorg.local/gitea | Login via Keycloak (see note) |
+| SonarQube | https://digiorg.local/sonarqube | admin / admin — **change immediately** |
+| Jaeger | https://digiorg.local/jaeger | Login via Keycloak |
+
+> **Gitea admin password:** The initial admin password is stored in a cluster secret:
+> ```bash
+> kubectl get secret gitea-admin-secret -n gitea \
+>   -o jsonpath='{.data.password}' | base64 -d && echo
+> ```
 
 ### 5. Explore the Platform
 
@@ -110,12 +167,80 @@ Backstage provides the Internal Developer Portal:
 - Tech Docs
 - Kubernetes plugin for cluster visibility
 
-### Monitoring Stack
+### Gitea (Source Control)
 
-Prometheus + Grafana provide observability:
+Gitea provides self-hosted Git hosting:
 
-- Pre-configured dashboards
-- Grafana authenticated via Keycloak OAuth
+- OIDC integration auto-configured by the setup script
+- DigiOrg organisation and initial users created during Phase 3
+- Admin password retrievable via `kubectl get secret gitea-admin-secret -n gitea`
+
+### SonarQube (Code Quality)
+
+SonarQube provides static code analysis and SAST:
+
+- Keycloak SAML configured automatically during Phase 3
+- First login: admin / admin — **change the password immediately**
+
+### Jaeger (Distributed Tracing)
+
+Jaeger provides end-to-end distributed tracing:
+
+- Backed by OpenSearch for trace storage
+- Keycloak OIDC via oauth2-proxy
+
+### OpenSearch
+
+OpenSearch serves as the trace and log storage backend:
+
+- Deployed in the `platform-db` namespace
+- `vm.max_map_count=262144` set on the KinD node during bootstrap (required)
+
+### cert-manager
+
+cert-manager handles TLS certificate issuance:
+
+- Self-signed CA for `digiorg.local` (certificate saved to `./digiorg-local-ca.crt`)
+- Manages certificates for all platform ingress routes
+
+### External Secrets Operator
+
+External Secrets Operator bridges Kubernetes secrets with external vaults:
+
+- Provider-swap pattern: Fake provider for local development, Azure Key Vault or HashiCorp Vault for production
+
+### NATS JetStream
+
+NATS provides persistent pub/sub messaging:
+
+- Deployed in the `messaging` namespace
+- JetStream persistence enabled
+
+### Shared PostgreSQL
+
+A single PostgreSQL instance serves multiple platform components:
+
+- Databases for Keycloak, Backstage, Gitea, and SonarQube
+
+### Kyverno (Policy Engine)
+
+Kyverno enforces Policy-as-Code across the cluster:
+
+- Admission controller for policy validation and mutation
+
+### Crossplane (Infrastructure as Code)
+
+Crossplane manages cloud infrastructure from Kubernetes:
+
+- Enables declarative provisioning of external resources
+
+### Observability Stack
+
+Prometheus + Grafana + Jaeger + OpenSearch provide the three-pillar observability model:
+
+- **Metrics** — Prometheus scrapes cluster and application metrics; Grafana provides pre-configured dashboards with Keycloak OAuth
+- **Traces** — Jaeger collects distributed traces, backed by OpenSearch
+- **Logs** — OpenSearch indexes platform logs
 
 ## Production Deployment
 

--- a/docs/guides/local-development.md
+++ b/docs/guides/local-development.md
@@ -45,28 +45,40 @@ Add the following to your `/etc/hosts` file (or `C:\Windows\System32\drivers\etc
 nu scripts/local-setup.nu up
 ```
 
-This runs in two phases:
+This runs in three phases:
 
 **Phase 1 (Bootstrap):**
 1. Create a KinD cluster (`digiorg-core-dev`)
-2. Install Gateway API CRDs
-3. Install NGINX Ingress Controller
-4. Configure CoreDNS for `digiorg.local`
-5. Create platform secrets (including shared PostgreSQL credentials)
-6. Install ArgoCD (Helm)
-7. Deploy root-app
+2. Set `vm.max_map_count=262144` on the KinD node via `docker exec` (required by OpenSearch embedded Elasticsearch)
+3. Install Gateway API CRDs
+4. Install NGINX Ingress Controller
+5. Configure CoreDNS for `digiorg.local`
+6. Create platform secrets (including shared PostgreSQL credentials)
+7. Install ArgoCD (Helm)
+8. Deploy root-app
 
 **Phase 2 (App-of-Apps):**
 ArgoCD syncs all platform components via sync waves:
-- Wave 0: cert-manager + ClusterIssuers, PostgreSQL
-- Wave 1: Keycloak, ArgoCD (self-managed) — depends on PostgreSQL
-- Wave 2: Landing Page, Gitea, Backstage, Monitoring — depends on Keycloak and PostgreSQL
-- Wave 3: Crossplane, Kyverno
+- Wave 0: cert-manager, external-secrets, nats, opensearch, postgresql
+- Wave 1: keycloak, argocd (self-managed)
+- Wave 2: landingpage, backstage, gitea, grafana, jaeger, sonarqube
+- Wave 3: crossplane, kyverno
+
+**Phase 3 (Post-Deployment Configuration):**
+After all apps are healthy, the script runs automated post-deployment steps:
+- **configure_gitea**: Registers the self-signed CA in Gitea's trust store, adds Keycloak as an OIDC provider via the `gitea admin auth` CLI, creates `digiorgadmin` and `digiorgdeveloper` users, and creates the `DigiOrg` organisation via the `tea` CLI.
+- **configure_sonarqube**: Waits for SonarQube to report `UP`, sets `serverBaseURL`, pushes all `sonar.auth.saml.*` settings via the Settings API, and enables SAML.
+- **restart_oidc_dependent_pods**: Restarts ArgoCD Server, Grafana, Backstage, and Landing Page to pick up updated OIDC configuration.
+- **patch_argocd_oidc_ca**: Embeds the self-signed CA cert in the ArgoCD Helm release via `helm upgrade --reuse-values`, saves the cert to `./digiorg-local-ca.crt`.
+
+> **Note:** Common `make` shortcuts are available — run `make help` to see them.
 
 ### Trust the Self-Signed CA Certificate
 
 The platform uses a self-signed CA certificate for `digiorg.local`. To avoid browser warnings,
 import the CA cert into your OS trust store:
+
+> **Note:** `nu scripts/local-setup.nu up` automatically saves the cert to `./digiorg-local-ca.crt`. The `kubectl` command below is an alternative if you need to extract it manually.
 
 ```bash
 # Extract CA cert from cluster
@@ -100,13 +112,15 @@ HTTP (`http://`) automatically redirects to HTTPS.
 | Grafana | https://digiorg.local/grafana | Login via Keycloak |
 | Backstage | https://digiorg.local/backstage | Login via Keycloak or Guest |
 | Gitea | https://digiorg.local/gitea | `gitea_admin` (see note below) |
+| SonarQube | https://digiorg.local/sonarqube | admin / admin — change immediately |
+| Jaeger | https://digiorg.local/jaeger | Login via Keycloak |
 
 **Gitea Admin Password:**
 ```bash
 kubectl get secret gitea-admin-secret -n gitea -o jsonpath='{.data.password}' | base64 -d && echo
 ```
 
-> **Note:** Gitea OIDC via Keycloak requires manual configuration in the Gitea Admin UI after first login. See [Gitea README](../../platform/base/gitea/README.md) for details.
+> **Note:** Keycloak OIDC is auto-configured by `local-setup.nu` (Phase 3). Use **Login via Keycloak** or the `gitea_admin` account.
 
 ### Set Kubeconfig
 
@@ -149,13 +163,30 @@ nu scripts/local-setup.nu reset
 │                                                                         │
 │  Root App discovers apps/ directory                                     │
 │      │                                                                  │
-│      ├── apps/platform/keycloak.yaml    → Wave 1                       │
-│      ├── apps/platform/argocd.yaml      → Wave 1 (self-managed)        │
-│      ├── apps/platform/gitea.yaml       → Wave 2                       │
-│      ├── apps/platform/backstage.yaml   → Wave 2                       │
-│      ├── apps/platform/grafana.yaml      → Wave 2                      │
-│      ├── apps/platform/crossplane.yaml  → Wave 3                       │
-│      └── apps/platform/kyverno.yaml     → Wave 3                       │
+│      ├── apps/platform/cert-manager.yaml     → Wave 0                  │
+│      ├── apps/platform/external-secrets.yaml → Wave 0                  │
+│      ├── apps/platform/nats.yaml             → Wave 0                  │
+│      ├── apps/platform/opensearch.yaml       → Wave 0                  │
+│      ├── apps/platform/postgresql.yaml       → Wave 0                  │
+│      ├── apps/platform/keycloak.yaml         → Wave 1                  │
+│      ├── apps/platform/argocd.yaml           → Wave 1 (self-managed)   │
+│      ├── apps/platform/landingpage.yaml      → Wave 2                  │
+│      ├── apps/platform/backstage.yaml        → Wave 2                  │
+│      ├── apps/platform/gitea.yaml            → Wave 2                  │
+│      ├── apps/platform/grafana.yaml          → Wave 2                  │
+│      ├── apps/platform/jaeger.yaml           → Wave 2                  │
+│      ├── apps/platform/sonarqube.yaml        → Wave 2                  │
+│      ├── apps/platform/crossplane.yaml       → Wave 3                  │
+│      └── apps/platform/kyverno.yaml          → Wave 3                  │
+│                                                                         │
+└───────────────────────────────────┬─────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    Post-Deployment (Phase 3)                            │
+│                                                                         │
+│  configure_gitea → configure_sonarqube → restart_oidc_dependent_pods   │
+│  → patch_argocd_oidc_ca                                                 │
 │                                                                         │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
@@ -165,10 +196,21 @@ nu scripts/local-setup.nu reset
 | Wave | Applications | Dependencies |
 |------|--------------|--------------|
 | -1 | root-app | Bootstrap (deployed by script) |
-| 0 | postgresql | Ingress, Secrets (shared DB for platform services) |
-| 1 | keycloak, argocd | keycloak: PostgreSQL, Ingress; argocd: Ingress (self-managed after Helm install) |
-| 2 | gitea, backstage, grafana | gitea: PostgreSQL; backstage: PostgreSQL, Keycloak (OIDC); grafana: None |
-| 3 | crossplane, kyverno | None |
+| 0 | cert-manager, external-secrets, nats, opensearch, postgresql | Ingress, CoreDNS, Secrets (foundational services) |
+| 1 | keycloak, argocd | keycloak: postgresql, cert-manager; argocd: Ingress (self-managed after Helm install) |
+| 2 | landingpage, backstage, gitea, grafana, jaeger, sonarqube | keycloak (OIDC/SAML); backstage, gitea, sonarqube: postgresql; jaeger: opensearch |
+| 3 | crossplane, kyverno | All platform services healthy |
+
+### Phase 3: Post-Deployment Configuration
+
+`local-setup.nu up` automatically runs the following after all ArgoCD apps are healthy:
+
+| Step | Function | What it does |
+|------|----------|--------------|
+| 1 | `configure_gitea` | Registers the self-signed CA in Gitea's trust store; adds Keycloak as an OIDC provider via `gitea admin auth add-oauth`; creates `digiorgadmin` + `digiorgdeveloper` users; creates the `DigiOrg` organisation via the `tea` CLI |
+| 2 | `configure_sonarqube` | Waits for `status: UP`; sets `serverBaseURL`; pushes all `sonar.auth.saml.*` settings via the Settings API; enables SAML |
+| 3 | `restart_oidc_dependent_pods` | Restarts ArgoCD Server, Grafana, Backstage, and Landing Page to pick up the updated OIDC/Keycloak configuration |
+| 4 | `patch_argocd_oidc_ca` | Embeds the self-signed CA cert in the ArgoCD Helm release via `helm upgrade --reuse-values`; saves `./digiorg-local-ca.crt` |
 
 ## Development Workflow
 
@@ -195,7 +237,7 @@ ArgoCD detects the change and syncs automatically (selfHeal enabled).
 kubectl get applications -n argocd
 
 # UI
-open http://digiorg.local/argocd
+open https://digiorg.local/argocd
 ```
 
 ### 5. Manual Sync (if needed)
@@ -238,6 +280,8 @@ spec:
       prune: true
 ```
 
+> **Note:** The example uses an SSH URL (`git@github.com:digiorg/core.git`), which requires SSH key setup. HTTPS alternative: `https://github.com/digiorg/core.git`
+
 ## Troubleshooting
 
 ### Cluster Won't Start
@@ -254,7 +298,7 @@ nu scripts/local-setup.nu reset
 
 ```bash
 # Check ArgoCD UI
-open http://digiorg.local/argocd
+open https://digiorg.local/argocd
 
 # Check app status
 kubectl get applications -n argocd -o wide
@@ -286,7 +330,7 @@ kubectl get ingress -A
 kubectl get pods -n keycloak
 
 # Check realm exists
-curl -s http://digiorg.local/keycloak/realms/digiorg-core-platform | jq .realm
+curl -s https://digiorg.local/keycloak/realms/digiorg-core-platform | jq .realm
 ```
 
 ## Resource Usage
@@ -296,12 +340,18 @@ The local cluster uses approximately:
 | Component | CPU | Memory |
 |-----------|-----|--------|
 | KinD Node | 2 cores | 4 GB |
-| Shared PostgreSQL | 0.3 cores | 512 MB |
+| SonarQube | 200m | 2Gi request (4Gi limit — includes embedded Elasticsearch) |
+| Prometheus + Grafana | 0.5 cores | 1 GB |
 | Keycloak | 0.4 cores | 768 MB |
+| Backstage | 0.4 cores | 768 MB |
+| Shared PostgreSQL | 0.3 cores | 512 MB |
 | ArgoCD | 0.5 cores | 512 MB |
+| OpenSearch | 250m | 512Mi request (1Gi limit) |
 | Crossplane | 0.2 cores | 256 MB |
 | Kyverno | 0.2 cores | 256 MB |
-| Prometheus + Grafana | 0.5 cores | 1 GB |
-| Backstage | 0.4 cores | 768 MB |
+| Jaeger + oauth2-proxy | ~100m | ~256Mi |
+| NATS + Surveyor | ~75m | ~96Mi |
+| External Secrets | ~25m | ~64Mi |
+| Landing Page | 10m | 32Mi |
 
-**Recommended:** At least 8 GB RAM allocated to Docker.
+**Recommended:** At least 16 GB RAM allocated to Docker (SonarQube alone requests 2Gi with a 4Gi limit for its embedded Elasticsearch).


### PR DESCRIPTION
## Summary

Fixes all factual errors and adds missing information for both developer guides. Changes based on a full read of `scripts/local-setup.nu` (1066 lines) and `apps/platform/*.yaml` wave annotations.

---

## `docs/guides/getting-started.md` — Closes #161

### 🔴 Corrections

**1. Step 3 — Installed components list rewritten**
- Replaced 6-item bullet list with full three-phase breakdown
- Phase 1: 8 bootstrap steps including vm.max_map_count for OpenSearch
- Phase 2: Wave table with all 15 ArgoCD-managed apps (was: 6)
- Phase 3 (was missing): configure_gitea, configure_sonarqube, OIDC pod restarts

**2. Step 4 — http:// → https://, 4 services added**
- All URLs corrected to https://
- Added: Landing Page, Gitea (with `kubectl get secret` for password), SonarQube (admin/admin — change immediately), Jaeger

**3. Step 3.5 added — CA Certificate import**
- macOS / Linux / Windows import commands
- Note: cert auto-saved to `./digiorg-local-ca.crt` by setup script

**4. Platform Components — 10 subsections added**
- Gitea, SonarQube, Jaeger, OpenSearch, cert-manager, External Secrets Operator, NATS JetStream, Shared PostgreSQL, Kyverno, Crossplane
- Monitoring Stack → Observability Stack (three-pillar: Metrics/Traces/Logs)

**5. Makefile shortcuts note added**

---

## `docs/guides/local-development.md` — Closes #162

### 🔴 Corrections

**1. Phase 1 — vm.max_map_count step inserted**

**2. Phase 2 waves — 7 missing apps added**
- Wave 0: external-secrets, nats, opensearch (were missing)
- Wave 2: landingpage, jaeger, sonarqube (were missing)
- App-of-Apps diagram expanded from 7 → all 15 apps

**3. Sync Waves table — all 15 apps with Dependencies column**

**4. Access Services — SonarQube + Jaeger added**

**5. Gitea OIDC note — fixed**
- Removed: "requires manual configuration in Admin UI"
- Replaced with: auto-configured by local-setup.nu Phase 3

**6. Phase 3 — fully documented**
- Quick Start prose + Architecture ASCII diagram + table

**7. http:// → https://** in Workflow + Troubleshooting

**8. CA cert section** — note about auto-saved `./digiorg-local-ca.crt`

### 🟡 Additions

**9. Resource Usage table expanded** — SonarQube 2Gi (critical!), OpenSearch, Jaeger, NATS, Landing Page, ESO; RAM recommendation updated 8GB → **16GB**

**10. SSH/HTTPS URL note** in Adding New Components

**11. Makefile shortcuts note**

---

Closes #161
Closes #162
