### PR TITLE
fix(fluentd): prevent OpenSearch 400 rejections for dotted Kubernetes labels

### DIFF
--- a/platform/base/fluentd/configmap.yaml
+++ b/platform/base/fluentd/configmap.yaml
@@ -80,6 +80,21 @@ data:
     </filter>
 
     # ============================================================
+    # FILTER: De-dot Kubernetes label keys for OpenSearch compatibility
+    # ============================================================
+    # OpenSearch treats dotted field names as nested object paths.
+    # Kubernetes labels like "app.kubernetes.io/component" conflict with "app"
+    # when both are present. This filter replaces dots and slashes in label
+    # keys with underscores to prevent mapping conflicts.
+    <filter raw.kubernetes.**>
+      @type record_transformer
+      enable_ruby true
+      <record>
+        kubernetes ${if record["kubernetes"]; k = record["kubernetes"].dup; if k["labels"].is_a?(Hash); k["labels"] = k["labels"].map{|key,val| [key.gsub(/[.\/]/, '_'), val]}.to_h; end; if k["namespace_labels"].is_a?(Hash); k["namespace_labels"] = k["namespace_labels"].map{|key,val| [key.gsub(/[.\/]/, '_'), val]}.to_h; end; k; else; record["kubernetes"]; end}
+      </record>
+    </filter>
+
+    # ============================================================
     # FILTER: Prometheus metrics counter per namespace/pod/container
     # ============================================================
     <filter raw.kubernetes.**>
@@ -100,6 +115,11 @@ data:
     # MATCH: Drop kube-system logs (high volume, low app value)
     # ============================================================
     <match raw.kubernetes.var.log.containers.**kube-system**.log>
+      @type null
+    </match>
+
+    # Drop Fluentd's own logs from the logging namespace to prevent feedback loops
+    <match raw.kubernetes.var.log.containers.**_logging_**.log>
       @type null
     </match>
 

--- a/platform/base/opensearch/README.md
+++ b/platform/base/opensearch/README.md
@@ -11,7 +11,8 @@ OpenSearch is an open-source, Apache 2.0-licensed search and analytics engine fo
 | `values.yaml` | OpenSearch Helm Chart values (cluster identity, JVM heap, auth, storage, resource limits). Chart: `opensearch-project/opensearch` v3.6.0, Repo: https://helm.opensearch.org |
 | `servicemonitor.yaml` | Prometheus Operator ServiceMonitor scraping OpenSearch metrics at `/_prometheus/metrics` (port 9200, interval 30s) |
 | `ism-retention-job.yaml` | ArgoCD PostSync Job that bootstraps the `digiorg-logs-retention-7d` ISM policy for 7-day Fluentd log retention. |
-| `kustomization.yaml` | Kustomize entrypoint — manages supplementary resources (ISM bootstrap job). OpenSearch itself is deployed via Helm by the ArgoCD Application (`apps/platform/opensearch.yaml`). Running `kubectl apply -k platform/base/opensearch/` deploys **only supplementary resources**, not OpenSearch itself. |
+| `index-template-job.yaml` | ArgoCD PostSync Job that bootstraps the `digiorg-logs-template` composable index template, mapping `kubernetes.labels` and `kubernetes.namespace_labels` as `flat_object` to prevent dotted-key mapping conflicts. |
+| `kustomization.yaml` | Kustomize entrypoint — manages supplementary resources (ISM bootstrap job, index template bootstrap job). OpenSearch itself is deployed via Helm by the ArgoCD Application (`apps/platform/opensearch.yaml`). Running `kubectl apply -k platform/base/opensearch/` deploys **only supplementary resources**, not OpenSearch itself. |
 
 ## Role in the Platform
 
@@ -163,6 +164,53 @@ kubectl exec -n platform-db opensearch-cluster-master-0 -- \
 # Check ISM policy enforcement on a specific index
 kubectl exec -n platform-db opensearch-cluster-master-0 -- \
   curl -s 'http://localhost:9200/_plugins/_ism/explain/digiorg-logs-*'
