### PR TITLE
fix(harbor): remove invalid 'groups' scope from OIDC config

### DIFF
--- a/platform/base/harbor/harbor-oidc-config-job.yaml
+++ b/platform/base/harbor/harbor-oidc-config-job.yaml
@@ -63,7 +63,7 @@ spec:
                   \"oidc_endpoint\": \"https://digiorg.local/keycloak/realms/digiorg-core-platform\",
                   \"oidc_client_id\": \"harbor\",
                   \"oidc_client_secret\": \"${OIDC_CLIENT_SECRET}\",
-                  \"oidc_scope\": \"openid,profile,email,groups\",
+                  \"oidc_scope\": \"openid,profile,email\",
                   \"oidc_verify_cert\": false,
                   \"oidc_auto_onboard\": true,
                   \"oidc_user_claim\": \"preferred_username\",


### PR DESCRIPTION
## Summary
Removes `groups` from the OIDC scope in the Harbor PostSync Job. Keycloak rejects it as `invalid_scope` because no custom `groups` scope is registered in the realm. The groups claim is already included via a client-level protocol mapper and requires no scope.

## Change
`platform/base/harbor/harbor-oidc-config-job.yaml`: `oidc_scope` changed from `openid,profile,email,groups` → `openid,profile,email`

Fixes digiorg/core#264