### PR TITLE
feat: Install Crossplane provider-kubernetes, provider-helm, and provider-http

### DIFF
--- a/apps/platform/crossplane-providers.yaml
+++ b/apps/platform/crossplane-providers.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: crossplane-providers
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 4: Depends on Crossplane (Wave 3) being installed and CRDs being available
+    argocd.argoproj.io/sync-wave: "4"
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/digiorg/core.git
+    targetRevision: HEAD
+    path: crossplane/providers
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: crossplane-system
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/crossplane/README.md
+++ b/crossplane/README.md
@@ -1,74 +1,81 @@
 # Crossplane
 
-This directory contains Crossplane configurations for multi-cloud infrastructure management.
+This directory contains Crossplane configurations for infrastructure automation via Kubernetes-native APIs.
 
 ## Structure
 
 ```
 crossplane/
-├── providers/       # Provider configurations
-│   ├── aws.yaml
-│   ├── azure.yaml
-│   ├── gcp.yaml
-│   └── ionos.yaml
-├── xrds/            # Composite Resource Definitions
-│   ├── database.yaml
-│   ├── kubernetes.yaml
-│   ├── network.yaml
-│   └── storage.yaml
-└── compositions/    # Compositions per provider
-    ├── aws/
-    ├── azure/
-    ├── gcp/
-    └── ionos/
+├── providers/       # Provider installations and ProviderConfigs
+│   ├── provider-kubernetes.yaml
+│   ├── provider-helm.yaml
+│   ├── provider-http.yaml
+│   └── kustomization.yaml
+├── xrds/            # Composite Resource Definitions (add here)
+└── compositions/    # Compositions live in core-app-catalog, not here
 ```
 
-## Concepts
+## Installed Providers
 
-### XRDs (Composite Resource Definitions)
+### provider-kubernetes
 
-XRDs define the **API** that platform users interact with. They are provider-agnostic:
+Manages Kubernetes resources (Deployments, Services, ConfigMaps, etc.) in the local or remote clusters.
+Used to compose higher-level abstractions that create Kubernetes workloads.
+
+- Package: `xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.15.0`
+- ProviderConfig: `InjectedIdentity` — uses the `crossplane-provider-kubernetes` ServiceAccount token
+- Permissions: `cluster-admin` ClusterRoleBinding on `crossplane-provider-kubernetes` SA
+
+### provider-helm
+
+Installs and manages Helm releases as Crossplane managed resources.
+Used to compose platform capabilities that are delivered via Helm charts.
+
+- Package: `xpkg.upbound.io/crossplane-contrib/provider-helm:v0.20.3`
+- ProviderConfig: `InjectedIdentity` — uses the `crossplane-provider-helm` ServiceAccount token
+- Permissions: `cluster-admin` ClusterRoleBinding on `crossplane-provider-helm` SA
+
+### provider-http
+
+Makes HTTP requests as Crossplane managed resources.
+Used to integrate with external REST APIs and webhooks as part of compositions.
+
+- Package: `xpkg.upbound.io/crossplane-contrib/provider-http:v0.5.1`
+- ProviderConfig: `None` credentials — no cluster permissions required
+
+## How ProviderConfigs Work
+
+Each provider has a `ProviderConfig` named `default`. Managed resources reference it via:
 
 ```yaml
-apiVersion: platform.digiorg.io/v1alpha1
-kind: Database
-metadata:
-  name: my-database
 spec:
-  engine: postgres
-  size: small
-  provider: aws
+  providerConfigRef:
+    name: default
 ```
 
-### Compositions
+The `InjectedIdentity` source means the provider pod uses its Kubernetes ServiceAccount token,
+which is bound to `cluster-admin` to allow full cluster management. The `None` source (provider-http)
+means no credentials are injected — the provider makes unauthenticated or externally-configured requests.
 
-Compositions define **how** the XRD is implemented for each provider:
+## Adding XRDs
 
-- `aws/database.yaml` → Creates RDS
-- `azure/database.yaml` → Creates Azure Database
-- `gcp/database.yaml` → Creates Cloud SQL
+Define new Composite Resource Definitions in `xrds/`. These declare the platform API that users interact with:
 
