### PR TITLE
fix: use package-runtime container name in DeploymentRuntimeConfig

### DIFF
--- a/crossplane/providers/packages/provider-helm.yaml
+++ b/crossplane/providers/packages/provider-helm.yaml
@@ -21,8 +21,7 @@ spec:
         spec:
           serviceAccountName: crossplane-provider-helm
           containers:
-            - name: provider-helm
-              image: xpkg.upbound.io/crossplane-contrib/provider-helm:v1.2.0
+            - name: package-runtime
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/crossplane/providers/packages/provider-kubernetes.yaml
+++ b/crossplane/providers/packages/provider-kubernetes.yaml
@@ -21,8 +21,7 @@ spec:
         spec:
           serviceAccountName: crossplane-provider-kubernetes
           containers:
-            - name: provider-kubernetes
-              image: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v1.2.1
+            - name: package-runtime
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Fixes #182. Changes container name in DeploymentRuntimeConfig from provider-specific names to package-runtime (Crossplane internal name) so the spec is merged via Strategic Merge Patch instead of creating a duplicate container. Removes explicit image references — Crossplane handles these automatically.