### PR TITLE
fix(opencost): set BASE_URL_OVERRIDE for subpath API routing

### DIFF
--- a/platform/base/ingress/opencost-assets-ingress.yaml
+++ b/platform/base/ingress/opencost-assets-ingress.yaml
@@ -34,9 +34,9 @@ spec:
     - host: digiorg.local
       http:
         paths:
-          # Routes /opencost/index.*.{js,css} → opencost:9090 at /index.*.{js,css}
+          # Routes /opencost/index.*.{js,css} and /opencost/favicon.* → opencost:9090
           # Static assets contain no sensitive data — bypass auth proxy intentionally.
-          - path: /opencost/(index\..+)
+          - path: /opencost/((?:index|favicon)\..+)
             pathType: ImplementationSpecific
             backend:
               service:

--- a/platform/base/opencost/ui-proxy.yaml
+++ b/platform/base/opencost/ui-proxy.yaml
@@ -95,6 +95,7 @@ data:
           sub_filter_types  text/html;
           sub_filter 'href="/index.' 'href="/opencost/index.';
           sub_filter 'src="/index.'  'src="/opencost/index.';
+          sub_filter 'href="/favicon.' 'href="/opencost/favicon.';
         }
 
         location /opencost/ {
@@ -121,6 +122,7 @@ data:
           sub_filter_types  text/html;
           sub_filter 'href="/index.' 'href="/opencost/index.';
           sub_filter 'src="/index.'  'src="/opencost/index.';
+          sub_filter 'href="/favicon.' 'href="/opencost/favicon.';
         }
       }
     }

--- a/platform/base/opencost/values.yaml
+++ b/platform/base/opencost/values.yaml
@@ -47,6 +47,9 @@ opencost:
 
   ui:
     enabled: true
+    extraEnv:
+      - name: BASE_URL_OVERRIDE
+        value: /opencost/model
 
 # Disable built-in ingress — DigiOrg uses unified NGINX ingress
 # oauth-proxy sidecar port registered in service for cross-namespace routing


### PR DESCRIPTION
## Summary

Sets `BASE_URL_OVERRIDE=/opencost/model` on the OpenCost UI container so that JavaScript API calls use the correct subpath-aware URL instead of root-absolute `/model/...`.

Also fixes the favicon 404 by adding a sub_filter rule and expanding the assets ingress regex.

## Changes

- `platform/base/opencost/values.yaml`: Add `extraEnv` with `BASE_URL_OVERRIDE=/opencost/model` to `opencost.ui`
- `platform/base/opencost/ui-proxy.yaml`: Add `sub_filter` for favicon path rewriting
- `platform/base/ingress/opencost-assets-ingress.yaml`: Expand regex to include `favicon.*` files

## How it works

1. `BASE_URL_OVERRIDE` overrides the API base URL in JS files at container startup (via `docker-entrypoint.sh`)
2. JS now calls `/opencost/model/...` instead of `/model/...`
3. Portal ingress matches → oauth2-proxy → ui-proxy strips `/opencost/` → `/model/...` at opencost:9090 → API proxy
4. JSON data returned correctly → SPA renders

## Acceptance Criteria

- [x] `BASE_URL_OVERRIDE=/opencost/model` set on UI container
- [x] Favicon sub_filter added to ui-proxy
- [x] Assets ingress regex expanded for favicon

Fixes digiorg/core#243