### PR TITLE
fix(opencost): remove duplicate proxy_redirect off — crashes nginx on startup

### DIFF
--- a/platform/base/opencost/ui-proxy.yaml
+++ b/platform/base/opencost/ui-proxy.yaml
@@ -85,12 +85,10 @@ data:
           # Disable upstream compression so sub_filter can work on plain HTML
           proxy_set_header   Accept-Encoding   "";
 
-          # Prevent nginx default proxy_redirect from rewriting Location headers
-          # with the internal listen port (9091), which would produce
-          # "http://digiorg.local:9091/opencost/" in browser redirects.
-          # The explicit rule below correctly rewrites any upstream-absolute
-          # redirect to the public HTTPS URL instead.
-          proxy_redirect off;
+          # Rewrite upstream-absolute Location headers to the public HTTPS URL.
+          # An explicit proxy_redirect rule implicitly disables the nginx default
+          # rewriting (which would leak the internal port 9091). Do NOT combine
+          # with 'proxy_redirect off;' — that causes a duplicate-directive crash.
           proxy_redirect http://opencost.cost-monitoring.svc.cluster.local:9090/
                          https://digiorg.local/opencost/;
 


### PR DESCRIPTION
## Summary

Fixes CrashLoopBackOff of `opencost-ui-proxy` caused by an invalid nginx config (Issue #239).

## Root Cause

PR #238 introduced `proxy_redirect off;` followed by an explicit `proxy_redirect` rule in the same `location` block. nginx does not allow this combination — `off` disables all `proxy_redirect` processing in the block, making any subsequent rule a duplicate:

```
[emerg] "proxy_redirect" directive is duplicate in /etc/nginx/nginx.conf:58
```

## Fix

Remove `proxy_redirect off;`. An explicit rule already suppresses the default rewriting behaviour — no `off` needed.

## Change

**`platform/base/opencost/ui-proxy.yaml`** — 1 line removed from nginx.conf ConfigMap.

## Acceptance Criteria

- [ ] `opencost-ui-proxy` starts without crash
- [ ] `https://digiorg.local/opencost/` reachable — no port 9091 redirect

Fixes digiorg/core#239 | Related: digiorg/core#237