### PR TITLE
feat: add Kyverno validation for required AppClaim fields

### DIFF
--- a/apps/platform/kyverno-policies.yaml
+++ b/apps/platform/kyverno-policies.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kyverno-policies
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 4: After Kyverno (Wave 3) — policies require Kyverno CRDs to be registered.
+    # AppClaim CRD is registered in Wave 7 (crossplane-xrds); Kyverno 3.x queues
+    # policies for unknown resource types and activates them once the CRD appears.
+    argocd.argoproj.io/sync-wave: "4"
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/digiorg/core.git
+    targetRevision: HEAD
+    path: policies/kyverno/appclaims
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kyverno
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/policies/kyverno/appclaims/kustomization.yaml
+++ b/policies/kyverno/appclaims/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - require-appclaim-fields.yaml

--- a/policies/kyverno/appclaims/require-appclaim-fields.yaml
+++ b/policies/kyverno/appclaims/require-appclaim-fields.yaml
@@ -1,0 +1,53 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-appclaim-fields
+  annotations:
+    policies.kyverno.io/title: "Require AppClaim Fields"
+    policies.kyverno.io/description: "Requires spec.appName, spec.team, and spec.size on every AppClaim before it enters the cluster."
+    policies.kyverno.io/severity: high
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: require-appname
+      match:
+        any:
+          - resources:
+              kinds:
+                - AppClaim
+              apiGroups:
+                - platform.digiorg.io
+      validate:
+        message: "AppClaim spec.appName is required and must be non-empty"
+        pattern:
+          spec:
+            appName: "?*"
+
+    - name: require-team
+      match:
+        any:
+          - resources:
+              kinds:
+                - AppClaim
+              apiGroups:
+                - platform.digiorg.io
+      validate:
+        message: "AppClaim spec.team is required and must be non-empty"
+        pattern:
+          spec:
+            team: "?*"
+
+    - name: require-size
+      match:
+        any:
+          - resources:
+              kinds:
+                - AppClaim
+              apiGroups:
+                - platform.digiorg.io
+      validate:
+        message: "AppClaim spec.size is required and must be non-empty (valid values: S, M, L)"
+        pattern:
+          spec:
+            size: "?*"


### PR DESCRIPTION
## Summary

Adds a Kyverno `ClusterPolicy` that enforces the three required self-service metadata fields on every `AppClaim` at admission time, providing immediate, clear rejection messages before incomplete claims can reach Crossplane composition reconciliation.

## Changes

- `policies/kyverno/appclaims/require-appclaim-fields.yaml` — `ClusterPolicy` with three rules (`require-appname`, `require-team`, `require-size`), each targeting `AppClaim` resources in `platform.digiorg.io` and validating the matching spec field is present and non-empty. `validationFailureAction: Enforce` rejects at admission; `background: true` enables audit reporting.
- `policies/kyverno/appclaims/kustomization.yaml` — Kustomize manifest so ArgoCD can render the directory.
- `apps/platform/kyverno-policies.yaml` — ArgoCD `Application` (Wave 4, after Kyverno Wave 3) pointing to `policies/kyverno/appclaims`. Kyverno 3.x queues policies for unregistered CRDs and activates them automatically once the AppClaim CRD appears (Wave 7, crossplane-xrds).

## Acceptance Criteria

- [x] A Kyverno policy exists for AppClaim required-field validation.
- [x] Missing `spec.appName` is rejected with a useful validation message.
- [x] Missing `spec.team` is rejected with a useful validation message.
- [x] Missing `spec.size` is rejected with a useful validation message.
- [x] The policy is wired into the existing deployment structure (ArgoCD app, Wave 4).
- [x] Policy manifests are valid YAML (validated with `python3 yaml.safe_load_all`).

## Tests

- YAML validated with Python `yaml.safe_load_all` — all files parse cleanly.
- `kubectl kustomize` / `kustomize` not available in the dev environment; kustomization structure follows the identical pattern used by `crossplane/xrds/kustomization.yaml`.
- End-to-end admission testing requires a live cluster with Kyverno 3.3.7 and the AppClaim CRD registered.

Fixes digiorg/core#200