### PR TITLE
fix(fluentd): switch to opensearch image and plugin

### DIFF
--- a/platform/base/fluentd/configmap.yaml
+++ b/platform/base/fluentd/configmap.yaml
@@ -107,7 +107,7 @@ data:
     # OUTPUT: Forward to OpenSearch (Elasticsearch-compatible API)
     # ============================================================
     <match raw.kubernetes.**>
-      @type elasticsearch
+      @type opensearch
       @id out_opensearch
       host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
       port "#{ENV['FLUENT_ELASTICSEARCH_PORT']}"

--- a/platform/base/fluentd/daemonset.yaml
+++ b/platform/base/fluentd/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: fluentd
-          image: fluent/fluentd-kubernetes-daemonset:v1.19-debian-elasticsearch8-1
+          image: fluent/fluentd-kubernetes-daemonset:v1.19-debian-opensearch-1
           env:
             - name: FLUENT_ELASTICSEARCH_HOST
               value: "opensearch-cluster-master.platform-db.svc.cluster.local"


### PR DESCRIPTION
## Summary
Fixes the fluentd plugin mismatch that caused a startup crash when connecting to OpenSearch.

## Root Cause
The `elasticsearch8` image variant bundles `fluent-plugin-elasticsearch` with the Elasticsearch 8.x Ruby client. This client performs a version check at startup and rejects OpenSearch (which reports a different version) as incompatible, crashing with exit status 2.

## Changes
- `platform/base/fluentd/daemonset.yaml`: Switch image from `v1.19-debian-elasticsearch8-1` to `v1.19-debian-opensearch-1` (includes `fluent-plugin-opensearch` natively)
- `platform/base/fluentd/configmap.yaml`: Change output plugin from `@type elasticsearch` to `@type opensearch`

## Acceptance Criteria
- [x] fluentd uses the OpenSearch-native image variant
- [x] Output plugin is `@type opensearch`
- [x] fluentd starts without errors and ships logs to OpenSearch
- [x] Prometheus metrics endpoint (port 24231) remains functional

Fixes digiorg/core#220