### PR TITLE
refactor: Reduce Makefile to utility targets only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,132 +2,18 @@
 # DigiOrg Core Platform - Makefile
 # =============================================================================
 
-.PHONY: help up down reset status test lint clean deps install
+# NOTE: Cluster lifecycle (up/down/reset/status) is managed by the Nushell script:
+#   nu scripts/local-setup.nu up|down|reset|status
+# This Makefile provides utility helpers only.
 
-# Default target
-help: ## Show this help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
-
-# =============================================================================
-# Local Development (KinD)
-# =============================================================================
+.PHONY: help deps argocd-password port-forward-argocd port-forward-vault port-forward-grafana lint validate-policies validate-crossplane clean kubeconfig
 
 CLUSTER_NAME := digiorg-core-dev
-KIND_CONFIG := platform/bootstrap/kind-config.yaml
 KUBECONFIG_LOCAL := $(PWD)/kubeconfig-local.yaml
 
-up: ## Start local KinD cluster with all components
-	@echo "Starting local development environment..."
-	@if command -v nu >/dev/null 2>&1; then \
-		nu scripts/local-setup.nu up; \
-	else \
-		echo "Nushell not found, using fallback..."; \
-		$(MAKE) _up-fallback; \
-	fi
-
-_up-fallback:
-	@kind create cluster --name $(CLUSTER_NAME) --config $(KIND_CONFIG) --kubeconfig $(KUBECONFIG_LOCAL) 2>/dev/null || true
-	@echo "Cluster created. Installing components..."
-	@export KUBECONFIG=$(KUBECONFIG_LOCAL) && $(MAKE) install
-	@echo ""
-	@echo "Local cluster ready!"
-	@echo "Run: export KUBECONFIG=$(KUBECONFIG_LOCAL)"
-
-down: ## Destroy local KinD cluster
-	@echo "Destroying local cluster..."
-	@kind delete cluster --name $(CLUSTER_NAME) 2>/dev/null || true
-	@rm -f $(KUBECONFIG_LOCAL)
-	@echo "Done."
-
-reset: down up ## Reset local cluster (destroy + create)
-
-status: ## Show cluster status
-	@if command -v nu >/dev/null 2>&1; then \
-		nu scripts/local-setup.nu status; \
-	else \
-		$(MAKE) _status-fallback; \
-	fi
-
-_status-fallback:
-	@echo "Cluster Status"
-	@echo "=============="
-	@kind get clusters 2>/dev/null | grep -q $(CLUSTER_NAME) && echo "● Cluster is running" || echo "✗ Cluster is not running"
-	@echo ""
-	@if [ -f $(KUBECONFIG_LOCAL) ]; then \
-		export KUBECONFIG=$(KUBECONFIG_LOCAL) && kubectl get nodes 2>/dev/null || true; \
-	fi
-
-# =============================================================================
-# Component Installation
-# =============================================================================
-
-install: install-ingress install-argocd install-crossplane install-vault install-kyverno ## Install all platform components
-	@echo "All components installed!"
-
-install-ingress: ## Install NGINX Ingress Controller
-	@echo "Installing Ingress Controller..."
-	@export KUBECONFIG=$(KUBECONFIG_LOCAL) && \
-		kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
-	@sleep 10
-	@export KUBECONFIG=$(KUBECONFIG_LOCAL) && \
-		kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=180s || true
-
-install-argocd: ## Install ArgoCD
-	@echo "Installing ArgoCD..."
-	@export KUBECONFIG=$(KUBECONFIG_LOCAL) && \
-		helm repo add argo https://argoproj.github.io/argo-helm 2>/dev/null || true && \
-		helm repo update && \
-		helm upgrade --install argocd argo/argo-cd \
-			--namespace argocd --create-namespace \
-			--set 'server.service.type=NodePort' \
-			--set 'server.service.nodePortHttp=30080' \
-			--set 'server.service.nodePortHttps=30443' \
-			--set 'configs.params.server\.insecure=true' \
-			--wait --timeout 5m
-
-install-crossplane: ## Install Crossplane
-	@echo "Installing Crossplane..."
-	@export KUBECONFIG=$(KUBECONFIG_LOCAL) && \
-		helm repo add crossplane-stable https://charts.crossplane.io/stable 2>/dev/null || true && \
-		helm repo update && \
-		helm upgrade --install crossplane crossplane-stable/crossplane \
-			--namespace crossplane-system --create-namespace \
-			--wait --timeout 5m
-
-install-vault: ## Install Vault (dev mode)
-	@echo "Installing Vault..."
-	@export KUBECONFIG=$(KUBECONFIG_LOCAL) && \
-		helm repo add hashicorp https://helm.releases.hashicorp.com 2>/dev/null || true && \
-		helm repo update && \
-		helm upgrade --install vault hashicorp/vault \
-			--namespace vault --create-namespace \
-			--set 'server.dev.enabled=true' \
-			--set 'server.dev.devRootToken=root' \
-			--set 'ui.enabled=true' \
-			--wait --timeout 5m
-
-install-kyverno: ## Install Kyverno
-	@echo "Installing Kyverno..."
-	@export KUBECONFIG=$(KUBECONFIG_LOCAL) && \
-		helm repo add kyverno https://kyverno.github.io/kyverno/ 2>/dev/null || true && \
-		helm repo update && \
-		helm upgrade --install kyverno kyverno/kyverno \
-			--namespace kyverno --create-namespace \
-			--set 'replicaCount=1' \
-			--wait --timeout 5m
-
-install-monitoring: ## Install Prometheus Stack (optional, slow)
-	@echo "Installing Monitoring Stack..."
-	@export KUBECONFIG=$(KUBECONFIG_LOCAL) && \
-		helm repo add prometheus-community https://prometheus-community.github.io/helm-charts 2>/dev/null || true && \
-		helm repo update && \
-		helm upgrade --install prometheus prometheus-community/kube-prometheus-stack \
-			--namespace monitoring --create-namespace \
-			--set 'grafana.service.type=NodePort' \
-			--set 'grafana.service.nodePort=30090' \
-			--set 'prometheus.prometheusSpec.retention=1d' \
-			--set 'alertmanager.enabled=false' \
-			--wait --timeout 10m
+# Default target — utility helpers only (cluster lifecycle: nu scripts/local-setup.nu)
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
 
 # =============================================================================
 # Access Services
