### PR TITLE
fix(opencost): replace configuration-snippet with dedicated nginx ui-proxy

### DIFF
--- a/platform/base/ingress/opencost-portal-ingress.yaml
+++ b/platform/base/ingress/opencost-portal-ingress.yaml
@@ -1,17 +1,15 @@
 # =============================================================================
-# OpenCost Portal Ingress (with sub_filter for Vite SPA subpath fix)
+# OpenCost Portal Ingress
 #
-# Replaces the /opencost route in the main digiorg-platform Ingress.
-# A dedicated Ingress is required to scope the configuration-snippet
-# (sub_filter) only to the /opencost location without affecting other routes.
+# Routes /opencost → oauth2-proxy → opencost-ui-proxy (nginx, port 9091).
+# The ui-proxy handles HTML sub_filter rewriting internally (at nginx level)
+# because configuration-snippet is disabled on this NGINX Ingress Controller.
 #
-# The OpenCost Vite SPA compiles with base '/' (root-absolute asset paths).
-# sub_filter rewrites href="/index. and src="/index. in HTML responses so the
-# browser requests /opencost/index.*.{js,css} instead of /index.*.{js,css}.
-# Those requests are then served by opencost-assets-ingress (strip prefix).
+# Asset requests (/opencost/index.*.{js,css}) are handled separately by
+# opencost-assets-ingress (rewrite-target: /$1 → directly to opencost:9090).
 #
 # Boot: applied by local-setup.nu bootstrap (not managed by ArgoCD).
-# Issue: #229 #231
+# Issue: #229 #231 #233
 # =============================================================================
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -25,14 +23,6 @@ metadata:
     cert-manager.io/cluster-issuer: "digiorg-local-ca-issuer"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    # Rewrite root-absolute Vite asset paths in HTML responses.
-    # After rewrite the browser requests /opencost/index.*.{js,css},
-    # handled by opencost-assets-ingress → opencost:9090.
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      sub_filter_once off;
-      sub_filter_types text/html;
-      sub_filter 'href="/index.' 'href="/opencost/index.';
-      sub_filter 'src="/index.'  'src="/opencost/index.';
 spec:
   ingressClassName: nginx
   tls:

--- a/platform/base/opencost/kustomization.yaml
+++ b/platform/base/opencost/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 resources:
   - oauth2-proxy.yaml
   - servicemonitor.yaml
-  # NOTE: Ingress resources for OpenCost are in platform/base/ingress/
-  # (opencost-portal-ingress.yaml, opencost-assets-ingress.yaml)
-  # and are applied during cluster bootstrap by local-setup.nu.
-  # Do NOT add ingress-nginx resources here — this kustomization is
-  # managed by the ArgoCD 'opencost' Application (namespace: cost-monitoring).
+  - ui-proxy.yaml
+  # NOTE: Ingress resources (opencost-portal-ingress, opencost-assets-ingress)
+  # are in platform/base/ingress/ and applied during bootstrap by local-setup.nu.
+  # Do NOT add ingress-nginx resources here — this kustomization is managed by
+  # the ArgoCD 'opencost' Application (destination.namespace: cost-monitoring).

--- a/platform/base/opencost/oauth2-proxy.yaml
+++ b/platform/base/opencost/oauth2-proxy.yaml
@@ -38,7 +38,10 @@ spec:
             - --oidc-issuer-url=https://digiorg.local/keycloak/realms/digiorg-core-platform
             - --client-id=opencost
             - --redirect-url=https://digiorg.local/opencost/oauth2/callback
-            - --upstream=http://opencost.cost-monitoring.svc.cluster.local:9090/
+            # Upstream points to the ui-proxy (not directly to opencost) so that
+            # HTML responses get the Vite asset path rewritten at the nginx level
+            # (configuration-snippet is disabled on the Ingress Controller).
+            - --upstream=http://opencost-ui-proxy.cost-monitoring.svc.cluster.local:9091/
             - --http-address=0.0.0.0:4180
             # proxy-prefix scopes the OAuth2 callback within the /opencost sub-path
             - --proxy-prefix=/opencost/oauth2