-### Providers
-
-Providers are the Crossplane plugins that communicate with cloud APIs:
-
-- `provider-aws`
-- `provider-azure`
-- `provider-gcp`
-- `provider-kubernetes`
-- `provider-helm`
-
-## Adding a New Resource Type
-
-1. Define the XRD in `xrds/`
-2. Create Compositions for each provider in `compositions/<provider>/`
-3. Document the new resource in this README
-4. Update platform documentation
-
-## Testing
-
-Test compositions locally using the Crossplane CLI:
-
-```bash
-crossplane beta validate crossplane/xrds/ crossplane/compositions/
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xapps.platform.digiorg.io
+spec:
+  group: platform.digiorg.io
+  names:
+    kind: XApp
+    plural: xapps
+  ...
 ```
+
+## Adding Compositions
+
+Compositions live in the **core-app-catalog** repository, not here. This keeps application-level
+compositions separate from the platform provider infrastructure. Reference the XRD group and kind
+from this repo when authoring compositions there.

--- a/crossplane/providers/kustomization.yaml
+++ b/crossplane/providers/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - provider-kubernetes.yaml
+  - provider-helm.yaml
+  - provider-http.yaml

--- a/crossplane/providers/provider-helm.yaml
+++ b/crossplane/providers/provider-helm.yaml
@@ -1,0 +1,49 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-helm
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-helm:v0.20.3
+  runtimeConfigRef:
+    apiVersion: pkg.crossplane.io/v1beta1
+    kind: DeploymentRuntimeConfig
+    name: provider-helm
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: provider-helm
+spec:
+  deploymentTemplate:
+    spec:
+      selector: {}
+      template:
+        spec:
+          serviceAccountName: crossplane-provider-helm
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crossplane-provider-helm
+  namespace: crossplane-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-provider-helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: crossplane-provider-helm
+    namespace: crossplane-system
+---
+apiVersion: helm.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: InjectedIdentity

--- a/crossplane/providers/provider-http.yaml
+++ b/crossplane/providers/provider-http.yaml
@@ -1,0 +1,14 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-http
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-http:v0.5.1
+---
+apiVersion: http.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: None

--- a/crossplane/providers/provider-kubernetes.yaml
+++ b/crossplane/providers/provider-kubernetes.yaml
@@ -1,0 +1,49 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-kubernetes
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.15.0
+  runtimeConfigRef:
+    apiVersion: pkg.crossplane.io/v1beta1
+    kind: DeploymentRuntimeConfig
+    name: provider-kubernetes
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: provider-kubernetes
+spec:
+  deploymentTemplate:
+    spec:
+      selector: {}
+      template:
+        spec:
+          serviceAccountName: crossplane-provider-kubernetes
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crossplane-provider-kubernetes
+  namespace: crossplane-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-provider-kubernetes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: crossplane-provider-kubernetes
+    namespace: crossplane-system
+---
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: InjectedIdentity


### PR DESCRIPTION
## Summary

Closes #170

Installs the three Crossplane providers required as foundation for all application compositions.

## Changes

### New files: `crossplane/providers/`

| File | Content |
|---|---|
| `provider-kubernetes.yaml` | Provider + DeploymentRuntimeConfig + ServiceAccount + ClusterRoleBinding (cluster-admin for local dev) + ProviderConfig (InjectedIdentity) |
| `provider-helm.yaml` | Provider + DeploymentRuntimeConfig + ServiceAccount + ClusterRoleBinding + ProviderConfig (InjectedIdentity) |
| `provider-http.yaml` | Provider + ProviderConfig (source: None) |
| `kustomization.yaml` | Kustomize entry point for all three providers |

### New file: `apps/platform/crossplane-providers.yaml`

ArgoCD Application that syncs `crossplane/providers/` into the cluster.
- **Sync wave 4** — runs after Crossplane (wave 3) is healthy and CRDs are available
- Automated sync with selfHeal + prune

## Architecture

```
Crossplane (wave 3)
      │
      └── crossplane-providers (wave 4)
           ├── provider-kubernetes  → manages K8s resources (Namespaces, Deployments, Services...)
           ├── provider-helm        → manages Helm releases in-cluster
           └── provider-http        → calls external HTTP APIs (Gitea REST API)
```

## Notes

- All providers use `InjectedIdentity` / cluster-admin for local KinD development — restrict in production
- ProviderConfig named `default` for each provider (referenced by Compositions without explicit name)
- provider-http uses `source: None` — per-request credentials via Compositions when needed