### PR TITLE
feat: Add OpenSearch Logs datasource to Grafana values

### DIFF
--- a/platform/base/grafana/values.yaml
+++ b/platform/base/grafana/values.yaml
@@ -56,6 +56,20 @@ grafana:
       # Index pattern: jaeger-span-YYYY-MM-DD (daily rotation by Jaeger)
       database: "jaeger-span-*"
 
+    # OpenSearch as Elasticsearch-compatible datasource for application and platform logs.
+    # Uses the digiorg-logs-* index pattern written by Fluentd.
+    - name: OpenSearch (Logs)
+      type: elasticsearch
+      url: http://opensearch-cluster-master.platform-db.svc.cluster.local:9200
+      access: proxy
+      isDefault: false
+      jsonData:
+        esVersion: "70"          # OpenSearch is compatible with ES 7.10.2 API
+        timeField: "@timestamp"
+        logMessageField: log
+        logLevelField: level
+      database: "digiorg-logs-*"
+
 prometheus:
   prometheusSpec:
     retention: 1d


### PR DESCRIPTION
## Summary
- Add a dedicated Grafana datasource for Fluentd logs stored in OpenSearch
- Configure the datasource for the digiorg-logs-* index pattern
- Keep trace and log OpenSearch exploration separated

## Changes
- platform/base/grafana/values.yaml: adds OpenSearch (Logs) datasource

## Acceptance Criteria
- [x] platform/base/grafana/values.yaml contains a new OpenSearch (Logs) datasource
- [x] The new datasource uses index pattern digiorg-logs-*
- [x] The new datasource points to the existing OpenSearch service in namespace platform-db
- [x] The new datasource uses type elasticsearch and the same OpenSearch compatibility style as OpenSearch (Traces)
- [x] The new datasource uses @timestamp as the time field
- [x] The new datasource configures log as log message field
- [x] The new datasource configures level as log level field
- [x] Existing Grafana datasources remain unchanged
- [x] No dashboards, Fluentd changes, or OpenSearch retention/ISM resources are included

Fixes digiorg/core#212