--- a/platform/base/opencost/ui-proxy.yaml
+++ b/platform/base/opencost/ui-proxy.yaml
@@ -1,0 +1,167 @@
+# =============================================================================
+# OpenCost UI Proxy
+#
+# Lightweight nginx reverse proxy that rewrites the OpenCost Vite SPA HTML
+# responses at the application level, avoiding the NGINX Ingress Controller's
+# configuration-snippet restriction (snippet annotations are disabled for
+# security reasons on this cluster).
+#
+# Responsibilities:
+#   1. Strip the /opencost prefix when forwarding to opencost:9090
+#      (standard nginx proxy_pass with trailing / on location and upstream)
+#   2. Apply sub_filter to HTML responses:
+#        href="/index.  →  href="/opencost/index.
+#        src="/index.   →  src="/opencost/index.
+#      This ensures the Vite SPA's root-absolute asset paths are rewritten
+#      to the /opencost/ subpath so the browser fetches them correctly.
+#   3. Disable upstream gzip so sub_filter can operate on uncompressed HTML.
+#
+# The oauth2-proxy --upstream points to this service (port 9091).
+# Static assets (/opencost/index.*.{js,css}) bypass this proxy entirely and
+# are served directly by opencost:9090 via the opencost-assets-ingress
+# (rewrite-target: /$1 strips the /opencost prefix at the NGINX ingress level).
+#
+# Issue: #233
+# =============================================================================
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opencost-ui-proxy-config
+  namespace: cost-monitoring
+  labels:
+    app.kubernetes.io/name: opencost-ui-proxy
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/part-of: digiorg-core-platform
+data:
+  nginx.conf: |
+    worker_processes  1;
+    error_log /dev/stderr warn;
+    pid /tmp/nginx.pid;
+
+    events {
+      worker_connections 64;
+    }
+
+    http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+      access_log    /dev/stdout;
+
+      # Required temp dirs for non-root nginx
+      client_body_temp_path /tmp/client_body;
+      proxy_temp_path       /tmp/proxy;
+      fastcgi_temp_path     /tmp/fastcgi;
+      uwsgi_temp_path       /tmp/uwsgi;
+      scgi_temp_path        /tmp/scgi;
+
+      server {
+        listen 9091;
+        server_name _;
+
+        # Proxy to OpenCost UI: strip /opencost prefix + rewrite HTML asset paths.
+        # proxy_pass with trailing / on both location and upstream strips the prefix:
+        #   GET /opencost/      → GET /      at opencost:9090
+        #   GET /opencost/foo   → GET /foo   at opencost:9090
+        location /opencost/ {
+          proxy_pass         http://opencost.cost-monitoring.svc.cluster.local:9090/;
+          proxy_http_version 1.1;
+          proxy_set_header   Host              $host;
+          proxy_set_header   X-Real-IP         $remote_addr;
+          proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+          proxy_set_header   X-Forwarded-Proto $scheme;
+
+          # Disable upstream compression so sub_filter can work on plain HTML
+          proxy_set_header   Accept-Encoding   "";
+
+          # Rewrite root-absolute Vite SPA asset paths to /opencost/ prefix
+          # OpenCost UI compiles with base '/' — assets referenced as /index.*.{js,css}
+          sub_filter_once off;
+          sub_filter_types  text/html;
+          sub_filter 'href="/index.' 'href="/opencost/index.';
+          sub_filter 'src="/index.'  'src="/opencost/index.';
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opencost-ui-proxy
+  namespace: cost-monitoring
+  labels:
+    app.kubernetes.io/name: opencost-ui-proxy
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opencost-ui-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: opencost-ui-proxy
+        app.kubernetes.io/component: proxy
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - name: http
+              containerPort: 9091
+              protocol: TCP
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          livenessProbe:
+            httpGet:
+              path: /opencost/
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /opencost/
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 101
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: opencost-ui-proxy-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opencost-ui-proxy
+  namespace: cost-monitoring
+  labels:
+    app.kubernetes.io/name: opencost-ui-proxy
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: opencost-ui-proxy
+  ports:
+    - name: http
+      port: 9091
+      targetPort: http
+      protocol: TCP


### PR DESCRIPTION
## Summary

Fixes the admission webhook rejection of `configuration-snippet` annotation
(Issue #233). The NGINX Ingress Controller has snippet annotations globally
disabled (`allow-snippet-annotations: false`).

## Root Cause

The `sub_filter` directives in `opencost-portal-ingress.yaml` require
`nginx.ingress.kubernetes.io/configuration-snippet`, which is blocked by the
Ingress Controller's admission webhook. The Vite SPA HTML rewriting cannot
happen at the Ingress level.

## Fix: `opencost-ui-proxy` nginx pod in `cost-monitoring`

Deploy a lightweight nginx reverse proxy that applies the HTML rewriting
internally, without relying on any Ingress Controller annotations:

```
Browser → /opencost/
  → portal-ingress (no snippet) → oauth2-proxy → opencost-ui-proxy:9091
  → nginx strips /opencost prefix → opencost:9090/
  → sub_filter: href="/index. → href="/opencost/index.
  → browser gets correct asset URLs

Browser → /opencost/index.abc.js
  → assets-ingress (rewrite-target: /$1) → opencost:9090/index.abc.js ✅
```

## Changes

| File | Change |
|------|--------|
| `platform/base/opencost/ui-proxy.yaml` | **New**: ConfigMap (nginx.conf) + Deployment + Service |
| `platform/base/opencost/oauth2-proxy.yaml` | `--upstream` → `opencost-ui-proxy:9091` |
| `platform/base/opencost/kustomization.yaml` | Add `ui-proxy.yaml` |
| `platform/base/ingress/opencost-portal-ingress.yaml` | Remove `configuration-snippet` annotation |

## Acceptance Criteria

- [ ] `kubectl kustomize platform/base/ingress | kubectl apply` succeeds (no admission webhook rejection)
- [ ] `opencost-ui-proxy` pod Running in `cost-monitoring`
- [ ] `https://digiorg.local/opencost` loads OpenCost React UI (no blank page)
- [ ] Assets load from `/opencost/index.*.{js,css}` (no 404s)
- [ ] Keycloak auth flow works

Fixes digiorg/core#233 | Related: digiorg/core#229 digiorg/core#231
