### PR TITLE
feat(argocd): Add ArgoCD Application for core-app-catalog (Wave 8)

### DIFF
--- a/apps/platform/core-app-catalog.yaml
+++ b/apps/platform/core-app-catalog.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: core-app-catalog
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 8: Depends on XRDs (Wave 7) being installed and CRDs available
+    argocd.argoproj.io/sync-wave: "8"
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/digiorg/core-app-catalog.git
+    targetRevision: HEAD
+    path: compositions/local
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: crossplane-system
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m


### PR DESCRIPTION
## Summary
Fügt die ArgoCD Application `core-app-catalog` (Sync Wave 8) hinzu, die das `digiorg/core-app-catalog` Repository als Composition-Quelle in die Platform einbindet. Damit werden die Crossplane Compositions aus `compositions/local/` automatisch im Cluster deployed und bei Änderungen aktualisiert.

## Changes
- `apps/platform/core-app-catalog.yaml`: Neue ArgoCD Application, Wave 8, zeigt auf `digiorg/core-app-catalog` → `compositions/local`
- `crossplane/compositions/.gitkeep`: Entfernt — Compositions liegen jetzt explizit in `core-app-catalog`

## Wave-Reihenfolge
| Wave | App | Abhängigkeit |
|---|---|---|
| 7 | crossplane-xrds | Providers + ProviderConfigs |
| **8** | **core-app-catalog** | **XRDs müssen installiert sein** |

## Acceptance Criteria
- [x] `apps/platform/core-app-catalog.yaml` als valide ArgoCD Application
- [x] Sync Wave 8 (nach crossplane-xrds Wave 7)
- [x] repoURL: https://github.com/digiorg/core-app-catalog.git
- [x] path: compositions/local
- [x] syncPolicy: automated, selfHeal, prune, ServerSideApply
- [x] `crossplane/compositions/.gitkeep` entfernt

Fixes digiorg/core#190