### PR TITLE
Fix Crossplane Provider deployment – add containers spec & update versions

### DIFF
--- a/crossplane/providers/packages/provider-helm.yaml
+++ b/crossplane/providers/packages/provider-helm.yaml
@@ -20,6 +20,9 @@ spec:
       template:
         spec:
           serviceAccountName: crossplane-provider-helm
+          containers:
+            - name: provider-helm
+              image: xpkg.upbound.io/crossplane-contrib/provider-helm:v0.22.0
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/crossplane/providers/packages/provider-kubernetes.yaml
+++ b/crossplane/providers/packages/provider-kubernetes.yaml
@@ -20,6 +20,9 @@ spec:
       template:
         spec:
           serviceAccountName: crossplane-provider-kubernetes
+          containers:
+            - name: provider-kubernetes
+              image: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.22.0
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Closes #177. Added missing  spec to DeploymentRuntimeConfig for provider-helm and provider-kubernetes and bumped provider versions to latest (helm v0.22.0, kubernetes v0.22.0). This resolves the Argo CD sync errors and manifest 404 issues.
