### PR TITLE
fix(harbor): configure OIDC via REST API PostSync Job + add admin secret

### DIFF
--- a/platform/base/harbor/harbor-admin-secret.yaml
+++ b/platform/base/harbor/harbor-admin-secret.yaml
@@ -1,0 +1,12 @@
+# =============================================================================
+# Harbor Admin Password
+# Required by values.yaml: existingSecretAdminPassword: harbor-admin-secret
+# =============================================================================
+apiVersion: v1
+kind: Secret
+metadata:
+  name: harbor-admin-secret
+  namespace: harbor
+type: Opaque
+stringData:
+  HARBOR_ADMIN_PASSWORD: "Harbor12345"

--- a/platform/base/harbor/harbor-oidc-config-job.yaml
+++ b/platform/base/harbor/harbor-oidc-config-job.yaml
@@ -1,0 +1,79 @@
+# =============================================================================
+# Harbor OIDC Configuration Job
+#
+# ArgoCD PostSync hook: runs after every Harbor deployment and configures
+# OIDC authentication via Harbor's REST API (PUT /api/v2.0/configurations).
+#
+# Harbor stores auth configuration in PostgreSQL — it cannot be set via
+# environment variables. This Job is the only GitOps-compatible approach.
+#
+# BeforeHookCreation: deletes the previous Job on re-sync so it always re-runs.
+# This ensures OIDC is configured on every fresh Kind cluster build.
+#
+# Issue: #262
+# =============================================================================
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: harbor-oidc-config
+  namespace: harbor
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: configure-oidc
+          image: curlimages/curl:8.7.1
+          env:
+            - name: HARBOR_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: harbor-admin-secret
+                  key: HARBOR_ADMIN_PASSWORD
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: harbor-oidc-secret
+                  key: OIDC_CLIENT_SECRET
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              HARBOR_API="http://harbor.harbor.svc.cluster.local/api/v2.0"
+
+              echo "Waiting for Harbor API to be ready..."
+              until curl -sf "${HARBOR_API}/ping" > /dev/null 2>&1; do
+                echo "  Harbor not ready yet, retrying in 5s..."
+                sleep 5
+              done
+              echo "Harbor API is ready."
+
+              echo "Configuring OIDC authentication..."
+              HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+                -u "admin:${HARBOR_ADMIN_PASSWORD}" \
+                -H "Content-Type: application/json" \
+                -d "{
+                  \"auth_mode\": \"oidc_auth\",
+                  \"oidc_name\": \"Keycloak\",
+                  \"oidc_endpoint\": \"https://digiorg.local/keycloak/realms/digiorg-core-platform\",
+                  \"oidc_client_id\": \"harbor\",
+                  \"oidc_client_secret\": \"${OIDC_CLIENT_SECRET}\",
+                  \"oidc_scope\": \"openid,profile,email,groups\",
+                  \"oidc_verify_cert\": false,
+                  \"oidc_auto_onboard\": true,
+                  \"oidc_user_claim\": \"preferred_username\",
+                  \"oidc_groups_claim\": \"groups\"
+                }" \
+                "${HARBOR_API}/configurations")
+
+              if [ "$HTTP_STATUS" = "200" ]; then
+                echo "OIDC configuration applied successfully (HTTP 200)."
+              else
+                echo "ERROR: Harbor API returned HTTP ${HTTP_STATUS}. OIDC configuration failed."
+                exit 1
+              fi

--- a/platform/base/harbor/kustomization.yaml
+++ b/platform/base/harbor/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - harbor-ui-proxy.yaml
   - harbor-oidc-secret.yaml
+  - harbor-admin-secret.yaml
+  - harbor-oidc-config-job.yaml

--- a/platform/base/harbor/values.yaml
+++ b/platform/base/harbor/values.yaml
@@ -71,33 +71,3 @@ cache:
   expireHours: 24
 
 logLevel: info
-
-# OIDC SSO via Keycloak
-# AUTH_MODE env vars are read by Harbor core on startup and written to the DB on first run.
-# On a fresh Kind cluster (DB always empty), these are applied on every deployment.
-# Harbor helm chart supports this via core.extraEnvVars (confirmed in templates/core/core-dpl.yaml).
-core:
-  extraEnvVars:
-    - name: AUTH_MODE
-      value: "oidc_auth"
-    - name: OIDC_NAME
-      value: "Keycloak"
-    - name: OIDC_ENDPOINT
-      value: "https://digiorg.local/keycloak/realms/digiorg-core-platform"
-    - name: OIDC_CLIENT_ID
-      value: "harbor"
-    - name: OIDC_CLIENT_SECRET
-      valueFrom:
-        secretKeyRef:
-          name: harbor-oidc-secret
-          key: OIDC_CLIENT_SECRET
-    - name: OIDC_SCOPE
-      value: "openid,profile,email,groups"
-    - name: OIDC_VERIFY_CERT
-      value: "false"
-    - name: OIDC_AUTO_ONBOARD
-      value: "true"
-    - name: OIDC_USER_CLAIM
-      value: "preferred_username"
-    - name: OIDC_GROUPS_CLAIM
-      value: "groups"


### PR DESCRIPTION
## Summary
Fixes Harbor OIDC SSO by replacing the incorrect env-var approach with an ArgoCD PostSync Job that configures Harbor via REST API. Also adds the missing admin password Secret.

## Root Cause
Harbor stores auth configuration in PostgreSQL — `core.extraEnvVars` with `AUTH_MODE` has no effect on Harbor's authentication mode. OIDC must be configured via `PUT /api/v2.0/configurations`.

## Changes
- `platform/base/harbor/values.yaml`: Removed incorrect `core.extraEnvVars` OIDC block
- `platform/base/harbor/harbor-admin-secret.yaml`: **New** — admin password Secret (was missing, caused login failure)
- `platform/base/harbor/harbor-oidc-config-job.yaml`: **New** — ArgoCD PostSync Job that calls Harbor REST API to configure OIDC on every deployment
- `platform/base/harbor/kustomization.yaml`: Added both new files to resources

## How it works
1. ArgoCD syncs Harbor (Helm chart + manifests)
2. Once Harbor is healthy, PostSync hook triggers the Job
3. Job waits for `/api/v2.0/ping` to be ready
4. Job calls `PUT /api/v2.0/configurations` with OIDC settings
5. Harbor login page now shows **LOGIN WITH KEYCLOAK** button

Fixes digiorg/core#262