### PR TITLE
feat(opencost): integrate OpenCost cost monitoring with Keycloak SSO

### DIFF
--- a/apps/platform/opencost.yaml
+++ b/apps/platform/opencost.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opencost
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: default
+  sources:
+    - repoURL: https://opencost.github.io/opencost-helm-chart
+      chart: opencost
+      targetRevision: "1.*"
+      helm:
+        releaseName: opencost
+        valueFiles:
+          - $values/platform/base/opencost/values.yaml
+    - repoURL: https://github.com/digiorg/core.git
+      targetRevision: HEAD
+      ref: values
+    - repoURL: https://github.com/digiorg/core.git
+      targetRevision: HEAD
+      path: platform/base/opencost
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cost-monitoring
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/platform/base/ingress/digiorg-ingress.yaml
+++ b/platform/base/ingress/digiorg-ingress.yaml
@@ -85,6 +85,15 @@ spec:
                 name: sonarqube
                 port:
                   number: 9000
+          # OpenCost Cost Monitoring — routed via oauth2-proxy for Keycloak SSO
+          # oauth2-proxy handles /opencost and /opencost/oauth2/callback (proxy-prefix)
+          - path: /opencost(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: opencost-oauth2-proxy
+                port:
+                  number: 4180
           # Landing Page (root path - must be last due to catch-all)
           - path: /
             pathType: Prefix
@@ -251,4 +260,19 @@ spec:
   externalName: landingpage.platform-apps.svc.cluster.local
   ports:
     - port: 8080
-
+---
+# ExternalName Service: routes ingress-nginx → opencost-oauth2-proxy in cost-monitoring namespace
+apiVersion: v1
+kind: Service
+metadata:
+  name: opencost-oauth2-proxy
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: opencost-oauth2-proxy
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  type: ExternalName
+  externalName: opencost-oauth2-proxy.cost-monitoring.svc.cluster.local
+  ports:
+    - port: 4180
+      protocol: TCP

--- a/platform/base/keycloak/digiorg-core-platform-realm.json
+++ b/platform/base/keycloak/digiorg-core-platform-realm.json
@@ -313,6 +313,30 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "opencost",
+      "name": "OpenCost",
+      "description": "OpenCost Cost Monitoring UI — Keycloak SSO via oauth2-proxy",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "opencost-client-secret",
+      "redirectUris": [
+        "https://digiorg.local/opencost/oauth2/callback"
+      ],
+      "webOrigins": [
+        "https://digiorg.local"
+      ],
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "frontchannelLogout": true,
+      "attributes": {
+        "post.logout.redirect.uris": "https://digiorg.local/opencost/*"
+      }
     }
   ],
   "roles": {

--- a/platform/base/landingpage/services-configmap.yaml
+++ b/platform/base/landingpage/services-configmap.yaml
@@ -79,5 +79,15 @@ data:
         "category": "devsecops",
         "requiresAuth": true,
         "displayOrder": 7
+      },
+      {
+        "id": "opencost",
+        "name": "Cloud Costs",
+        "description": "Kubernetes cost monitoring & allocation",
+        "path": "/opencost",
+        "icon": "chart",
+        "category": "monitoring",
+        "requiresAuth": true,
+        "displayOrder": 8
       }
     ]

--- a/platform/base/opencost/kustomization.yaml
+++ b/platform/base/opencost/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - oauth2-proxy.yaml
+  - servicemonitor.yaml

