### PR TITLE
chore(refactor): update core-catalog references (#254)

### DIFF
--- a/apps/platform/core-catalog.yaml
+++ b/apps/platform/core-catalog.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: core-app-catalog
+  name: core-catalog
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
@@ -12,7 +12,7 @@ spec:
   project: default
 
   source:
-    repoURL: https://github.com/digiorg/core-app-catalog.git
+    repoURL: https://github.com/digiorg/core-catalog.git
     targetRevision: HEAD
     path: compositions/local
 

--- a/crossplane/README.md
+++ b/crossplane/README.md
@@ -12,7 +12,7 @@ crossplane/
 │   ├── provider-http.yaml
 │   └── kustomization.yaml
 ├── xrds/            # Composite Resource Definitions (add here)
-└── compositions/    # Compositions live in core-app-catalog, not here
+└── compositions/    # Compositions live in core-catalog, not here
 ```
 
 ## Installed Providers
@@ -76,6 +76,6 @@ spec:
 
 ## Adding Compositions
 
-Compositions live in the **core-app-catalog** repository, not here. This keeps application-level
+Compositions live in the **core-catalog** repository, not here. This keeps application-level
 compositions separate from the platform provider infrastructure. Reference the XRD group and kind
 from this repo when authoring compositions there.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -83,7 +83,7 @@ ArgoCD takes over and deploys all platform components via sync waves:
 | 5 | monitoring-extras | ServiceMonitors (requires monitoring stack) |
 | 6 | crossplane-provider-configs | Provider configurations |
 | 7 | crossplane-xrds | Composite Resource Definitions |
-| 8 | core-app-catalog | Core app catalog |
+| 8 | core-catalog | Core catalog |
 
 ArgoCD deploys platform components as individual Application resources defined in `apps/platform/*.yaml`, not via an ApplicationSet CRD.
 

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -578,7 +578,7 @@ def deploy_root_app [] {
     print "  Wave  5: monitoring-extras (ServiceMonitors)"
     print "  Wave  6: crossplane-provider-configs"
     print "  Wave  7: crossplane-xrds"
-    print "  Wave  8: core-app-catalog"
+    print "  Wave  8: core-catalog"
 
     # Wait for apps to sync
     print ""
@@ -613,7 +613,7 @@ def wait_for_argocd_apps [] {
         # Wave 7
         "crossplane-xrds",
         # Wave 8
-        "core-app-catalog"
+        "core-catalog"
     ]
     
     mut all_healthy = false


### PR DESCRIPTION
## Summary

- Renamed `apps/platform/core-app-catalog.yaml` → `apps/platform/core-catalog.yaml`
- Updated ArgoCD Application `metadata.name` from `core-app-catalog` to `core-catalog`
- Updated `repoURL` to point at `https://github.com/digiorg/core-catalog.git`
- Updated `crossplane/README.md` to reference `core-catalog` (lines 15 and 79)
- Updated `scripts/README.md` wave table (wave 8 entry)
- Updated `scripts/local-setup.nu` printed wave label and component list

Closes #254.

## Test plan

- [ ] Verify `grep -r "core-app-catalog" .` returns no results in tracked files
- [ ] Confirm the ArgoCD Application manifest name and repoURL are correct in `apps/platform/core-catalog.yaml`
- [ ] Confirm `scripts/README.md` wave 8 row shows `core-catalog`
- [ ] Confirm `nu scripts/local-setup.nu up` prints `Wave  8: core-catalog` and waits for app `core-catalog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)