### PR TITLE
feat: Add Fluentd DaemonSet as platform logging component

### DIFF
--- a/apps/platform/fluentd.yaml
+++ b/apps/platform/fluentd.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: fluentd
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 4: After opensearch (Wave 3) — log collector deployed once storage backend is ready
+    argocd.argoproj.io/sync-wave: "4"
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/digiorg/core.git
+    targetRevision: HEAD
+    path: platform/base/fluentd
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: logging
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/platform/base/fluentd/configmap.yaml
+++ b/platform/base/fluentd/configmap.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-config
+  namespace: logging
+  labels:
+    app: fluentd
+    app.kubernetes.io/part-of: digiorg-core-platform
+    app.kubernetes.io/component: logging
+data:
+  fluent.conf: |
+    # ============================================================
+    # INPUT: Container logs from all namespaces
+    # ============================================================
+    <source>
+      @type tail
+      @id in_tail_container_logs
+      path /var/log/containers/*.log
+      pos_file /var/log/fluentd-containers.log.pos
+      tag raw.kubernetes.*
+      read_from_head true
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+          time_key time
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+          time_format %Y-%m-%dT%H:%M:%S.%N%:z
+        </pattern>
+      </parse>
+    </source>
+
+    # ============================================================
+    # INPUT: Prometheus metrics endpoint
+    # ============================================================
+    <source>
+      @type prometheus
+      bind 0.0.0.0
+      port 24231
+      metrics_path /metrics
+    </source>
+
+    <source>
+      @type prometheus_output_monitor
+      interval 10
+    </source>
+
+    # ============================================================
+    # FILTER: Enrich with Kubernetes metadata
+    # ============================================================
+    <filter raw.kubernetes.**>
+      @type kubernetes_metadata
+      @id filter_kube_metadata
+      kubernetes_url "#{ENV['KUBERNETES_URL'] || 'https://kubernetes.default.svc'}"
+      skip_labels false
+      skip_container_metadata false
+      skip_namespace_metadata false
+    </filter>
+
+    # ============================================================
+    # FILTER: Parse structured JSON logs, preserve plain-text logs
+    # ============================================================
+    <filter raw.kubernetes.**>
+      @type parser
+      key_name log
+      reserve_data true
+      remove_key_name_field false
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # ============================================================
+    # FILTER: Prometheus metrics counter per namespace/pod/container
+    # ============================================================
+    <filter raw.kubernetes.**>
+      @type prometheus
+      <metric>
+        name fluentd_input_records_total
+        type counter
+        desc Total number of log records collected
+        <labels>
+          namespace $.kubernetes.namespace_name
+          pod $.kubernetes.pod_name
+          container $.kubernetes.container_name
+        </labels>
+      </metric>
+    </filter>
+
+    # ============================================================
+    # MATCH: Drop kube-system logs (high volume, low app value)
+    # ============================================================
+    <match raw.kubernetes.var.log.containers.**kube-system**.log>
+      @type null
+    </match>
+
+    # ============================================================
+    # OUTPUT: Forward to OpenSearch (Elasticsearch-compatible API)
+    # ============================================================
+    <match raw.kubernetes.**>
+      @type elasticsearch
+      @id out_opensearch
+      host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
+      port "#{ENV['FLUENT_ELASTICSEARCH_PORT']}"
+      scheme http
+      ssl_verify false
+      logstash_format true
+      logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'digiorg-logs'}"
+      include_tag_key true
+      tag_key @log_name
+
+      <buffer>
+        @type file
+        path /var/log/fluentd-buffers/kubernetes.system.buffer
+        flush_mode interval
+        retry_type exponential_backoff
+        flush_thread_count 2
+        flush_interval 5s
+        retry_forever true
+        retry_max_interval 30
+        chunk_limit_size 2M
+        queue_limit_length 8
+        overflow_action block
+      </buffer>
+    </match>

--- a/platform/base/fluentd/daemonset.yaml
+++ b/platform/base/fluentd/daemonset.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  namespace: logging
+  labels:
+    app: fluentd
+    app.kubernetes.io/part-of: digiorg-core-platform
+    app.kubernetes.io/component: logging
+spec:
+  selector:
+    matchLabels:
+      app: fluentd
+  template:
+    metadata:
+      labels:
+        app: fluentd
+        app.kubernetes.io/part-of: digiorg-core-platform
+        app.kubernetes.io/component: logging
+    spec:
+      serviceAccountName: fluentd
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+      containers:
+        - name: fluentd
+          image: fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch8-amd64
+          env:
+            - name: FLUENT_ELASTICSEARCH_HOST
+              value: "opensearch-cluster-master.platform-db.svc.cluster.local"
+            - name: FLUENT_ELASTICSEARCH_PORT
+              value: "9200"
+            - name: FLUENT_ELASTICSEARCH_SSL_VERIFY
+              value: "false"
+            - name: FLUENT_ELASTICSEARCH_LOGSTASH_FORMAT
+              value: "true"
+            - name: FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX
+              value: "digiorg-logs"
+            - name: FLUENT_ELASTICSEARCH_INDEX_NAME
+              value: "digiorg-logs"
+            - name: KUBERNETES_URL
+              value: "https://kubernetes.default.svc"
+          ports:
+            - name: prometheus
+              containerPort: 24231
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: fluentd-config
+              mountPath: /fluentd/etc/fluent.conf
+              subPath: fluent.conf
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: fluentd-config
+          configMap:
+            name: fluentd-config

--- a/platform/base/fluentd/kustomization.yaml
+++ b/platform/base/fluentd/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: logging
+
+resources:
+  - namespace.yaml
+  - rbac.yaml
+  - configmap.yaml
+  - daemonset.yaml
+  - service.yaml

--- a/platform/base/fluentd/namespace.yaml
+++ b/platform/base/fluentd/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logging
+  labels:
+    app.kubernetes.io/part-of: digiorg-core-platform
+    app.kubernetes.io/component: logging

--- a/platform/base/fluentd/rbac.yaml
+++ b/platform/base/fluentd/rbac.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd
+  namespace: logging
+  labels:
+    app: fluentd
+    app.kubernetes.io/part-of: digiorg-core-platform
+    app.kubernetes.io/component: logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluentd
+  labels:
+    app: fluentd
+    app.kubernetes.io/part-of: digiorg-core-platform
+    app.kubernetes.io/component: logging
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluentd
+  labels:
+    app: fluentd
+    app.kubernetes.io/part-of: digiorg-core-platform
+    app.kubernetes.io/component: logging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluentd
+subjects:
+  - kind: ServiceAccount
+    name: fluentd
+    namespace: logging

--- a/platform/base/fluentd/service.yaml
+++ b/platform/base/fluentd/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fluentd
+  namespace: logging
+  labels:
+    app: fluentd
+    app.kubernetes.io/part-of: digiorg-core-platform
+    app.kubernetes.io/component: logging
+spec:
+  selector:
+    app: fluentd
+  clusterIP: None
+  ports:
+    - name: prometheus
+      port: 24231
+      targetPort: 24231
+      protocol: TCP


### PR DESCRIPTION
## Summary
- Add Fluentd as a new DigiOrg Core platform logging component
- Deploy Fluentd via ArgoCD/Kustomize into the logging namespace
- Configure DaemonSet log collection from container logs and forwarding to OpenSearch digiorg-logs-* indices

## Changes
- apps/platform/fluentd.yaml: registers the Fluentd ArgoCD Application
- platform/base/fluentd/: adds namespace, RBAC, config, DaemonSet, Service, and Kustomize base

## Acceptance Criteria
- [x] apps/platform/fluentd.yaml exists and follows the existing DigiOrg Core ArgoCD Application pattern
- [x] platform/base/fluentd/ contains the required Kustomize manifests for the Fluentd base deployment
- [x] Namespace logging is created or managed by the component
- [x] Fluentd runs as a DaemonSet on cluster nodes
- [x] Fluentd reads logs from /var/log/containers/*.log
- [x] Fluentd enriches records with Kubernetes metadata
- [x] Fluentd forwards logs to the existing OpenSearch service in namespace platform-db
- [x] Logs use index prefix digiorg-logs / daily index pattern digiorg-logs-*
- [x] RBAC is limited to the read permissions required for metadata enrichment
- [x] The implementation is compatible with existing ArgoCD/Kustomize platform conventions
- [x] Existing platform components are not modified except where required to register the new Fluentd Application

Fixes digiorg/core#208