--- a/platform/base/opencost/oauth2-proxy.yaml
+++ b/platform/base/opencost/oauth2-proxy.yaml
@@ -1,0 +1,110 @@
+# =============================================================================
+# oauth2-proxy — Keycloak SSO gateway for OpenCost UI
+#
+# Flow:
+#   Browser → NGINX (/opencost) → oauth2-proxy:4180 → Keycloak OIDC → OpenCost UI
+#
+# The proxy-prefix /opencost/oauth2 scopes the callback within the /opencost sub-path.
+#
+# Secret: opencost-oauth2-proxy-secrets (created by local-setup.nu)
+#   - client-secret  : Keycloak client secret for the "opencost" OIDC client
+#   - cookie-secret  : 32-byte random base64 string for session cookie encryption
+# =============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opencost-oauth2-proxy
+  namespace: cost-monitoring
+  labels:
+    app.kubernetes.io/name: opencost-oauth2-proxy
+    app.kubernetes.io/component: auth-proxy
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opencost-oauth2-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: opencost-oauth2-proxy
+        app.kubernetes.io/component: auth-proxy
+    spec:
+      containers:
+        - name: oauth2-proxy
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+          args:
+            - --provider=oidc
+            - --oidc-issuer-url=https://digiorg.local/keycloak/realms/digiorg-core-platform
+            - --client-id=opencost
+            - --redirect-url=https://digiorg.local/opencost/oauth2/callback
+            - --upstream=http://opencost.cost-monitoring.svc.cluster.local:9090/
+            - --http-address=0.0.0.0:4180
+            # proxy-prefix scopes the OAuth2 callback within the /opencost sub-path
+            - --proxy-prefix=/opencost/oauth2
+            - --cookie-secure=true
+            - --cookie-samesite=lax
+            - --cookie-path=/opencost
+            - --cookie-name=_oauth2_proxy_opencost
+            - --email-domain=*
+            - --skip-provider-button=true
+            - --pass-access-token=false
+            - --pass-authorization-header=false
+            - --set-xauthrequest=false
+            # Skip TLS verification for self-signed cert (local dev only — remove in production)
+            - --ssl-insecure-skip-verify=true
+            - --oidc-extra-audience=opencost
+            # Allow unverified emails for local dev Keycloak test users
+            - --insecure-oidc-allow-unverified-email=true
+          env:
+            - name: OAUTH2_PROXY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: opencost-oauth2-proxy-secrets
+                  key: client-secret
+            - name: OAUTH2_PROXY_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: opencost-oauth2-proxy-secrets
+                  key: cookie-secret
+          ports:
+            - name: http
+              containerPort: 4180
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opencost-oauth2-proxy
+  namespace: cost-monitoring
+  labels:
+    app.kubernetes.io/name: opencost-oauth2-proxy
+    app.kubernetes.io/component: auth-proxy
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: opencost-oauth2-proxy
+  ports:
+    - name: http
+      port: 4180
+      targetPort: http

--- a/platform/base/opencost/servicemonitor.yaml
+++ b/platform/base/opencost/servicemonitor.yaml
@@ -1,0 +1,22 @@
+# =========================================================
+# ServiceMonitor — Prometheus scrapes OpenCost metrics
+# Issue: #224
+# =========================================================
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: opencost
+  namespace: cost-monitoring
+  labels:
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/part-of: digiorg-core-platform
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opencost
+  endpoints:
+    - port: http-api
+      path: /metrics
+      interval: 1m
+      honorLabels: true

