### PR TITLE
fix(opencost): rewrite Vite asset paths for UI subpath (#266)

### DIFF
--- a/platform/base/ingress/opencost-assets-ingress.yaml
+++ b/platform/base/ingress/opencost-assets-ingress.yaml
@@ -5,11 +5,11 @@
 # cannot coexist on the same Ingress in NGINX Ingress Controller.
 #
 # This ingress strips the /opencost prefix when serving static JS/CSS assets:
-#   GET /opencost/index.abc.js → opencost:9090 at /index.abc.js
+#   GET /opencost/assets/index.abc.js → opencost:9090 at /assets/index.abc.js
 #
-# The matching HTML sub_filter (href="/index. → href="/opencost/index.) is
-# applied via configuration-snippet on the main digiorg-platform Ingress path
-# /opencost(/|$)(.*) — which uses the opencost-oauth2-proxy as backend.
+# The matching HTML sub_filter (src="/assets/ → src="/opencost/assets/) is
+# applied via the opencost-ui-proxy ConfigMap on locations = /opencost and
+# /opencost/ — which uses the opencost-oauth2-proxy as backend.
 #
 # Boot: applied by local-setup.nu bootstrap (not managed by ArgoCD).
 # Issue: #229 #231
@@ -34,9 +34,9 @@ spec:
     - host: digiorg.local
       http:
         paths:
-          # Routes /opencost/index.*.{js,css} and /opencost/favicon.* → opencost:9090
+          # Routes /opencost/assets/* and /opencost/favicon.* → opencost:9090
           # Static assets contain no sensitive data — bypass auth proxy intentionally.
-          - path: /opencost/((?:index|favicon)\..+)
+          - path: /opencost/(assets/.+|favicon\..+)
             pathType: ImplementationSpecific
             backend:
               service:

--- a/platform/base/opencost/ui-proxy.yaml
+++ b/platform/base/opencost/ui-proxy.yaml
@@ -10,14 +10,15 @@
 #   1. Strip the /opencost prefix when forwarding to opencost:9090
 #      (standard nginx proxy_pass with trailing / on location and upstream)
 #   2. Apply sub_filter to HTML responses:
-#        href="/index.  →  href="/opencost/index.
-#        src="/index.   →  src="/opencost/index.
+#        src="/assets/   →  src="/opencost/assets/
+#        href="/assets/  →  href="/opencost/assets/
+#        href="/favicon. →  href="/opencost/favicon.
 #      This ensures the Vite SPA's root-absolute asset paths are rewritten
 #      to the /opencost/ subpath so the browser fetches them correctly.
 #   3. Disable upstream gzip so sub_filter can operate on uncompressed HTML.
 #
 # The oauth2-proxy --upstream points to this service (port 9091).
-# Static assets (/opencost/index.*.{js,css}) bypass this proxy entirely and
+# Static assets (/opencost/assets/* and favicon) bypass this proxy entirely and
 # are served directly by opencost:9090 via the opencost-assets-ingress
 # (rewrite-target: /$1 strips the /opencost prefix at the NGINX ingress level).
 #
@@ -93,8 +94,8 @@ data:
                          https://digiorg.local/opencost/;
           sub_filter_once off;
           sub_filter_types  text/html;
-          sub_filter 'href="/index.' 'href="/opencost/index.';
-          sub_filter 'src="/index.'  'src="/opencost/index.';
+          sub_filter 'src="/assets/'   'src="/opencost/assets/';
+          sub_filter 'href="/assets/'  'href="/opencost/assets/';
           sub_filter 'href="/favicon.' 'href="/opencost/favicon.';
         }
 
@@ -117,11 +118,11 @@ data:
                          https://digiorg.local/opencost/;
 
           # Rewrite root-absolute Vite SPA asset paths to /opencost/ prefix
-          # OpenCost UI compiles with base '/' — assets referenced as /index.*.{js,css}
+          # OpenCost UI compiles with base '/' — assets referenced as /assets/* and /favicon.*
           sub_filter_once off;
           sub_filter_types  text/html;
-          sub_filter 'href="/index.' 'href="/opencost/index.';
-          sub_filter 'src="/index.'  'src="/opencost/index.';
+          sub_filter 'src="/assets/'   'src="/opencost/assets/';
+          sub_filter 'href="/assets/'  'href="/opencost/assets/';
           sub_filter 'href="/favicon.' 'href="/opencost/favicon.';
         }
       }


### PR DESCRIPTION
## Summary
- Update OpenCost UI proxy rewrite rules to match Vite `/assets/` output
- Route `/opencost/assets/*` through the static asset ingress
- Preserve favicon and existing auth/API routing behavior

## Changes
- `platform/base/opencost/ui-proxy.yaml`: rewrite `/assets/` references to `/opencost/assets/`
- `platform/base/ingress/opencost-assets-ingress.yaml`: route `/opencost/assets/*` to OpenCost UI service

## Verification
- [ ] `git diff --check`
- [ ] Reviewed diff for scoped OpenCost changes
- [ ] Runtime validation pending in cluster: `/opencost/` UI, asset loading, SSO redirect, `/opencost/model/*` API calls

Fixes digiorg/core#266