### PR TITLE
fix(scripts): sync wait loop and docs with all ArgoCD app waves — add harbor/opencost/cnpg/fluentd, fix opensearch wave, increase limit to 150

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -60,6 +60,11 @@ The script installs only the minimal infrastructure needed to run ArgoCD:
    - `tracing/jaeger-oauth2-proxy-secrets`: `client-secret`, `cookie-secret`
    - `platform-db/opensearch-secrets`: `OPENSEARCH_ADMIN_PASSWORD`
    - `tracing/jaeger-opensearch-credentials`: `password` (Jaeger → OpenSearch auth)
+   - `cost-monitoring/opencost-oauth2-proxy-secrets`: `client-secret`, `cookie-secret`
+   - `harbor/harbor-admin-secret`: `HARBOR_ADMIN_PASSWORD`
+   - `harbor/harbor-secret-key`: `secretKey` (16-char internal encryption key)
+   - `harbor/harbor-db-secret`: `password` (shared PostgreSQL)
+   - `harbor/harbor-oidc-secret`: `client-secret` (Keycloak OIDC)
 8. **ArgoCD** (Helm install)
 9. **Root App** (triggers App-of-Apps)
 
@@ -70,10 +75,15 @@ ArgoCD takes over and deploys all platform components via sync waves:
 | Wave | Applications | Description |
 |------|--------------|-------------|
 | -1 | root-app | Bootstrap (deployed by script) |
-| 0 | cert-manager, external-secrets, postgresql, opensearch, nats | Foundation services |
+| 0 | cert-manager, cnpg, external-secrets, nats, postgresql | Foundation infrastructure |
 | 1 | keycloak, argocd | Identity + self-managed ArgoCD |
-| 2 | landingpage, backstage, gitea, grafana, jaeger, sonarqube | Platform services |
-| 3 | crossplane, kyverno | Extensions and policy |
+| 2 | backstage, gitea, grafana, harbor, jaeger, landingpage, opencost, sonarqube | Platform services |
+| 3 | crossplane, kyverno, opensearch | Extensions, policy, observability backend |
+| 4 | crossplane-providers, fluentd, kyverno-policies | Provider plugins, log shipping, policies |
+| 5 | monitoring-extras | ServiceMonitors (requires monitoring stack) |
+| 6 | crossplane-provider-configs | Provider configurations |
+| 7 | crossplane-xrds | Composite Resource Definitions |
+| 8 | core-app-catalog | Core app catalog |
 
 ArgoCD deploys platform components as individual Application resources defined in `apps/platform/*.yaml`, not via an ApplicationSet CRD.
 
@@ -117,6 +127,8 @@ After `up` completes, access services via:
 | Gitea | https://digiorg.local/gitea | `gitea_admin` / password from `gitea/gitea-admin-secret` |
 | SonarQube | https://digiorg.local/sonarqube | admin / admin — change immediately |
 | Jaeger | https://digiorg.local/jaeger | Login via Keycloak |
+| OpenCost | https://digiorg.local/opencost | Login via Keycloak |
+| Harbor | https://digiorg.local/harbor | Login via Keycloak (OIDC post-setup required) |
 
 **Note:** Requires `/etc/hosts` entry: `127.0.0.1 digiorg.local`
 
@@ -160,7 +172,14 @@ All passwords and secrets used by the bootstrap script can be overridden by sett
 | `SONARQUBE_DB_PASSWORD` | random | SonarQube PostgreSQL database password |
 | `SONARQUBE_MONITORING_PASSCODE` | random | SonarQube monitoring passcode |
 | `JAEGER_OIDC_CLIENT_SECRET` | `jaeger-client-secret` | Jaeger OAuth2 proxy OIDC client secret |
+| `JAEGER_COOKIE_SECRET` | random (base64) | Jaeger oauth2-proxy cookie encryption secret |
 | `OPENSEARCH_ADMIN_PASSWORD` | random | OpenSearch admin password |
