### PR TITLE
feat(harbor): configure OIDC SSO via Keycloak

### DIFF
--- a/platform/base/harbor/harbor-oidc-secret.yaml
+++ b/platform/base/harbor/harbor-oidc-secret.yaml
@@ -1,0 +1,12 @@
+# =============================================================================
+# Harbor OIDC Client Secret
+# Keycloak client: harbor | Realm: digiorg-core-platform
+# =============================================================================
+apiVersion: v1
+kind: Secret
+metadata:
+  name: harbor-oidc-secret
+  namespace: harbor
+type: Opaque
+stringData:
+  OIDC_CLIENT_SECRET: "harbor-client-secret"

--- a/platform/base/harbor/kustomization.yaml
+++ b/platform/base/harbor/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - harbor-ui-proxy.yaml
+  - harbor-oidc-secret.yaml

--- a/platform/base/harbor/values.yaml
+++ b/platform/base/harbor/values.yaml
@@ -71,3 +71,33 @@ cache:
   expireHours: 24
 
 logLevel: info
+
+# OIDC SSO via Keycloak
+# AUTH_MODE env vars are read by Harbor core on startup and written to the DB on first run.
+# On a fresh Kind cluster (DB always empty), these are applied on every deployment.
+# Harbor helm chart supports this via core.extraEnvVars (confirmed in templates/core/core-dpl.yaml).
+core:
+  extraEnvVars:
+    - name: AUTH_MODE
+      value: "oidc_auth"
+    - name: OIDC_NAME
+      value: "Keycloak"
+    - name: OIDC_ENDPOINT
+      value: "https://digiorg.local/keycloak/realms/digiorg-core-platform"
+    - name: OIDC_CLIENT_ID
+      value: "harbor"
+    - name: OIDC_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: harbor-oidc-secret
+          key: OIDC_CLIENT_SECRET
+    - name: OIDC_SCOPE
+      value: "openid,profile,email,groups"
+    - name: OIDC_VERIFY_CERT
+      value: "false"
+    - name: OIDC_AUTO_ONBOARD
+      value: "true"
+    - name: OIDC_USER_CLAIM
+      value: "preferred_username"
+    - name: OIDC_GROUPS_CLAIM
+      value: "groups"


### PR DESCRIPTION
## Summary
Configures Harbor OIDC authentication via Keycloak so the **"LOGIN WITH KEYCLOAK"** button appears on the Harbor login page.

## Changes
- `platform/base/harbor/harbor-oidc-secret.yaml`: New — Kubernetes Secret with OIDC client secret
- `platform/base/harbor/kustomization.yaml`: Add harbor-oidc-secret.yaml to resources
- `platform/base/harbor/values.yaml`: Add `core.extraEnvVars` with OIDC configuration (AUTH_MODE, OIDC_ENDPOINT, client ID/secret, scopes)

## Notes
- Keycloak `harbor` client was already configured in the realm (redirect URI, groups mapper, client secret)
- `OIDC_VERIFY_CERT=false` required for self-signed cert at digiorg.local
- `OIDC_AUTO_ONBOARD=true` creates Harbor user on first OIDC login
- Harbor core reads env vars on startup; on fresh Kind cluster (empty DB) these are applied on every deploy

Fixes digiorg/core#260