@@ -153,12 +39,8 @@ port-forward-grafana: ## Port forward Grafana (http://localhost:3000)
 		kubectl port-forward svc/prometheus-grafana -n monitoring 3000:80
 
 # =============================================================================
-# Testing & Linting
+# Linting & Validation
 # =============================================================================
-
-test: ## Run all tests
-	@echo "Running tests..."
-	@echo "TODO: Implement tests"
 
 lint: ## Lint all configurations
 	@echo "Linting YAML files..."


### PR DESCRIPTION
## Summary

Closes #168

The `scripts/local-setup.nu` Nushell script is the authoritative tool for cluster lifecycle management (3-phase bootstrap with App-of-Apps, Keycloak OIDC, Gitea, SonarQube, etc.). The Makefile's `up`/`down`/`reset`/`status` targets were an inferior duplicate that caused confusion.

## Changes

**Removed** (207 → 88 lines):
- `up` / `_up-fallback` / `down` / `reset` / `status` / `_status-fallback`
- All `install-*` targets (ingress, argocd, crossplane, vault, kyverno, monitoring)

**Kept** (utility helpers not in Nushell script):
- `deps` — check required tools
- `argocd-password` — retrieve admin password
- `port-forward-argocd/vault/grafana`
- `lint` / `validate-policies` / `validate-crossplane`
- `clean` / `kubeconfig`

**Added:**
- Prominent note at top of Makefile pointing to `nu scripts/local-setup.nu` for lifecycle commands

## How to use cluster lifecycle going forward

```bash
nu scripts/local-setup.nu up      # Full bootstrap
nu scripts/local-setup.nu down    # Destroy cluster
nu scripts/local-setup.nu reset   # Reset
nu scripts/local-setup.nu status  # Status
```