--- a/platform/base/opencost/values.yaml
+++ b/platform/base/opencost/values.yaml
@@ -1,0 +1,51 @@
+# =========================================================
+# OpenCost — Helm Values
+# Chart: https://github.com/opencost/opencost-helm-chart
+# Issue: #224
+# =========================================================
+
+clusterName: digiorg-core-dev
+
+opencost:
+  exporter:
+    defaultClusterId: digiorg-core-dev
+    apiPort: 9003
+    extraEnv:
+      PROMETHEUS_SERVER_ENDPOINT: http://prometheus-server.monitoring.svc.cluster.local:80
+    resources:
+      requests:
+        cpu: 10m
+        memory: 55Mi
+      limits:
+        memory: 512Mi
+
+  customPricing:
+    enabled: true
+    provider: custom
+    costModel:
+      description: DigiOrg local dev pricing
+      CPU: 0.031611
+      spotCPU: 0.006655
+      RAM: 0.004237
+      spotRAM: 0.000892
+      storage: 0.00005479452
+      zoneNetworkEgress: 0.01
+      regionNetworkEgress: 0.01
+      internetNetworkEgress: 0.12
+
+  mcp:
+    enabled: true
+    port: 8081
+
+  ui:
+    enabled: true
+
+# Disable built-in ingress — DigiOrg uses unified NGINX ingress
+# oauth-proxy sidecar port registered in service for cross-namespace routing
+service:
+  enabled: true
+  type: ClusterIP
+  extraPorts:
+    - name: oauth-proxy
+      port: 4180
+      targetPort: 4180

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -90,6 +90,7 @@ def "main up" [] {
     print "  ArgoCD:       https://digiorg.local/argocd    (Login via Keycloak)"
     print "  Grafana:      https://digiorg.local/grafana   (Login via Keycloak)"
     print "  Jaeger:       https://digiorg.local/jaeger    (Login via Keycloak)"
+    print "  OpenCost:    https://digiorg.local/opencost  (Login via Keycloak)"
     print ""
     print $"(ansi yellow)Prerequisites:(ansi reset)"
     print $"  1. Add to /etc/hosts: 127.0.0.1 digiorg.local"
@@ -201,7 +202,7 @@ def "main status" [] {
         print $"(ansi cyan_bold)Platform Pods(ansi reset)"
         print "============="
         
-        let namespaces = ["kube-system", "platform-db", "argocd", "keycloak", "messaging", "crossplane-system", "kyverno", "monitoring", "backstage", "gitea", "platform-apps", "cert-manager", "code-quality", "tracing", "external-secrets"]
+        let namespaces = ["kube-system", "platform-db", "argocd", "keycloak", "messaging", "crossplane-system", "kyverno", "monitoring", "backstage", "gitea", "platform-apps", "cert-manager", "code-quality", "tracing", "external-secrets", "cost-monitoring"]
         for ns in $namespaces {
             let status = try {
                 let pods = (kubectl get pods -n $ns --no-headers | lines | length)
@@ -493,6 +494,15 @@ type: kubernetes.io/service-account-token" | save --force $token_secret_file
         --from-literal=cookie-secret=($jaeger_cookie_secret)
         --dry-run=client -o yaml | kubectl apply -f -)
 
+    # cost-monitoring namespace + OpenCost oauth2-proxy secrets
+    kubectl create namespace cost-monitoring --dry-run=client -o yaml | kubectl apply -f -
+    let opencost_oidc_secret = ($env.OPENCOST_OIDC_CLIENT_SECRET? | default "opencost-client-secret")
+    let opencost_cookie_secret = ($env.OPENCOST_COOKIE_SECRET? | default (generate_password | str substring 0..31 | encode base64))
+    (kubectl create secret generic opencost-oauth2-proxy-secrets -n cost-monitoring
+        --from-literal=client-secret=($opencost_oidc_secret)
+        --from-literal=cookie-secret=($opencost_cookie_secret)
+        --dry-run=client -o yaml | kubectl apply -f -)
+
     # OpenSearch secret (admin password for observability backend)
     let opensearch_admin_password = ($env.OPENSEARCH_ADMIN_PASSWORD? | default (generate_password))
     # Secret in platform-db namespace (for OpenSearch itself)
@@ -541,7 +551,7 @@ def deploy_root_app [] {
     print "  Wave -1: root-app (just deployed)"
     print "  Wave  0: cert-manager, external-secrets, postgresql, opensearch, nats"
     print "  Wave  1: keycloak, argocd (self-managed)"
-    print "  Wave  2: landingpage, backstage, gitea, grafana, jaeger, sonarqube"
+    print "  Wave  2: landingpage, backstage, gitea, grafana, jaeger, sonarqube, opencost"
     print "  Wave  3: crossplane, kyverno"
     print "  Wave  4: crossplane-providers"
     print "  Wave  5: monitoring-extras (ServiceMonitors)"
@@ -570,7 +580,7 @@ def wait_for_argocd_apps [] {
         # Wave 1
         "keycloak", "argocd",
         # Wave 2
-        "landingpage", "backstage", "gitea", "grafana", "jaeger", "sonarqube",
+        "landingpage", "backstage", "gitea", "grafana", "jaeger", "sonarqube", "opencost",
         # Wave 3
         "crossplane", "kyverno",
         # Wave 4


### PR DESCRIPTION
## Summary

Integrates OpenCost as a new platform component for Kubernetes cost monitoring and allocation visibility.

## Changes

- `apps/platform/opencost.yaml`: ArgoCD Application (Wave 2, Helm chart `opencost/opencost`, namespace `cost-monitoring`)
- `platform/base/opencost/values.yaml`: Helm values (Prometheus endpoint, custom pricing, MCP, UI)
- `platform/base/opencost/oauth2-proxy.yaml`: oauth2-proxy Deployment + Service (Keycloak OIDC gateway)
- `platform/base/opencost/servicemonitor.yaml`: Prometheus ServiceMonitor for OpenCost metrics
- `platform/base/opencost/kustomization.yaml`: Kustomize manifest list
- `platform/base/ingress/digiorg-ingress.yaml`: Added `/opencost` route + ExternalName Service
- `platform/base/landingpage/services-configmap.yaml`: Added `Cloud Costs` tile (displayOrder 8)
- `platform/base/keycloak/digiorg-core-platform-realm.json`: Added `opencost` OIDC client
- `scripts/local-setup.nu`: Added `cost-monitoring` namespace + `opencost-oauth2-proxy-secrets`

## Acceptance Criteria

- [ ] `cost-monitoring` namespace created by `local-setup.nu`
- [ ] `opencost-oauth2-proxy-secrets` Secret created by `local-setup.nu`
- [ ] `opencost` ArgoCD Application deploys to wave 2, reports Healthy
- [ ] OpenCost UI accessible at `https://digiorg.local/opencost` after Keycloak login
- [ ] Landing Page shows `Cloud Costs` tile (displayOrder 8)
- [ ] Keycloak client `opencost` registered in realm JSON
- [ ] Prometheus scrapes OpenCost metrics via ServiceMonitor

Fixes digiorg/core#224