### PR TITLE
feat(harbor): integrate Harbor OCI registry with ui-proxy, shared PostgreSQL, and Keycloak OIDC

### DIFF
--- a/apps/platform/harbor.yaml
+++ b/apps/platform/harbor.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: harbor
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: default
+  sources:
+    - repoURL: https://helm.goharbor.io
+      chart: harbor
+      targetRevision: "1.*"
+      helm:
+        releaseName: harbor
+        valueFiles:
+          - $values/platform/base/harbor/values.yaml
+    - repoURL: https://github.com/digiorg/core.git
+      targetRevision: HEAD
+      ref: values
+    - repoURL: https://github.com/digiorg/core.git
+      targetRevision: HEAD
+      path: platform/base/harbor
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: harbor
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/platform/base/harbor/harbor-ui-proxy.yaml
+++ b/platform/base/harbor/harbor-ui-proxy.yaml
@@ -1,0 +1,194 @@
+# =============================================================================
+# Harbor UI Proxy
+#
+# Lightweight nginx reverse proxy that rewrites the Harbor Angular SPA HTML
+# responses at the application level, avoiding the NGINX Ingress Controller's
+# configuration-snippet restriction (snippet annotations are disabled for
+# security reasons on this cluster).
+#
+# Responsibilities:
+#   1. Strip the /harbor prefix when forwarding to harbor:80
+#      (standard nginx proxy_pass with trailing / on location and upstream)
+#   2. Apply sub_filter to HTML responses:
+#        <base href="/">  →  <base href="/harbor/">
+#      This ensures the Angular SPA's root-absolute asset paths are rewritten
+#      to the /harbor/ subpath so the browser fetches them correctly.
+#   3. Disable upstream gzip so sub_filter can operate on uncompressed HTML.
+#
+# Issue: #225
+# =============================================================================
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: harbor-ui-proxy-config
+  namespace: harbor
+  labels:
+    app.kubernetes.io/name: harbor-ui-proxy
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/part-of: digiorg-core-platform
+data:
+  nginx.conf: |
+    worker_processes  1;
+    error_log /dev/stderr warn;
+    pid /tmp/nginx.pid;
+
+    events {
+      worker_connections 64;
+    }
+
+    http {
+      # No mime.types include needed for a pure reverse-proxy:
+      # Content-Type is determined by upstream response headers, not nginx.
+      # Including mime.types caused a duplicate 'text/html' warning on nginx:alpine.
+      default_type  application/octet-stream;
+      access_log    /dev/stdout;
+
+      # Required temp dirs for non-root nginx
+      client_body_temp_path /tmp/client_body;
+      proxy_temp_path       /tmp/proxy;
+      fastcgi_temp_path     /tmp/fastcgi;
+      uwsgi_temp_path       /tmp/uwsgi;
+      scgi_temp_path        /tmp/scgi;
+
+      server {
+        listen 9091;
+        server_name _;
+
+        # Health endpoint: checks nginx is alive WITHOUT touching the upstream.
+        # Used by liveness + readiness probes independent of Harbor's state.
+        location /healthz {
+          access_log off;
+          return 200 "ok";
+          add_header Content-Type text/plain;
+        }
+
+        # Exact match for the bare /harbor path (no trailing slash).
+        # Without this, nginx auto-redirects /harbor → /harbor/ using an
+        # absolute Location that includes the internal port 9091 (non-standard,
+        # so nginx appends it). This block proxies the root directly — no redirect,
+        # no port leak.
+        # Issue: #225
+        location = /harbor {
+          proxy_pass         http://harbor.harbor.svc.cluster.local:80/;
+          proxy_http_version 1.1;
+          proxy_set_header   Host              $host;
+          proxy_set_header   X-Real-IP         $remote_addr;
+          proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+          proxy_set_header   X-Forwarded-Proto $scheme;
+          proxy_set_header   Accept-Encoding   "";
+          proxy_redirect http://harbor.harbor.svc.cluster.local:80/
+                         https://digiorg.local/harbor/;
+          sub_filter_once off;
+          sub_filter_types  text/html;
+          sub_filter '<base href="/">' '<base href="/harbor/">';
+        }
+
+        location /harbor/ {
+          proxy_pass         http://harbor.harbor.svc.cluster.local:80/;
+          proxy_http_version 1.1;
+          proxy_set_header   Host              $host;
+          proxy_set_header   X-Real-IP         $remote_addr;
+          proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+          proxy_set_header   X-Forwarded-Proto $scheme;
+
+          # Disable upstream compression so sub_filter can work on plain HTML
+          proxy_set_header   Accept-Encoding   "";
+
+          # Rewrite upstream-absolute Location headers to the public HTTPS URL.
+          # An explicit proxy_redirect rule implicitly disables the nginx default
+          # rewriting (which would leak the internal port 9091). Do NOT combine
+          # with 'proxy_redirect off;' — that causes a duplicate-directive crash.
+          proxy_redirect http://harbor.harbor.svc.cluster.local:80/
+                         https://digiorg.local/harbor/;
+
+          # Rewrite Angular SPA base href for subpath deployment
+          sub_filter_once off;
+          sub_filter_types  text/html;
+          sub_filter '<base href="/">' '<base href="/harbor/">';
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: harbor-ui-proxy
+  namespace: harbor
+  labels:
+    app.kubernetes.io/name: harbor-ui-proxy
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: harbor-ui-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: harbor-ui-proxy
+        app.kubernetes.io/component: proxy
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - name: http
+              containerPort: 9091
+              protocol: TCP
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 101
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: harbor-ui-proxy-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: harbor-ui-proxy
+  namespace: harbor
+  labels:
+    app.kubernetes.io/name: harbor-ui-proxy
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: harbor-ui-proxy
+  ports:
+    - name: http
+      port: 9091
+      targetPort: http
+      protocol: TCP

--- a/platform/base/harbor/kustomization.yaml
+++ b/platform/base/harbor/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - harbor-ui-proxy.yaml

--- a/platform/base/harbor/values.yaml
+++ b/platform/base/harbor/values.yaml
@@ -1,0 +1,73 @@
+expose:
+  type: clusterIP
+  tls:
+    enabled: false
+  clusterIP:
+    name: harbor
+    ports:
+      httpPort: 80
+      httpsPort: 443
+
+# Docker CLI uses this as the registry hostname
+# externalURL must be the root domain (not a subpath) — Harbor requirement
+externalURL: https://digiorg.local
+
+existingSecretAdminPassword: harbor-admin-secret
+existingSecretAdminPasswordKey: HARBOR_ADMIN_PASSWORD
+existingSecretSecretKey: harbor-secret-key
+
+# External PostgreSQL — reuse platform shared instance (platform-db namespace)
+# Harbor's built-in PostgreSQL disabled to reduce resource usage
+database:
+  type: external
+  external:
+    host: postgresql.platform-db.svc.cluster.local
+    port: "5432"
+    username: harbor
+    coreDatabase: registry
+    existingSecret: harbor-db-secret
+    sslmode: disable
+
+# Built-in Redis — no shared Redis in the platform
+redis:
+  type: internal
+
+persistence:
+  enabled: true
+  resourcePolicy: "keep"
+  persistentVolumeClaim:
+    registry:
+      size: 10Gi
+      accessMode: ReadWriteOnce
+    jobservice:
+      jobLog:
+        size: 1Gi
+    trivy:
+      size: 5Gi
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    additionalLabels:
+      release: prometheus
+
+trace:
+  enabled: true
+  provider: otel
+  sample_rate: 0.1
+  otel:
+    endpoint: jaeger-collector.tracing.svc.cluster.local:4318
+    url_path: /v1/traces
+    compression: false
+    insecure: true
+    timeout: 10
+
+trivy:
+  enabled: true
+
+cache:
+  enabled: true
+  expireHours: 24
+
+logLevel: info

--- a/platform/base/ingress/harbor-ingress.yaml
+++ b/platform/base/ingress/harbor-ingress.yaml
@@ -1,0 +1,100 @@
+# =============================================================================
+# Harbor Ingress — OCI Registry + Portal routing
+#
+# Routes:
+#   /harbor(/|$)(.*)  → harbor-ui-proxy:9091  (Angular SPA via sub_filter nginx)
+#   /v2/(.*)          → harbor:80              (Docker registry API)
+#   /api/(.*)         → harbor:80              (Harbor REST API)
+#   /service/(.*)     → harbor:80              (Docker token service)
+#   /c/(.*)           → harbor:80              (OIDC callback)
+#
+# Harbor's internal nginx (expose.type=clusterIP) handles component routing.
+# configuration-snippet is DISABLED on this cluster — use harbor-ui-proxy instead.
+# Issue: #225
+# =============================================================================
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: harbor-ingress
+  namespace: ingress-nginx
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
+    cert-manager.io/cluster-issuer: "digiorg-local-ca-issuer"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - digiorg.local
+      secretName: digiorg-local-tls
+  rules:
+    - host: digiorg.local
+      http:
+        paths:
+          - path: /harbor(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: harbor-ui-proxy
+                port:
+                  number: 9091
+          - path: /v2/(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: harbor
+                port:
+                  number: 80
+          - path: /api/(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: harbor
+                port:
+                  number: 80
+          - path: /service/(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: harbor
+                port:
+                  number: 80
+          - path: /c/(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: harbor
+                port:
+                  number: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: harbor-ui-proxy
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: harbor-ui-proxy
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  type: ExternalName
+  externalName: harbor-ui-proxy.harbor.svc.cluster.local
+  ports:
+    - port: 9091
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: harbor
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: harbor
+    app.kubernetes.io/part-of: digiorg-core-platform
+spec:
+  type: ExternalName
+  externalName: harbor.harbor.svc.cluster.local
+  ports:
+    - port: 80

--- a/platform/base/ingress/kustomization.yaml
+++ b/platform/base/ingress/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   # Both are bootstrap-managed (applied by local-setup.nu), NOT by ArgoCD.
   - opencost-portal-ingress.yaml
   - opencost-assets-ingress.yaml
+  - harbor-ingress.yaml

--- a/platform/base/keycloak/digiorg-core-platform-realm.json
+++ b/platform/base/keycloak/digiorg-core-platform-realm.json
@@ -337,6 +337,42 @@
       "attributes": {
         "post.logout.redirect.uris": "https://digiorg.local/opencost/*"
       }
+    },
+    {
+      "clientId": "harbor",
+      "name": "Harbor Registry",
+      "description": "Harbor OCI Registry — native Keycloak OIDC SSO",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "harbor-client-secret",
+      "redirectUris": ["https://digiorg.local/c/oidc/callback"],
+      "webOrigins": ["https://digiorg.local"],
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": true,
+      "frontchannelLogout": true,
+      "attributes": {
+        "post.logout.redirect.uris": "https://digiorg.local/harbor/*"
+      },
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "false",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
     }
   ],
   "roles": {

--- a/platform/base/landingpage/services.json
+++ b/platform/base/landingpage/services.json
@@ -78,5 +78,15 @@
     "category": "monitoring",
     "requiresAuth": true,
     "displayOrder": 8
+  },
+  {
+    "id": "harbor",
+    "name": "Harbor Registry",
+    "description": "OCI container registry with vulnerability scanning",
+    "path": "/harbor",
+    "icon": "server",
+    "category": "infrastructure",
+    "requiresAuth": true,
+    "displayOrder": 9
   }
 ]

--- a/platform/base/postgresql/statefulset.yaml
+++ b/platform/base/postgresql/statefulset.yaml
@@ -28,6 +28,10 @@ data:
         CREATE USER sonarqube WITH PASSWORD '${SONARQUBE_DB_PASSWORD}';
         CREATE DATABASE sonarqube OWNER sonarqube;
         GRANT ALL PRIVILEGES ON DATABASE sonarqube TO sonarqube;
+
+        CREATE USER harbor WITH PASSWORD '${HARBOR_DB_PASSWORD}';
+        CREATE DATABASE registry OWNER harbor;
+        GRANT ALL PRIVILEGES ON DATABASE registry TO harbor;
     EOSQL
 
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname keycloak <<-EOSQL
@@ -44,6 +48,10 @@ data:
 
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname sonarqube <<-EOSQL
         GRANT ALL ON SCHEMA public TO sonarqube;
+    EOSQL
+
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname registry <<-EOSQL
+        GRANT ALL ON SCHEMA public TO harbor;
     EOSQL
 ---
 apiVersion: apps/v1
@@ -98,6 +106,11 @@ spec:
                 secretKeyRef:
                   name: postgresql-secrets
                   key: SONARQUBE_DB_PASSWORD
+            - name: HARBOR_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-secrets
+                  key: HARBOR_DB_PASSWORD
             # Set PGDATA to a subdirectory to avoid "lost+found" issues
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -91,6 +91,7 @@ def "main up" [] {
     print "  Grafana:      https://digiorg.local/grafana   (Login via Keycloak)"
     print "  Jaeger:       https://digiorg.local/jaeger    (Login via Keycloak)"
     print "  OpenCost:    https://digiorg.local/opencost  (Login via Keycloak)"
+    print "  Harbor:       https://digiorg.local/harbor   (Login via Keycloak)"
     print ""
     print $"(ansi yellow)Prerequisites:(ansi reset)"
     print $"  1. Add to /etc/hosts: 127.0.0.1 digiorg.local"
@@ -380,6 +381,10 @@ def create_platform_namespaces_secrets [] {
     let gitea_oidc_secret = ($env.GITEA_OIDC_CLIENT_SECRET? | default "gitea-client-secret")
     let sonarqube_db_password = ($env.SONARQUBE_DB_PASSWORD? | default (generate_password))
     let sonarqube_monitoring_passcode = ($env.SONARQUBE_MONITORING_PASSCODE? | default (generate_password))
+    let harbor_admin_password = ($env.HARBOR_ADMIN_PASSWORD? | default "Harbor12345")
+    let harbor_secret_key = ($env.HARBOR_SECRET_KEY? | default "not-a-secure-key")
+    let harbor_db_password = ($env.HARBOR_DB_PASSWORD? | default (generate_password))
+    let harbor_oidc_secret = ($env.HARBOR_OIDC_CLIENT_SECRET? | default "harbor-client-secret")
     
     # Platform-db namespace and PostgreSQL secrets (shared database for Keycloak + Backstage + Gitea)
     kubectl create namespace platform-db --dry-run=client -o yaml | kubectl apply -f -
@@ -389,6 +394,7 @@ def create_platform_namespaces_secrets [] {
         --from-literal=BACKSTAGE_DB_PASSWORD=($backstage_db_password)
         --from-literal=GITEA_DB_PASSWORD=($gitea_db_password)
         --from-literal=SONARQUBE_DB_PASSWORD=($sonarqube_db_password)
+        --from-literal=HARBOR_DB_PASSWORD=($harbor_db_password)
         --dry-run=client -o yaml | kubectl apply -f -)
     
     # Keycloak namespace and DB credentials secret
@@ -479,6 +485,21 @@ type: kubernetes.io/service-account-token" | save --force $token_secret_file
         --dry-run=client -o yaml | kubectl apply -f -)
     (kubectl create secret generic sonarqube-monitoring-secret -n code-quality
         --from-literal=SONAR_WEB_SYSTEMPASSCODE=($sonarqube_monitoring_passcode)
+        --dry-run=client -o yaml | kubectl apply -f -)
+
+    # Harbor namespace and secrets
+    kubectl create namespace harbor --dry-run=client -o yaml | kubectl apply -f -
+    (kubectl create secret generic harbor-admin-secret -n harbor
+        --from-literal=HARBOR_ADMIN_PASSWORD=($harbor_admin_password)
+        --dry-run=client -o yaml | kubectl apply -f -)
+    (kubectl create secret generic harbor-secret-key -n harbor
+        --from-literal=secretKey=($harbor_secret_key)
+        --dry-run=client -o yaml | kubectl apply -f -)
+    (kubectl create secret generic harbor-db-secret -n harbor
+        --from-literal=password=($harbor_db_password)
+        --dry-run=client -o yaml | kubectl apply -f -)
+    (kubectl create secret generic harbor-oidc-secret -n harbor
+        --from-literal=client-secret=($harbor_oidc_secret)
         --dry-run=client -o yaml | kubectl apply -f -)
 
     # Messaging namespace (for NATS server + Surveyor)


### PR DESCRIPTION
## Summary

Integrates Harbor as the platform-native OCI container registry.

## Changes

- `apps/platform/harbor.yaml`: ArgoCD Application (wave 2, multi-source)
- `platform/base/harbor/values.yaml`: Helm values (external PostgreSQL, built-in Redis, Trivy, OTEL tracing, metrics)
- `platform/base/harbor/harbor-ui-proxy.yaml`: nginx proxy for Angular SPA sub_filter (avoids disabled configuration-snippet)
- `platform/base/harbor/kustomization.yaml`: Kustomize base
- `platform/base/postgresql/statefulset.yaml`: Add harbor user + registry DB to shared PostgreSQL
- `platform/base/ingress/harbor-ingress.yaml`: Dedicated ingress + ExternalName services
- `platform/base/ingress/kustomization.yaml`: Add harbor-ingress.yaml
- `platform/base/keycloak/digiorg-core-platform-realm.json`: Add harbor OIDC client
- `platform/base/landingpage/services.json`: Add Harbor Registry tile (displayOrder 9)
- `scripts/local-setup.nu`: Add harbor namespace, secrets, and info print

## Architecture

- `expose.type: clusterIP` — Harbor manages its own internal nginx for component routing
- `harbor-ui-proxy` — nginx sub_filter rewrites `<base href="/">` → `<base href="/harbor/">` for Angular SPA
- External PostgreSQL: `postgresql.platform-db.svc.cluster.local` (shared platform instance)
- Routes: `/harbor` → ui-proxy → harbor:80, `/v2/`, `/api/`, `/service/`, `/c/` → harbor:80

## Post-deploy (manual one-time)

OIDC must be configured via Harbor Admin UI after first deployment:
- Auth Mode: OIDC, Provider: Keycloak
- Endpoint: `https://digiorg.local/keycloak/realms/digiorg-core-platform`
- Client ID: `harbor`, Client Secret from `harbor-oidc-secret`

Closes digiorg/core#225