### PR TITLE
fix(opencost): healthz probe + remove mime.types from ui-proxy nginx

### DIFF
--- a/platform/base/opencost/ui-proxy.yaml
+++ b/platform/base/opencost/ui-proxy.yaml
@@ -44,7 +44,9 @@ data:
     }
 
     http {
-      include       /etc/nginx/mime.types;
+      # No mime.types include needed for a pure reverse-proxy:
+      # Content-Type is determined by upstream response headers, not nginx.
+      # Including mime.types caused a duplicate 'text/html' warning on nginx:alpine.
       default_type  application/octet-stream;
       access_log    /dev/stdout;
 
@@ -63,6 +65,15 @@ data:
         # proxy_pass with trailing / on both location and upstream strips the prefix:
         #   GET /opencost/      → GET /      at opencost:9090
         #   GET /opencost/foo   → GET /foo   at opencost:9090
+        # Health endpoint: checks nginx is alive WITHOUT touching the upstream.
+        # Used by liveness + readiness probes so a slow-starting opencost pod
+        # (1-3 min for Prometheus init) does not cause CrashLoopBackOff.
+        location /healthz {
+          access_log off;
+          return 200 "ok";
+          add_header Content-Type text/plain;
+        }
+
         location /opencost/ {
           proxy_pass         http://opencost.cost-monitoring.svc.cluster.local:9090/;
           proxy_http_version 1.1;
@@ -124,17 +135,20 @@ spec:
               memory: 64Mi
           livenessProbe:
             httpGet:
-              path: /opencost/
+              # /healthz returns 200 from nginx itself — no upstream dependency.
+              # Avoids CrashLoopBackOff while opencost is still starting up.
+              path: /healthz
               port: http
-            initialDelaySeconds: 5
+            initialDelaySeconds: 3
             periodSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /opencost/
+              path: /healthz
               port: http
-            initialDelaySeconds: 3
+            initialDelaySeconds: 2
             periodSeconds: 5
+            failureThreshold: 3
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true


### PR DESCRIPTION
## Summary

Fixes two bugs in `opencost-ui-proxy` that cause CrashLoopBackOff and block ArgoCD wave 2 (Issue #235).

## Bug 1 — Liveness probe depends on upstream → CrashLoopBackOff

The liveness/readiness probes checked `GET /opencost/`, which nginx proxies to `opencost:9090`. During fresh deployment, opencost takes 1–3 min to initialize. Until then: connection refused → 502 → liveness fails → pod restarts → CrashLoopBackOff → wave 2 blocked.

**Fix:** Added `location /healthz { return 200 "ok"; }` to nginx.conf. Both probes now use `/healthz` — checks nginx process only, no upstream dependency. The proxy stays `Running 1/1` while opencost initializes.

## Bug 2 — Duplicate MIME type warning

`include /etc/nginx/mime.types;` in a pure reverse-proxy config caused a `duplicate MIME type "text/html"` warning on `nginx:1.27-alpine`.

**Fix:** Removed the include. Content-Type for proxied responses comes from the upstream headers, not from nginx mime.types.

## Changes

`platform/base/opencost/ui-proxy.yaml`:
- nginx.conf: removed `include /etc/nginx/mime.types;`
- nginx.conf: added `location /healthz { return 200 "ok"; }`
- Deployment: `livenessProbe.httpGet.path` → `/healthz`
- Deployment: `readinessProbe.httpGet.path` → `/healthz`

## Acceptance Criteria

- [ ] `opencost-ui-proxy` reaches `Running 1/1` immediately on deploy
- [ ] No `duplicate MIME type` warning in logs
- [ ] No 502 liveness failures in logs
- [ ] ArgoCD `opencost` Application reaches `Synced+Healthy`
- [ ] `https://digiorg.local/opencost` serves the OpenCost UI correctly

Fixes digiorg/core#235 | Related: digiorg/core#233