### PR TITLE
fix(opencost): proxy_redirect in ui-proxy — prevent port 9091 leaking to browser

### DIFF
--- a/platform/base/opencost/ui-proxy.yaml
+++ b/platform/base/opencost/ui-proxy.yaml
@@ -85,6 +85,15 @@ data:
           # Disable upstream compression so sub_filter can work on plain HTML
           proxy_set_header   Accept-Encoding   "";
 
+          # Prevent nginx default proxy_redirect from rewriting Location headers
+          # with the internal listen port (9091), which would produce
+          # "http://digiorg.local:9091/opencost/" in browser redirects.
+          # The explicit rule below correctly rewrites any upstream-absolute
+          # redirect to the public HTTPS URL instead.
+          proxy_redirect off;
+          proxy_redirect http://opencost.cost-monitoring.svc.cluster.local:9090/
+                         https://digiorg.local/opencost/;
+
           # Rewrite root-absolute Vite SPA asset paths to /opencost/ prefix
           # OpenCost UI compiles with base '/' — assets referenced as /index.*.{js,css}
           sub_filter_once off;


### PR DESCRIPTION
## Summary

Fixes the CORS/navigation error when clicking the OpenCost tile (Issue #237).

## Root Cause

nginx `proxy_redirect default` rewrites upstream `Location` headers using
the nginx listen port (`9091`) and the `Host` header (`digiorg.local`):
`Location: http://opencost:9090/` → `Location: http://digiorg.local:9091/opencost/`

The browser receives this redirect, tries `http://digiorg.local:9091` (internal, unreachable) and shows the CORS frame error.

## Fix

Two `proxy_redirect` directives in the `location /opencost/` block:

| Directive | Purpose |
|-----------|---------|
| `proxy_redirect off;` | Disables the default port-leaking rewrite |
| `proxy_redirect http://opencost:9090/ https://digiorg.local/opencost/;` | Rewrites upstream-absolute redirects to the correct public HTTPS URL |

## Change

**`platform/base/opencost/ui-proxy.yaml`** — nginx.conf ConfigMap: 2 lines added in `location /opencost/`

## Acceptance Criteria

- [ ] Clicking OpenCost tile navigates to `https://digiorg.local/opencost/`
- [ ] No port 9091 visible in browser DevTools network tab
- [ ] No CORS/frame error
- [ ] OpenCost React UI loads

Fixes digiorg/core#237 | Related: digiorg/core#233 digiorg/core#235