### PR TITLE
feat: Add CloudNativePG (CNPG) Operator as platform component

### DIFF
--- a/apps/platform/cnpg.yaml
+++ b/apps/platform/cnpg.yaml
@@ -1,0 +1,47 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cnpg
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 0: Infrastructure operator — no dependencies on other platform services
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: default
+
+  source:
+    repoURL: https://cloudnative-pg.github.io/charts
+    chart: cloudnative-pg
+    targetRevision: 0.22.0
+    helm:
+      releaseName: cnpg
+      values: |
+        # CloudNativePG Helm values for local development
+        replicaCount: 1
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 512Mi
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cnpg-system
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 5m

--- a/platform/base/cnpg/kustomization.yaml
+++ b/platform/base/cnpg/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# CNPG Operator is installed via Helm by ArgoCD.
+# This kustomization provides supplementary resources if needed.
+# See: apps/platform/cnpg.yaml
+
+resources: []


### PR DESCRIPTION
## Summary

Installs the CloudNativePG (CNPG) Operator as a new platform component via ArgoCD + Helm.

## Changes
- New ArgoCD Application: `apps/platform/cnpg.yaml` (sync wave 0)
- New Kustomize base: `platform/base/cnpg/`

## Acceptance Criteria
- [ ] CNPG Operator deployed and running in `cnpg-system` namespace
- [ ] `Cluster` CRD available in the cluster
- [ ] ArgoCD Application `cnpg` syncs cleanly (wave 0)
- [ ] Existing platform PostgreSQL (`platform-db`) is unaffected

Fixes digiorg/core#171