+| `OPENCOST_OIDC_CLIENT_SECRET` | `opencost-client-secret` | OpenCost OAuth2 proxy OIDC client secret |
+| `OPENCOST_COOKIE_SECRET` | random (base64) | OpenCost oauth2-proxy cookie encryption secret |
+| `HARBOR_ADMIN_PASSWORD` | `Harbor12345` | Harbor initial admin password |
+| `HARBOR_SECRET_KEY` | `not-a-secure-key` | Harbor 16-char internal encryption key |
+| `HARBOR_DB_PASSWORD` | random | Harbor PostgreSQL database password |
+| `HARBOR_OIDC_CLIENT_SECRET` | `harbor-client-secret` | Harbor Keycloak OIDC client secret |
 
 ## Cluster Name
 

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -63,13 +63,13 @@ def "main up" [] {
 
     # Configure SonarQube (SAML + base URL)
     print ""
-    print $"(ansi cyan_bold)Phase 3: Configure SonarQube(ansi reset)"
+    print $"(ansi cyan_bold)Phase 4: Configure SonarQube(ansi reset)"
     print "────────────────────────────────────"
     configure_sonarqube
 
     # Restart OIDC-dependent pods after Keycloak is ready
     print ""
-    print $"(ansi cyan_bold)Phase 3: Restart OIDC dependent PODs(ansi reset)"
+    print $"(ansi cyan_bold)Phase 5: Restart OIDC dependent PODs(ansi reset)"
     print "────────────────────────────────────"
     restart_oidc_dependent_pods
     
@@ -203,7 +203,7 @@ def "main status" [] {
         print $"(ansi cyan_bold)Platform Pods(ansi reset)"
         print "============="
         
-        let namespaces = ["kube-system", "platform-db", "argocd", "keycloak", "messaging", "crossplane-system", "kyverno", "monitoring", "backstage", "gitea", "platform-apps", "cert-manager", "code-quality", "tracing", "external-secrets", "cost-monitoring"]
+        let namespaces = ["kube-system", "platform-db", "argocd", "keycloak", "messaging", "crossplane-system", "kyverno", "monitoring", "backstage", "gitea", "platform-apps", "cert-manager", "code-quality", "tracing", "external-secrets", "cost-monitoring", "harbor", "opensearch"]
         for ns in $namespaces {
             let status = try {
                 let pods = (kubectl get pods -n $ns --no-headers | lines | length)
@@ -570,11 +570,11 @@ def deploy_root_app [] {
     print ""
     print "ArgoCD Sync Waves:"
     print "  Wave -1: root-app (just deployed)"
-    print "  Wave  0: cert-manager, external-secrets, postgresql, opensearch, nats"
+    print "  Wave  0: cert-manager, cnpg, external-secrets, nats, postgresql"
     print "  Wave  1: keycloak, argocd (self-managed)"
-    print "  Wave  2: landingpage, backstage, gitea, grafana, jaeger, sonarqube, opencost"
-    print "  Wave  3: crossplane, kyverno"
-    print "  Wave  4: crossplane-providers"
+    print "  Wave  2: backstage, gitea, grafana, harbor, jaeger, landingpage, opencost, sonarqube"
+    print "  Wave  3: crossplane, kyverno, opensearch"
+    print "  Wave  4: crossplane-providers, fluentd, kyverno-policies"
     print "  Wave  5: monitoring-extras (ServiceMonitors)"
     print "  Wave  6: crossplane-provider-configs"
     print "  Wave  7: crossplane-xrds"
@@ -597,15 +597,15 @@ def wait_for_argocd_apps [] {
     # Apps to wait for (in wave order) — must match apps/platform/*.yaml exactly
     let apps = [
         # Wave 0
-        "cert-manager", "external-secrets", "postgresql", "opensearch", "nats",
+        "cert-manager", "cnpg", "external-secrets", "nats", "postgresql",
         # Wave 1
         "keycloak", "argocd",
         # Wave 2
-        "landingpage", "backstage", "gitea", "grafana", "jaeger", "sonarqube", "opencost",
+        "backstage", "gitea", "grafana", "harbor", "jaeger", "landingpage", "opencost", "sonarqube",
         # Wave 3
-        "crossplane", "kyverno",
+        "crossplane", "kyverno", "opensearch",
         # Wave 4
-        "crossplane-providers",
+        "crossplane-providers", "fluentd", "kyverno-policies",
         # Wave 5
         "monitoring-extras",
         # Wave 6
@@ -618,7 +618,7 @@ def wait_for_argocd_apps [] {
     
     mut all_healthy = false
     mut attempts = 0
-    let max_attempts = 120  # 20 minutes with 10sec intervals
+    let max_attempts = 150  # 25 minutes with 10sec intervals — platform has grown
     
     loop {
         $attempts = $attempts + 1


### PR DESCRIPTION
## Summary

Syncs `scripts/local-setup.nu` and `scripts/README.md` with the actual set of ArgoCD applications in `apps/platform/*.yaml`.

## Changes

### `scripts/local-setup.nu`

| Change | Detail |
|--------|--------|
| `wait_for_argocd_apps` — apps list | Added `cnpg` (Wave 0), `harbor` (Wave 2); moved `opensearch` to Wave 3; added `fluentd` + `kyverno-policies` (Wave 4) |
| `max_attempts` | 120 → 150 (25 min — platform has grown to 25 apps) |
| `deploy_root_app` wave print | Updated to match actual wave assignments |
| `main status` namespaces | Added `harbor`, `opensearch` |
| Phase labels in `main up` | Renamed duplicate "Phase 3" to Phase 3 / Phase 4 / Phase 5 |

### `scripts/README.md`

| Change | Detail |
|--------|--------|
| Wave table | Fully rewritten — 9 waves, all 25 apps correct |
| Service Access table | Added OpenCost + Harbor rows |
| Bootstrap Secrets | Added 5 Harbor secrets + 2 OpenCost secrets |
| Environment Variables | Added 7 new variables (JAEGER_COOKIE_SECRET, OPENCOST_*, HARBOR_*) |

Fixes digiorg/core#252