### PR TITLE
feat: Add Grafana dashboards for DigiOrg logs and Fluentd health

### DIFF
--- a/platform/base/fluentd/grafana-dashboards.yaml
+++ b/platform/base/fluentd/grafana-dashboards.yaml
@@ -1,0 +1,884 @@
+# =============================================================================
+# Grafana Dashboard ConfigMap for DigiOrg logging and Fluentd health.
+# The grafana_dashboard: "1" label triggers automatic dashboard provisioning
+# via the Grafana sidecar in kube-prometheus-stack.
+# =============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-grafana-dashboards
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+    app.kubernetes.io/name: fluentd-grafana-dashboards
+    app.kubernetes.io/part-of: digiorg-core-platform
+data:
+  digiorg-log-explorer.json: |
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${logs_ds}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 50,
+                "lineWidth": 1
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "bucketAggs": [
+                {
+                  "field": "@timestamp",
+                  "id": "2",
+                  "settings": {
+                    "interval": "auto",
+                    "min_doc_count": "0",
+                    "trimEdges": "0"
+                  },
+                  "type": "date_histogram"
+                }
+              ],
+              "datasource": {
+                "type": "elasticsearch",
+                "uid": "${logs_ds}"
+              },
+              "metrics": [
+                {
+                  "id": "1",
+                  "type": "count"
+                }
+              ],
+              "query": "kubernetes.namespace_name:$namespace",
+              "refId": "A",
+              "timeField": "@timestamp"
+            }
+          ],
+          "title": "Log Volume",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${logs_ds}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "red",
+                "mode": "fixed"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "bucketAggs": [
+                {
+                  "field": "@timestamp",
+                  "id": "2",
+                  "settings": {
+                    "interval": "auto",
+                    "min_doc_count": "0"
+                  },
+                  "type": "date_histogram"
+                }
+              ],
+              "datasource": {
+                "type": "elasticsearch",
+                "uid": "${logs_ds}"
+              },
+              "metrics": [
+                {
+                  "id": "1",
+                  "type": "count"
+                }
+              ],
+              "query": "level:error AND kubernetes.namespace_name:$namespace",
+              "refId": "A",
+              "timeField": "@timestamp"
+            }
+          ],
+          "title": "Error Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${logs_ds}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 3,
+          "options": {
+            "displayLabels": ["name", "value"],
+            "legend": {
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "pieType": "pie",
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "bucketAggs": [
+                {
+                  "field": "level.keyword",
+                  "id": "1",
+                  "settings": {
+                    "min_doc_count": "1",
+                    "order": "desc",
+                    "orderBy": "_count",
+                    "size": "10"
+                  },
+                  "type": "terms"
+                }
+              ],
+              "datasource": {
+                "type": "elasticsearch",
+                "uid": "${logs_ds}"
+              },
+              "metrics": [
+                {
+                  "id": "2",
+                  "type": "count"
+                }
+              ],
+              "query": "kubernetes.namespace_name:$namespace",
+              "refId": "A",
+              "timeField": "@timestamp"
+            }
+          ],
+          "title": "Log Level Breakdown",
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${logs_ds}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 4,
+          "options": {
+            "footer": {
+              "show": false
+            },
+            "showHeader": true
+          },
+          "targets": [
+            {
+              "bucketAggs": [
+                {
+                  "field": "kubernetes.namespace_name.keyword",
+                  "id": "1",
+                  "settings": {
+                    "min_doc_count": "1",
+                    "order": "desc",
+                    "orderBy": "_count",
+                    "size": "10"
+                  },
+                  "type": "terms"
+                }
+              ],
+              "datasource": {
+                "type": "elasticsearch",
+                "uid": "${logs_ds}"
+              },
+              "metrics": [
+                {
+                  "id": "2",
+                  "type": "count"
+                }
+              ],
+              "query": "level:error",
+              "refId": "A",
+              "timeField": "@timestamp"
+            }
+          ],
+          "title": "Error Count by Namespace",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${logs_ds}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 5,
+          "options": {
+            "footer": {
+              "show": false
+            },
+            "showHeader": true
+          },
+          "targets": [
+            {
+              "bucketAggs": [
+                {
+                  "field": "kubernetes.pod_name.keyword",
+                  "id": "1",
+                  "settings": {
+                    "min_doc_count": "1",
+                    "order": "desc",
+                    "orderBy": "_count",
+                    "size": "10"
+                  },
+                  "type": "terms"
+                }
+              ],
+              "datasource": {
+                "type": "elasticsearch",
+                "uid": "${logs_ds}"
+              },
+              "metrics": [
+                {
+                  "id": "2",
+                  "type": "count"
+                }
+              ],
+              "query": "kubernetes.namespace_name:$namespace",
+              "refId": "A",
+              "timeField": "@timestamp"
+            }
+          ],
+          "title": "Top Noisy Pods",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${logs_ds}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 24
+          },
+          "id": 6,
+          "options": {
+            "dedupStrategy": "none",
+            "enableLogDetails": true,
+            "showLabels": false,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": false
+          },
+          "targets": [
+            {
+              "bucketAggs": [],
+              "datasource": {
+                "type": "elasticsearch",
+                "uid": "${logs_ds}"
+              },
+              "metrics": [
+                {
+                  "id": "1",
+                  "type": "logs"
+                }
+              ],
+              "query": "kubernetes.namespace_name:$namespace AND kubernetes.pod_name:$pod AND level:$level",
+              "refId": "A",
+              "timeField": "@timestamp"
+            }
+          ],
+          "title": "Recent Logs",
+          "type": "logs"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 37,
+      "style": "dark",
+      "tags": ["logging", "digiorg"],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "hide": 0,
+            "includeAll": false,
+            "label": "Log Datasource",
+            "multi": false,
+            "name": "logs_ds",
+            "options": [],
+            "query": "elasticsearch",
+            "refresh": 1,
+            "regex": "/OpenSearch \\(Logs\\)/",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "allValue": "*",
+            "current": {},
+            "datasource": {
+              "type": "elasticsearch",
+              "uid": "${logs_ds}"
+            },
+            "definition": "{\"find\":\"terms\",\"field\":\"kubernetes.namespace_name.keyword\"}",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "{\"find\":\"terms\",\"field\":\"kubernetes.namespace_name.keyword\"}",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "allValue": "*",
+            "current": {},
+            "datasource": {
+              "type": "elasticsearch",
+              "uid": "${logs_ds}"
+            },
+            "definition": "{\"find\":\"terms\",\"field\":\"kubernetes.pod_name.keyword\",\"query\":\"kubernetes.namespace_name:$namespace\"}",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Pod",
+            "multi": false,
+            "name": "pod",
+            "options": [],
+            "query": "{\"find\":\"terms\",\"field\":\"kubernetes.pod_name.keyword\",\"query\":\"kubernetes.namespace_name:$namespace\"}",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "allValue": "*",
+            "current": {},
+            "datasource": {
+              "type": "elasticsearch",
+              "uid": "${logs_ds}"
+            },
+            "definition": "{\"find\":\"terms\",\"field\":\"kubernetes.container_name.keyword\",\"query\":\"kubernetes.namespace_name:$namespace\"}",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Container",
+            "multi": false,
+            "name": "container",
+            "options": [],
+            "query": "{\"find\":\"terms\",\"field\":\"kubernetes.container_name.keyword\",\"query\":\"kubernetes.namespace_name:$namespace\"}",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "allValue": "*",
+            "current": {
+              "selected": true,
+              "text": "All",
+              "value": "$__all"
+            },
+            "hide": 0,
+            "includeAll": true,
+            "label": "Level",
+            "multi": false,
+            "name": "level",
+            "options": [
+              {
+                "selected": true,
+                "text": "All",
+                "value": "$__all"
+              },
+              {
+                "selected": false,
+                "text": "info",
+                "value": "info"
+              },
+              {
+                "selected": false,
+                "text": "warn",
+                "value": "warn"
+              },
+              {
+                "selected": false,
+                "text": "error",
+                "value": "error"
+              },
+              {
+                "selected": false,
+                "text": "debug",
+                "value": "debug"
+              }
+            ],
+            "query": "info,warn,error,debug",
+            "skipUrlSync": false,
+            "type": "custom"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "DigiOrg Log Explorer",
+      "uid": "digiorg-log-explorer",
+      "version": 1
+    }
+  fluentd-health.json: |
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom_ds}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prom_ds}"
+              },
+              "expr": "sum(rate(fluentd_input_records_total[5m])) by (namespace)",
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Input Records/s",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom_ds}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prom_ds}"
+              },
+              "expr": "sum(rate(fluentd_output_status_num_records_total[5m])) by (plugin_id)",
+              "legendFormat": "{{plugin_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Output Records/s",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom_ds}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prom_ds}"
+              },
+              "expr": "fluentd_output_status_buffer_queue_length",
+              "legendFormat": "{{plugin_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Buffer Queue Length",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom_ds}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 5
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prom_ds}"
+              },
+              "expr": "fluentd_output_status_retry_count",
+              "legendFormat": "{{plugin_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Retry Count",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom_ds}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "red",
+                "mode": "fixed"
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 5,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prom_ds}"
+              },
+              "expr": "rate(fluentd_output_status_num_errors_total[5m])",
+              "legendFormat": "{{plugin_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Output Errors",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom_ds}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "DOWN"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "UP"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 6,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "value_and_name"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prom_ds}"
+              },
+              "expr": "up{job=\"fluentd\"}",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Fluentd Instances Up",
+          "type": "stat"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 37,
+      "style": "dark",
+      "tags": ["logging", "fluentd"],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "hide": 0,
+            "includeAll": false,
+            "label": "Prometheus Datasource",
+            "multi": false,
+            "name": "prom_ds",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Fluentd Health",
+      "uid": "fluentd-health",
+      "version": 1
+    }

