### PR TITLE
fix(keycloak): increase memory limits to prevent OOMKilled

### DIFF
--- a/platform/base/keycloak/keycloak-deployment.yaml
+++ b/platform/base/keycloak/keycloak-deployment.yaml
@@ -80,6 +80,10 @@ spec:
             # Management interface must use root path, not the HTTP relative path
             - name: KC_HTTP_MANAGEMENT_RELATIVE_PATH
               value: "/"
+            # JVM heap ceiling — must stay below container memory limit (2Gi)
+            # Without this, JVM estimates available RAM from host instead of container limits → OOMKill
+            - name: JAVA_OPTS_KC_HEAP
+              value: "-XX:MaxRAMPercentage=70 -XX:InitialRAMPercentage=50 -XX:MaxRAM=1536m"
           ports:
             - containerPort: 8080
               name: http
@@ -92,10 +96,10 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 384Mi
+              memory: 1Gi
             limits:
               cpu: 1000m
-              memory: 768Mi
+              memory: 2Gi
           startupProbe:
             httpGet:
               path: /health/ready


### PR DESCRIPTION
## Summary
Increases Keycloak container memory limits and adds explicit JVM heap ceiling to prevent OOMKilled crashes during Quarkus augmentation phase on Kind clusters.

## Changes
- `platform/base/keycloak/keycloak-deployment.yaml`: Memory requests 384Mi → 1Gi, limits 768Mi → 2Gi; added `JAVA_OPTS_KC_HEAP` env var to cap JVM heap at 1536m

## Acceptance Criteria
- [ ] Keycloak Pod starts without OOMKilled
- [ ] `kubectl describe pod` shows no `OOMKilled` in Last State
- [ ] Keycloak health endpoint responds on port 9000 after startup

Fixes digiorg/core#258