### PR TITLE
fix(backstage): Add RBAC, kubernetes-ingestor env-vars, extend ArgoCD wave wait-list

### DIFF
--- a/platform/base/backstage/deployment.yaml
+++ b/platform/base/backstage/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: backstage
     spec:
+      serviceAccountName: backstage
       # Wait for PostgreSQL to be ready before starting Backstage
       initContainers:
         - name: wait-for-postgres
@@ -84,6 +85,17 @@ spec:
                   name: backstage-secrets
                   key: GITHUB_TOKEN
                   optional: true
+            # Kubernetes Ingestor — in-cluster configuration
+            # KUBERNETES_API_URL: internal cluster API server (Backstage runs in-cluster)
+            - name: KUBERNETES_API_URL
+              value: "https://kubernetes.default.svc"
+            # Token from long-lived ServiceAccount secret (created by local-setup.nu)
+            - name: KUBERNETES_SERVICE_ACCOUNT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: backstage-k8s-token
+                  key: token
+                  optional: false
           resources:
             requests:
               memory: "512Mi"

--- a/platform/base/backstage/kustomization.yaml
+++ b/platform/base/backstage/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: backstage
 
 resources:
   - namespace.yaml
+  - rbac.yaml
   - deployment.yaml
   - service.yaml
 

--- a/platform/base/backstage/rbac.yaml
+++ b/platform/base/backstage/rbac.yaml
@@ -1,0 +1,46 @@
+# RBAC for Backstage kubernetes-ingestor
+# Grants Backstage read-only access to Crossplane XRDs, AppClaims, and standard K8s resources
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backstage
+  namespace: backstage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backstage-kubernetes-ingestor
+rules:
+  # Crossplane XRDs and Compositions
+  - apiGroups: ["apiextensions.crossplane.io"]
+    resources: ["compositeresourcedefinitions", "compositions"]
+    verbs: ["get", "list", "watch"]
+  # AppClaims and Applications (platform.digiorg.io)
+  - apiGroups: ["platform.digiorg.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  # Standard Kubernetes resources for workload ingestion
+  - apiGroups: [""]
+    resources: ["namespaces", "pods", "services", "configmaps", "serviceaccounts"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+    verbs: ["get", "list", "watch"]
+  # CRDs for XRD discovery
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backstage-kubernetes-ingestor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: backstage-kubernetes-ingestor
+subjects:
+  - kind: ServiceAccount
+    name: backstage
+    namespace: backstage

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -375,7 +375,12 @@ def create_platform_namespaces_secrets [] {
         --from-literal=AUTH_OIDC_CLIENT_SECRET=($backstage_oidc_secret)
         --from-literal=GITHUB_TOKEN=""
         --dry-run=client -o yaml | kubectl apply -f -)
-    
+
+    # Backstage kubernetes-ingestor ServiceAccount token (long-lived)
+    # Pre-created so Backstage deployment can mount it; token populated by K8s once SA exists
+    let backstage_k8s_token_yaml = "apiVersion: v1\nkind: Secret\nmetadata:\n  name: backstage-k8s-token\n  namespace: backstage\n  annotations:\n    kubernetes.io/service-account.name: backstage\ntype: kubernetes.io/service-account-token"
+    $backstage_k8s_token_yaml | kubectl apply -f -
+
     # Monitoring namespace (Grafana uses Helm values for OAuth secret)
     kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
     
@@ -476,6 +481,10 @@ def deploy_root_app [] {
     print "  Wave  1: keycloak, argocd (self-managed)"
     print "  Wave  2: landingpage, backstage, gitea, grafana, jaeger, sonarqube"
     print "  Wave  3: crossplane, kyverno"
+    print "  Wave  4: crossplane-providers"
+    print "  Wave  6: crossplane-provider-configs"
+    print "  Wave  7: crossplane-xrds"
+    print "  Wave  8: core-app-catalog"
 
     # Wait for apps to sync
     print ""
@@ -500,7 +509,15 @@ def wait_for_argocd_apps [] {
         # Wave 2
         "landingpage", "backstage", "gitea", "grafana", "jaeger", "sonarqube",
         # Wave 3
-        "crossplane", "kyverno"
+        "crossplane", "kyverno",
+        # Wave 4
+        "crossplane-providers",
+        # Wave 6
+        "crossplane-provider-configs",
+        # Wave 7
+        "crossplane-xrds",
+        # Wave 8
+        "core-app-catalog"
     ]
     
     mut all_healthy = false


### PR DESCRIPTION
## Summary
Fixes three root causes of Backstage 503 errors and missing ArgoCD Waves 7/8 after fresh cluster setup.

## Changes

### platform/base/backstage/rbac.yaml (NEW)
- ServiceAccount `backstage` in namespace `backstage`
- ClusterRole `backstage-kubernetes-ingestor`: read access to Crossplane XRDs, AppClaims, standard K8s resources, CRDs
- ClusterRoleBinding: SA `backstage` → ClusterRole

### platform/base/backstage/kustomization.yaml
- Added `rbac.yaml` to resources

### platform/base/backstage/deployment.yaml
- Added `serviceAccountName: backstage`
- Added `KUBERNETES_API_URL=https://kubernetes.default.svc` (in-cluster)
- Added `KUBERNETES_SERVICE_ACCOUNT_TOKEN` from `backstage-k8s-token` Secret

### scripts/local-setup.nu
- Added `backstage-k8s-token` ServiceAccount token Secret creation
- Extended `apps` wait-list to include Waves 4–8: `crossplane-providers`, `crossplane-provider-configs`, `crossplane-xrds`, `core-app-catalog`
- Updated wave print output to show Waves 4–8

## Root Causes Fixed
| # | Problem | Fix |
|---|---|---|
| 1 | Missing KUBERNETES_API_URL + TOKEN env vars → kubernetes-ingestor 503 | Added env vars to deployment.yaml |
| 2 | No ServiceAccount/RBAC for Backstage cluster access | New rbac.yaml |
| 3 | local-setup.nu only waits for Waves 0-3 | Extended apps wait-list |

Fixes digiorg/core#192