### PR TITLE
fix: update Crossplane provider versions to latest releases

### DIFF
--- a/crossplane/providers/packages/provider-helm.yaml
+++ b/crossplane/providers/packages/provider-helm.yaml
@@ -3,7 +3,7 @@ kind: Provider
 metadata:
   name: provider-helm
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-helm:v0.20.3
+  package: xpkg.upbound.io/crossplane-contrib/provider-helm:v1.2.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig
@@ -22,7 +22,7 @@ spec:
           serviceAccountName: crossplane-provider-helm
           containers:
             - name: provider-helm
-              image: xpkg.upbound.io/crossplane-contrib/provider-helm:v0.22.0
+              image: xpkg.upbound.io/crossplane-contrib/provider-helm:v1.2.0
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/crossplane/providers/packages/provider-http.yaml
+++ b/crossplane/providers/packages/provider-http.yaml
@@ -3,4 +3,4 @@ kind: Provider
 metadata:
   name: provider-http
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-http:v0.5.1
+  package: xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.14

--- a/crossplane/providers/packages/provider-kubernetes.yaml
+++ b/crossplane/providers/packages/provider-kubernetes.yaml
@@ -3,7 +3,7 @@ kind: Provider
 metadata:
   name: provider-kubernetes
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.15.0
+  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v1.2.1
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig
@@ -22,7 +22,7 @@ spec:
           serviceAccountName: crossplane-provider-kubernetes
           containers:
             - name: provider-kubernetes
-              image: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.22.0
+              image: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v1.2.1
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Fixes #180. Updates provider versions to latest available releases:
- provider-helm: v0.20.3 → v1.2.0
- provider-kubernetes: v0.15.0 → v1.2.1
- provider-http: v0.5.1 → v1.0.14

The previous versions (including v0.22.0 from PR #179) do not exist in the Upbound registry, causing pod pull failures.