### PR TITLE
fix(opencost): use explicit Prometheus URL to avoid clusterName DNS conflict

### DIFF
--- a/platform/base/opencost/values.yaml
+++ b/platform/base/opencost/values.yaml
@@ -10,12 +10,13 @@ opencost:
   # -- Prometheus configuration (chart resolves PROMETHEUS_SERVER_ENDPOINT from here;
   #    do NOT also set it in exporter.extraEnv — that causes a duplicate env var error)
   prometheus:
+    # Use external URL with explicit cluster.local suffix — the Helm chart builds the
+    # internal URL as svc.<clusterName>, which resolves to svc.digiorg-core-dev (invalid DNS).
     internal:
+      enabled: false
+    external:
       enabled: true
-      serviceName: prometheus-server
-      namespaceName: monitoring
-      port: 80
-      scheme: http
+      url: "http://prometheus-server.monitoring.svc.cluster.local:80"
 
   exporter:
     defaultClusterId: digiorg-core-dev


### PR DESCRIPTION
## Summary

Switches from `prometheus.internal` to `prometheus.external` with an explicit `cluster.local` URL, fixing the DNS lookup failure caused by the Helm chart using `clusterName` (`digiorg-core-dev`) as the DNS suffix.

## Problem

The OpenCost Helm chart helper `opencost.prometheusServerEndpoint` constructs the Prometheus URL as:
```
{{ scheme }}://{{ serviceName }}.{{ namespaceName }}.svc.{{ clusterName }}:{{ port }}
```

With `clusterName: digiorg-core-dev`, this produces:
```
http://prometheus-server.monitoring.svc.digiorg-core-dev:80  ❌ no such host
```

## Fix

Use `prometheus.external` with the correct FQDN:
```
http://prometheus-server.monitoring.svc.cluster.local:80  ✅
```

## Changes

- `platform/base/opencost/values.yaml`: Replace `prometheus.internal` with `prometheus.external` using explicit URL

Fixes digiorg/core#245