### PR TITLE
feat(xrd): Implement AppClaim XRD with S/M/L sizing

### DIFF
--- a/apps/platform/crossplane-xrds.yaml
+++ b/apps/platform/crossplane-xrds.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: crossplane-xrds
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 7: Depends on Crossplane providers and ProviderConfigs (Wave 6) being ready
+    argocd.argoproj.io/sync-wave: "7"
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/digiorg/core.git
+    targetRevision: HEAD
+    path: crossplane/xrds
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: crossplane-system
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/crossplane/xrds/application.yaml
+++ b/crossplane/xrds/application.yaml
@@ -1,0 +1,104 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: applications.platform.digiorg.io
+spec:
+  group: platform.digiorg.io
+  names:
+    kind: Application
+    plural: applications
+  claimNames:
+    kind: AppClaim
+    plural: appclaims
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - appName
+                - team
+                - size
+              properties:
+                appName:
+                  type: string
+                  pattern: '^[a-z0-9][a-z0-9-]{0,31}$'
+                  description: "RFC 1123 App-Name, max 32 characters"
+                team:
+                  type: string
+                  description: "Owner team name (e.g. platform-team)"
+                size:
+                  type: string
+                  enum: [S, M, L]
+                  description: "T-shirt size: S=Dev/Sandbox, M=Standard, L=Production"
+                database:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      default: false
+                    engine:
+                      type: string
+                      enum: [postgresql]
+                      default: postgresql
+                services:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, image, port]
+                    properties:
+                      name:
+                        type: string
+                        description: "Service name"
+                      image:
+                        type: string
+                        description: "Container image reference"
+                      port:
+                        type: integer
+                        minimum: 1
+                        maximum: 65535
+                        description: "Container port"
+                      replicas:
+                        type: integer
+                        minimum: 1
+                        default: 1
+                        description: "Override replica count (size preset applies if omitted)"
+                gitea:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      default: false
+                    visibility:
+                      type: string
+                      enum: [private, public]
+                      default: private
+                    cicd:
+                      type: boolean
+                      default: true
+                      description: "Create Gitea Actions pipeline"
+                messaging:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      default: false
+                    subjects:
+                      type: array
+                      items:
+                        type: string
+                      description: "NATS subjects (e.g. my-app.events.>)"
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  description: "Current provisioning phase"
+                message:
+                  type: string
+                  description: "Human-readable status message"

--- a/crossplane/xrds/kustomization.yaml
+++ b/crossplane/xrds/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - application.yaml


### PR DESCRIPTION
## Summary
Implements the AppClaim CompositeResourceDefinition (XRD) as the central API contract for app-level infrastructure claims in the DigiOrg Core Platform.

## Changes
- `crossplane/xrds/application.yaml`: AppClaim XRD with S/M/L T-shirt sizing and component flags (database, services, gitea, messaging)
- `crossplane/xrds/kustomization.yaml`: Kustomize entrypoint for XRDs directory
- `apps/platform/crossplane-xrds.yaml`: ArgoCD Application (Sync Wave 7) deploying the XRD

## Acceptance Criteria
- [ ] `crossplane/xrds/application.yaml` exists with valid XRD
- [ ] XRD defines AppClaim (namespaced) and Application (cluster-scoped)
- [ ] Required fields validated: appName (RFC 1123), team, size (S/M/L)
- [ ] Optional flags: database.enabled, gitea.enabled, messaging.enabled
- [ ] `crossplane/xrds/kustomization.yaml` references application.yaml
- [ ] `apps/platform/crossplane-xrds.yaml` ArgoCD Application (Wave 7) created

Fixes digiorg/core#187