### PR TITLE
fix(harbor): narrow /api/(.*) ingress to /api/v2.0/(.*) — fixes landingpage tile

### DIFF
--- a/platform/base/ingress/harbor-ingress.yaml
+++ b/platform/base/ingress/harbor-ingress.yaml
@@ -49,7 +49,7 @@ spec:
                 name: harbor
                 port:
                   number: 80
-          - path: /api/(.*)
+          - path: /api/v2\.0/(.*)
             pathType: ImplementationSpecific
             backend:
               service:


### PR DESCRIPTION
## Summary

Narrows the Harbor ingress API path from `/api/(.*)` to `/api/v2\.0/(.*)` so the landing page's `/api/services` request is no longer intercepted by Harbor.

## Root Cause

The broad `/api/(.*)` rule in `harbor-ingress.yaml` matched `GET /api/services` before it could reach the landingpage nginx. Harbor returned 401, causing `fetchServices()` to fall back to hardcoded defaults (which don't include Harbor). All 8 existing tiles were shown from the fallback list — but Harbor was never added there.

## Change

```
- path: /api/(.*)       ← matched /api/services → Harbor 401
+ path: /api/v2\.0/(.*) ← Harbor REST API only; /api/services falls through to landingpage ✅
```

Harbor's REST API exclusively uses `/api/v2.0/...` paths. No other Harbor endpoint uses bare `/api/`.

Fixes digiorg/core#250
Related: digiorg/core#225