+```
+
+### Index Template — `digiorg-logs-template`
+
+An OpenSearch composable index template (`_index_template` API) is bootstrapped automatically by the `opensearch-index-template-bootstrap` ArgoCD PostSync Job defined in `index-template-job.yaml`.
+
+This template solves a mapping conflict caused by Kubernetes label keys containing dots (e.g. `app.kubernetes.io/component`). OpenSearch interprets dotted field names as nested object paths, which conflicts with single-segment keys like `app` that also exist in the labels map.
+
+**Template behaviour:**
+
+| Setting | Value |
+|---------|-------|
+| Template name | `digiorg-logs-template` |
+| Index pattern | `digiorg-logs-*` |
+| Priority | 200 (higher than ISM template at 100) |
+| `kubernetes.labels` mapping | `flat_object` — stores the entire labels map as a single opaque object; no per-key field mapping conflicts |
+| `kubernetes.namespace_labels` mapping | `flat_object` — same rationale |
+| Other `kubernetes.*` fields | `keyword` (namespace_name, pod_name, container_name, host) |
+| `@timestamp` | `date` |
+| `log`, `message` | `text` + `.keyword` sub-field |
+| `dynamic` | `true` — other fields are auto-mapped |
+
+> **Why `flat_object`?** OpenSearch 2.x `flat_object` type stores the entire JSON subtree without expanding each key into a dedicated field. This avoids the mapping conflict where both `kubernetes.labels.app` (string) and `kubernetes.labels.app_kubernetes_io/component` (string) would otherwise compete as sibling document fields. See [OpenSearch flat_object docs](https://docs.opensearch.org/latest/field-types/supported-field-types/flat-object/).
+
+> **Note:** Fluentd's `record_transformer` filter (in `configmap.yaml`) also sanitizes label keys by replacing dots and slashes with underscores before ingest. The `flat_object` mapping provides a second layer of defence for any dotted keys that slip through.
+
+**Bootstrap job behaviour:**
+
+- Runs as an ArgoCD `PostSync` hook after the opensearch application syncs.
+- Idempotent: checks whether the template already exists; skips creation if so.
+- Fails fast if OpenSearch is unreachable so ArgoCD reports degraded status rather than silently continuing.
+- Delete policy: `BeforeHookCreation,HookSucceeded` — cleans up the Job pod after success; removes any stale failed Job before re-creating on the next sync.
+
+**Verify the template was applied:**
+
+```bash
+# Check the index template
+kubectl exec -n platform-db opensearch-cluster-master-0 -- \
+  curl -s 'http://localhost:9200/_index_template/digiorg-logs-template' | python3 -m json.tool
+
+# Confirm flat_object mapping on an existing index
+kubectl exec -n platform-db opensearch-cluster-master-0 -- \
+  curl -s 'http://localhost:9200/digiorg-logs-*/_mapping' | python3 -m json.tool | grep -A2 '"labels"'
+
+# Check bootstrap Job status
+kubectl get job -n platform-db opensearch-index-template-bootstrap
+kubectl logs -n platform-db -l app.kubernetes.io/name=opensearch-index-template-bootstrap
 ```
 
 ## Jaeger Integration

--- a/platform/base/opensearch/index-template-job.yaml
+++ b/platform/base/opensearch/index-template-job.yaml
@@ -1,0 +1,85 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: opensearch-index-template-bootstrap
+  namespace: platform-db
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: opensearch-index-template-bootstrap
+        app.kubernetes.io/part-of: digiorg-core-platform
+        app.kubernetes.io/component: logging
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: index-template-bootstrap
+          image: curlimages/curl:8.10.1
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+
+              OPENSEARCH_URL="http://opensearch-cluster-master.platform-db.svc.cluster.local:9200"
+              TEMPLATE_NAME="digiorg-logs-template"
+
+              echo "Checking OpenSearch connectivity at ${OPENSEARCH_URL} ..."
+              curl -sf "${OPENSEARCH_URL}/_cluster/health" > /dev/null || {
+                echo "ERROR: OpenSearch unreachable at ${OPENSEARCH_URL}" >&2
+                exit 1
+              }
+              echo "OpenSearch is reachable."
+
+              HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+                "${OPENSEARCH_URL}/_index_template/${TEMPLATE_NAME}")
+
+              if [ "${HTTP_STATUS}" = "200" ]; then
+                echo "Index template ${TEMPLATE_NAME} already exists — no action needed."
+                exit 0
+              fi
+
+              echo "Creating index template ${TEMPLATE_NAME} ..."
+              curl -sf -X PUT "${OPENSEARCH_URL}/_index_template/${TEMPLATE_NAME}" \
+                -H 'Content-Type: application/json' \
+                -d '{
+                  "index_patterns": ["digiorg-logs-*"],
+                  "priority": 200,
+                  "template": {
+                    "mappings": {
+                      "dynamic": true,
+                      "properties": {
+                        "@timestamp": { "type": "date" },
+                        "stream": { "type": "keyword" },
+                        "log": {
+                          "type": "text",
+                          "fields": {
+                            "keyword": { "type": "keyword", "ignore_above": 256 }
+                          }
+                        },
+                        "message": {
+                          "type": "text",
+                          "fields": {
+                            "keyword": { "type": "keyword", "ignore_above": 256 }
+                          }
+                        },
+                        "kubernetes": {
+                          "properties": {
+                            "namespace_name": { "type": "keyword" },
+                            "pod_name": { "type": "keyword" },
+                            "container_name": { "type": "keyword" },
+                            "host": { "type": "keyword" },
+                            "labels": { "type": "flat_object" },
+                            "namespace_labels": { "type": "flat_object" }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }'
+
+              echo ""
+              echo "Index template ${TEMPLATE_NAME} created successfully."

--- a/platform/base/opensearch/kustomization.yaml
+++ b/platform/base/opensearch/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: platform-db
 
 resources:
   - ism-retention-job.yaml
+  - index-template-job.yaml
 
 # ServiceMonitor moved to platform/base/monitoring-extras/ (deployed in Wave 5)
 # OpenSearch itself is deployed via Helm by apps/platform/opensearch.yaml


### PR DESCRIPTION
## Summary
Fixes Fluentd OpenSearch 400 rejections caused by Kubernetes label keys containing dots/slashes (e.g. `app.kubernetes.io/component`).

- **platform/base/fluentd/configmap.yaml**: Added drop rule for Fluentd's own logs (prevents feedback loop); added record_transformer filter to de-dot label keys
- **platform/base/opensearch/index-template-job.yaml**: New ArgoCD PostSync Job that bootstraps an OpenSearch index template mapping `kubernetes.labels` and `kubernetes.namespace_labels` as `flat_object` type
- **platform/base/opensearch/kustomization.yaml**: Registered new index template job
- **platform/base/opensearch/README.md**: Documented index template, verification commands

## Test plan
- [ ] Fluentd no longer logs repeated 400 Rejected by OpenSearch warnings
- [ ] Fluentd does not ingest its own container logs from namespace logging
- [ ] Kubernetes labels with dots/slashes do not cause OpenSearch mapping conflicts
- [ ] digiorg-logs-* indices receive a stable mapping/template before first ingest
- [ ] Documentation updated with template verification commands

Fixes digiorg/core#222

🤖 Generated with [Claude Code](https://claude.com/claude-code)