--- a/platform/base/fluentd/kustomization.yaml
+++ b/platform/base/fluentd/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - configmap.yaml
   - daemonset.yaml
   - service.yaml
+  - grafana-dashboards.yaml


### PR DESCRIPTION
## Summary
- Add Grafana dashboard ConfigMap for DigiOrg centralized logging
- Add DigiOrg Log Explorer dashboard backed by OpenSearch (Logs)
- Add Fluentd Health dashboard backed by Prometheus metrics

## Changes
- `platform/base/fluentd/grafana-dashboards.yaml`: adds two dashboard JSON definitions for Grafana sidecar provisioning
- `platform/base/fluentd/kustomization.yaml`: registers the dashboard ConfigMap

## Acceptance Criteria
- [x] `platform/base/fluentd/grafana-dashboards.yaml` exists
- [x] The ConfigMap is labelled with `grafana_dashboard: "1"`
- [x] The ConfigMap is created in namespace `monitoring`
- [x] `platform/base/fluentd/kustomization.yaml` references the dashboard ConfigMap
- [x] A `DigiOrg Log Explorer` dashboard is included
- [x] A `Fluentd Health` dashboard is included
- [x] The log dashboard uses the `OpenSearch (Logs)` datasource / `digiorg-logs-*` log index
- [x] The Fluentd health dashboard uses Prometheus metrics from the Fluentd ServiceMonitor
- [x] Existing Grafana datasource configuration remains unchanged
- [x] Fluentd DaemonSet/config/output remains unchanged
- [x] No OpenSearch retention/ISM resources are included
- [x] Dashboard JSON is valid JSON embedded in YAML

Fixes digiorg/core#214