### PR TITLE
fix(opencost): dedicated ingress for Vite SPA subpath (sub_filter + asset rewrite)

### DIFF
--- a/platform/base/ingress/digiorg-ingress.yaml
+++ b/platform/base/ingress/digiorg-ingress.yaml
@@ -85,15 +85,6 @@ spec:
                 name: sonarqube
                 port:
                   number: 9000
-          # OpenCost Cost Monitoring — routed via oauth2-proxy for Keycloak SSO
-          # oauth2-proxy handles /opencost and /opencost/oauth2/callback (proxy-prefix)
-          - path: /opencost(/|$)(.*)
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: opencost-oauth2-proxy
-                port:
-                  number: 4180
           # Landing Page (root path - must be last due to catch-all)
           - path: /
             pathType: Prefix
@@ -260,19 +251,3 @@ spec:
   externalName: landingpage.platform-apps.svc.cluster.local
   ports:
     - port: 8080
----
-# ExternalName Service: routes ingress-nginx → opencost-oauth2-proxy in cost-monitoring namespace
-apiVersion: v1
-kind: Service
-metadata:
-  name: opencost-oauth2-proxy
-  namespace: ingress-nginx
-  labels:
-    app.kubernetes.io/name: opencost-oauth2-proxy
-    app.kubernetes.io/part-of: digiorg-core-platform
-spec:
-  type: ExternalName
-  externalName: opencost-oauth2-proxy.cost-monitoring.svc.cluster.local
-  ports:
-    - port: 4180
-      protocol: TCP

--- a/platform/base/opencost/kustomization.yaml
+++ b/platform/base/opencost/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - oauth2-proxy.yaml
   - servicemonitor.yaml
+  - opencost-ingress.yaml

--- a/platform/base/opencost/opencost-ingress.yaml
+++ b/platform/base/opencost/opencost-ingress.yaml
@@ -1,0 +1,118 @@
+# =============================================================================
+# OpenCost Dedicated Ingress
+#
+# Two separate Ingress objects are required because rewrite-target and
+# configuration-snippet cannot coexist on the same Ingress path:
+#
+# A) portal-ingress: routes /opencost → oauth2-proxy with sub_filter
+#    The OpenCost Vite UI compiles with base '/' (root-absolute asset paths).
+#    sub_filter rewrites href="/index. and src="/index. in HTML responses
+#    so the browser requests /opencost/index.*.{js,css} instead of /index.*.{js,css}.
+#
+# B) assets-ingress: routes /opencost/(index\..+) → opencost:9090 directly
+#    with rewrite-target: /$1 to strip the /opencost prefix.
+#    Static JS/CSS assets contain no sensitive data.
+#
+# Issue: #229
+# =============================================================================
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: opencost-portal-ingress
+  namespace: ingress-nginx
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
+    cert-manager.io/cluster-issuer: "digiorg-local-ca-issuer"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    # Rewrite root-absolute Vite asset paths in HTML responses.
+    # OpenCost SPA references assets as /index.*.{js,css}.
+    # After rewrite the browser requests /opencost/index.*.{js,css}
+    # which is routed by opencost-assets-ingress (below) to opencost:9090.
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      sub_filter_once off;
+      sub_filter_types text/html;
+      sub_filter 'href="/index.' 'href="/opencost/index.';
+      sub_filter 'src="/index.'  'src="/opencost/index.';
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - digiorg.local
+      secretName: digiorg-local-tls
+  rules:
+    - host: digiorg.local
+      http:
+        paths:
+          - path: /opencost(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: opencost-oauth2-proxy
+                port:
+                  number: 4180
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: opencost-assets-ingress
+  namespace: ingress-nginx
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - digiorg.local
+      secretName: digiorg-local-tls
+  rules:
+    - host: digiorg.local
+      http:
+        paths:
+          - path: /opencost/(index\..+)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: opencost
+                port:
+                  number: 9090
+---
+# ExternalName Service: ingress-nginx → opencost-oauth2-proxy (cost-monitoring ns)
+apiVersion: v1
+kind: Service
+metadata:
+  name: opencost-oauth2-proxy
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: opencost-oauth2-proxy
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  type: ExternalName
+  externalName: opencost-oauth2-proxy.cost-monitoring.svc.cluster.local
+  ports:
+    - port: 4180
+      protocol: TCP
+---
+# ExternalName Service: ingress-nginx → opencost UI service (cost-monitoring ns)
+# Used by assets-ingress to serve /index.*.{js,css} directly without auth proxy.
+apiVersion: v1
+kind: Service
+metadata:
+  name: opencost
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  type: ExternalName
+  externalName: opencost.cost-monitoring.svc.cluster.local
+  ports:
+    - port: 9090
+      protocol: TCP


### PR DESCRIPTION
## Summary

Fixes the blank OpenCost UI page caused by Vite SPA absolute asset paths (Bug 1 of issue #229).

## Root Cause

OpenCost UI is compiled with `base: '/'` — assets in the HTML are referenced as
`/index.*.{js,css}` (root-absolute). When served under `/opencost`, the browser
tries to fetch them from `digiorg.local/` → 404.

## Fix

Two dedicated Ingress objects (split because `rewrite-target` and
`configuration-snippet` cannot coexist on the same Ingress path):

1. **`opencost-portal-ingress`**: routes `/opencost` → oauth2-proxy with
   `configuration-snippet` that runs `sub_filter` on HTML responses, rewriting
   `href="/index.` → `href="/opencost/index.` and `src="/index.` → `src="/opencost/index.`

2. **`opencost-assets-ingress`**: routes `/opencost/(index\..+)` → opencost:9090
   directly with `rewrite-target: /$1`, stripping the prefix so opencost serves
   `/index.abc.js` correctly.

The `/opencost` path + `opencost-oauth2-proxy` ExternalName Service are removed from
`digiorg-ingress.yaml` (moved to the dedicated file).

## Changes

| File | Change |
|------|--------|
| `platform/base/opencost/opencost-ingress.yaml` | New: portal + assets Ingress + 2 ExternalName Services |
| `platform/base/ingress/digiorg-ingress.yaml` | Remove /opencost path rule + ExternalName Service |
| `platform/base/opencost/kustomization.yaml` | Add opencost-ingress.yaml to resources |

## Acceptance Criteria

- [ ] `https://digiorg.local/opencost` loads the OpenCost React UI (no blank page)
- [ ] CSS and JS assets load from `/opencost/index.*.{js,css}` (no 404s)
- [ ] Keycloak auth flow works (redirect → callback → back to OpenCost UI)

Fixes digiorg/core#229 (Bug 1) | Related: digiorg/core#224