### PR TITLE
fix(opensearch): move to sync-wave 3 to fix ServiceMonitor CRD timing

### DIFF
--- a/apps/platform/opensearch.yaml
+++ b/apps/platform/opensearch.yaml
@@ -6,8 +6,8 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    # Wave 0: Data layer — deployed alongside PostgreSQL, before Jaeger (Wave 2)
-    argocd.argoproj.io/sync-wave: "0"
+    # Wave 3: After kube-prometheus-stack (Wave 2) — ServiceMonitor CRD must exist before opensearch sync
+    argocd.argoproj.io/sync-wave: "3"
 spec:
   project: default
 


### PR DESCRIPTION
## Summary

Fixes the ArgoCD sync failure for the `opensearch` Application caused by a sync-wave ordering conflict.

## Root Cause

The `opensearch` Application (previously Wave 0) includes a `ServiceMonitor` resource (via Kustomize). The `ServiceMonitor` CRD is provided by `kube-prometheus-stack`, which is deployed by the `grafana` Application at **Wave 2**. ArgoCD validates all resources before applying — at Wave 0 the CRD does not yet exist, causing the sync to fail with:

```
The Kubernetes API could not find monitoring.coreos.com/ServiceMonitor for requested resource platform-db/opensearch.
```

## Changes

- `apps/platform/opensearch.yaml`: sync-wave `"0"` → `"3"` (after grafana/kube-prometheus-stack at Wave 2)

## Why Wave 3 is safe

OpenSearch has no hard dependency on other Wave-0 services (postgresql, cert-manager, nats, cnpg). Applications that depend on OpenSearch (Backstage etc.) are at Wave 2+ and will re-sync after OpenSearch is available.

## Acceptance Criteria

- [ ] ArgoCD syncs `opensearch` Application without errors on fresh cluster deployment
- [ ] `kubectl get servicemonitor opensearch -n platform-db` returns the resource
- [ ] No regression to other Wave-0 services

Fixes digiorg/core#185