### PR TITLE
fix(fluentd): correct image tag to v1.19-debian-elasticsearch8-1

### DIFF
--- a/platform/base/fluentd/daemonset.yaml
+++ b/platform/base/fluentd/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: fluentd
-          image: fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch8-amd64
+          image: fluent/fluentd-kubernetes-daemonset:v1.19-debian-elasticsearch8-1
           env:
             - name: FLUENT_ELASTICSEARCH_HOST
               value: "opensearch-cluster-master.platform-db.svc.cluster.local"


### PR DESCRIPTION
## Summary
Fixes the fluentd DaemonSet which could not start because the configured image tag does not exist on Docker Hub.

## Root Cause
The tag `v1-debian-elasticsearch8-amd64` is invalid:
- `v1` alone is not a published tag (correct format: `v{major}.{minor}-debian-elasticsearch8-{patch}`)
- `-amd64` suffix is not used in official tags (image is multi-arch)

## Changes
- `platform/base/fluentd/daemonset.yaml`: Updated image tag from `v1-debian-elasticsearch8-amd64` to `v1.19-debian-elasticsearch8-1`

## Acceptance Criteria
- [x] fluentd DaemonSet uses a valid, existing Docker Hub image tag
- [x] Tag supports both amd64 and arm64 architectures

Fixes digiorg/core#218