### PR TITLE
feat: Add Fluentd Prometheus ServiceMonitor

### DIFF
--- a/platform/base/monitoring-extras/fluentd-servicemonitor.yaml
+++ b/platform/base/monitoring-extras/fluentd-servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: fluentd
+  namespace: logging
+  labels:
+    release: prometheus    # Required: kube-prometheus-stack discovers by this label
+spec:
+  namespaceSelector:
+    matchNames:
+      - logging
+  selector:
+    matchLabels:
+      app: fluentd
+  endpoints:
+    - port: prometheus
+      path: /metrics
+      interval: 30s

--- a/platform/base/monitoring-extras/kustomization.yaml
+++ b/platform/base/monitoring-extras/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - nats-servicemonitor.yaml
   - jaeger-servicemonitor.yaml
   - opensearch-servicemonitor.yaml
+  - fluentd-servicemonitor.yaml


### PR DESCRIPTION
## Summary
- Add Fluentd ServiceMonitor to monitoring-extras
- Enable Prometheus scraping of Fluentd metrics from the logging namespace
- Wire the new ServiceMonitor into the existing monitoring-extras Kustomize base

## Changes
- platform/base/monitoring-extras/fluentd-servicemonitor.yaml: adds Fluentd ServiceMonitor
- platform/base/monitoring-extras/kustomization.yaml: includes the new resource

## Acceptance Criteria
- [x] platform/base/monitoring-extras/fluentd-servicemonitor.yaml exists
- [x] platform/base/monitoring-extras/kustomization.yaml references the new Fluentd ServiceMonitor
- [x] The ServiceMonitor selects the Fluentd service in namespace logging
- [x] The endpoint uses port prometheus
- [x] The endpoint uses path /metrics
- [x] The scrape interval is 30s
- [x] The resource follows existing DigiOrg Core ServiceMonitor conventions
- [x] No Grafana dashboards, Grafana datasource changes, or OpenSearch retention policies are included

Fixes digiorg/core#210