### PR TITLE
fix(opencost): prevent ui-proxy port leak on bare path redirect

### DIFF
--- a/platform/base/opencost/ui-proxy.yaml
+++ b/platform/base/opencost/ui-proxy.yaml
@@ -74,6 +74,29 @@ data:
           add_header Content-Type text/plain;
         }
 
+        # Exact match for the bare /opencost path (no trailing slash).
+        # Without this, nginx auto-redirects /opencost → /opencost/ using an
+        # absolute Location that includes the internal port 9091 (non-standard,
+        # so nginx appends it). oauth2-proxy forwards that Location as-is, leaking
+        # http://digiorg.local:9091/opencost/ to the browser which can't reach it.
+        # This block proxies the root directly — no redirect, no port leak.
+        # Issue: #241
+        location = /opencost {
+          proxy_pass         http://opencost.cost-monitoring.svc.cluster.local:9090/;
+          proxy_http_version 1.1;
+          proxy_set_header   Host              $host;
+          proxy_set_header   X-Real-IP         $remote_addr;
+          proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+          proxy_set_header   X-Forwarded-Proto $scheme;
+          proxy_set_header   Accept-Encoding   "";
+          proxy_redirect http://opencost.cost-monitoring.svc.cluster.local:9090/
+                         https://digiorg.local/opencost/;
+          sub_filter_once off;
+          sub_filter_types  text/html;
+          sub_filter 'href="/index.' 'href="/opencost/index.';
+          sub_filter 'src="/index.'  'src="/opencost/index.';
+        }
+
         location /opencost/ {
           proxy_pass         http://opencost.cost-monitoring.svc.cluster.local:9090/;
           proxy_http_version 1.1;


### PR DESCRIPTION
## Summary

- Adds `location = /opencost` exact-match block to the ui-proxy nginx config so bare `/opencost` requests are proxied directly to opencost:9090 instead of triggering nginx's automatic trailing-slash redirect.

## Root Cause

nginx only had `location /opencost/ { ... }` (trailing slash). A request to `/opencost` (no trailing slash) matched no exact location, causing nginx to issue its built-in 301 redirect to append the slash. Because nginx listens on non-standard port 9091, it constructs an absolute `Location: http://digiorg.local:9091/opencost/` header. oauth2-proxy proxies this 3xx response unmodified to the browser, which then tries to reach port 9091 — unreachable externally.

## Changes

- `platform/base/opencost/ui-proxy.yaml`: Add `location = /opencost` block that proxies `GET /opencost` directly to `opencost.cost-monitoring.svc.cluster.local:9090/`, applying the same `sub_filter` HTML rewriting and `proxy_redirect` rules as the existing `/opencost/` block. No redirect is issued, so no internal port is ever sent to the browser.

## Validation

- Python `yaml.safe_load_all` confirms all files in `platform/base/opencost/` are valid YAML.
- `location = /opencost` (exact match) takes precedence over `location /opencost/` (prefix), so `/opencost/` traffic is unaffected.
- The `proxy_redirect` rule in the new block reuses the same pattern as the existing block, covering any redirects that opencost:9090 may itself emit.

Fixes #241