### PR TITLE
fix(harbor): correct sub_filter pattern to match Harbor's self-closing base href

### DIFF
--- a/platform/base/harbor/harbor-ui-proxy.yaml
+++ b/platform/base/harbor/harbor-ui-proxy.yaml
@@ -81,7 +81,7 @@ data:
                          https://digiorg.local/harbor/;
           sub_filter_once off;
           sub_filter_types  text/html;
-          sub_filter '<base href="/">' '<base href="/harbor/">';
+          sub_filter '<base href="/"/>' '<base href="/harbor/"/>';
         }
 
         location /harbor/ {
@@ -105,7 +105,7 @@ data:
           # Rewrite Angular SPA base href for subpath deployment
           sub_filter_once off;
           sub_filter_types  text/html;
-          sub_filter '<base href="/">' '<base href="/harbor/">';
+          sub_filter '<base href="/"/>' '<base href="/harbor/"/>';
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes the `harbor-ui-proxy` sub_filter that silently fails to rewrite `<base href>`, causing all Angular assets to 404 and the UI to stay stuck at "Loading...".

## Root Cause

Harbor's Angular portal outputs:
```html
<base href="/"/>
```
(HTML5 void element with self-closing `/>`)

The previous sub_filter searched for `<base href="/">` (without the trailing `/`) — no match, no rewrite.

## Fix

**2 lines changed** in both location blocks of `harbor-ui-proxy.yaml`:

| Before | After |
|--------|-------|
| `sub_filter '<base href="/">' '<base href="/harbor/">';` | `sub_filter '<base href="/"/>' '<base href="/harbor/"/>';` |

## Result

- `<base href="/"/>` → rewritten to `<base href="/harbor/"/>`
- Angular resolves assets as `/harbor/styles.abc.css` → harbor-ui-proxy strips prefix → `harbor:80/styles.abc.css` → ✅
- UI loads past "Loading..." and shows the Harbor login/dashboard

Fixes digiorg/core#248