### PR TITLE
fix(platform): ArgoCD OutOfSync — pin Helm versions, HEAD→main, namespace pre-creation (#270)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,34 @@ Drei-Säulen-System: **Metriken** (Prometheus + Grafana) + **Traces** (Jaeger + 
 - **ArgoCD** — GitOps Continuous Delivery (mit Keycloak SSO)
 - **Crossplane** — Infrastructure-as-Code
 
+## Wellen-Abhängigkeitsgraph & Versions-Pinning-Policy
+
+### Sync-Wave-Reihenfolge
+
+| Wave | Anwendungen | Abhängigkeiten |
+|------|-------------|----------------|
+| -1 | **namespaces** | Keine — erstellt alle Platform-Namespaces vor |
+| 0 | cert-manager, cnpg, external-secrets, nats, postgresql | Namespaces (Wave -1) |
+| 1 | argocd, keycloak | Wave-0-Komponenten bereit |
+| 2 | backstage, gitea, grafana, harbor, jaeger, landingpage, opencost, sonarqube | Keycloak SSO (Wave 1), PostgreSQL (Wave 0) |
+| 3 | crossplane, kyverno, opensearch | Wave-2-Apps laufen |
+| 4 | crossplane-providers, fluentd, kyverno-policies | Crossplane/Kyverno (Wave 3) |
+| 5 | monitoring-extras | ServiceMonitor-CRD aus kube-prometheus-stack (Wave 2) |
+| 6 | crossplane-provider-configs | Crossplane-Provider (Wave 4) |
+| 7 | crossplane-xrds | Provider-Configs (Wave 6) |
+| 8 | core-catalog | XRDs registriert (Wave 7) |
+
+### Versions-Pinning-Policy
+
+**Helm-Charts** — Immer auf exakte Versionen pinnen (z.B. `1.43.2`), keine Floating Ranges (`1.*`, `1.2.x`).
+Gepinnte Versionen bewusst nach Tests aktualisieren und die Änderung in der PR-Beschreibung dokumentieren.
+
+**Git-Referenzen** — Immer `targetRevision: main` verwenden (niemals `HEAD`). Für Cross-Repository-Referenzen
+(z.B. core-catalog) auf einen spezifischen Commit-SHA pinnen und bewusst aktualisieren.
+
+**Cross-Repository-Abhängigkeiten** — `core-catalog.git` ist auf einen spezifischen Commit-SHA gepinnt.
+Bei Updates zuerst API/CRD-Kompatibilität mit dem core Wave 0–7 Stack validieren.
+
 ### Quick Start (Lokale Entwicklung)
 
 ```bash
@@ -261,6 +289,34 @@ Three-pillar system: **Metrics** (Prometheus + Grafana) + **Traces** (Jaeger + O
 #### 🚀 GitOps Engine
 - **ArgoCD** — GitOps Continuous Delivery (with Keycloak SSO)
 - **Crossplane** — Infrastructure-as-Code
+
+## Wave Dependency Graph & Version Pinning Policy
+
+### Sync Wave Order
+
+| Wave | Applications | Dependencies |
+|------|-------------|--------------|
+| -1 | **namespaces** | None — pre-creates all platform namespaces |
+| 0 | cert-manager, cnpg, external-secrets, nats, postgresql | Namespaces (wave -1) |
+| 1 | argocd, keycloak | Wave 0 components ready |
+| 2 | backstage, gitea, grafana, harbor, jaeger, landingpage, opencost, sonarqube | Keycloak SSO (wave 1), PostgreSQL (wave 0) |
+| 3 | crossplane, kyverno, opensearch | Wave 2 apps running |
+| 4 | crossplane-providers, fluentd, kyverno-policies | Crossplane/Kyverno (wave 3) |
+| 5 | monitoring-extras | ServiceMonitor CRD from kube-prometheus-stack (wave 2) |
+| 6 | crossplane-provider-configs | Crossplane providers (wave 4) |
+| 7 | crossplane-xrds | Provider configs (wave 6) |
+| 8 | core-catalog | XRDs registered (wave 7) |
+
+### Version Pinning Policy
+
+**Helm Charts** — Always pin to exact versions (e.g., `1.43.2`), never floating ranges (`1.*`, `1.2.x`).
+Update pinned versions deliberately after testing; document the change in the PR description.
+
+**Git References** — Always use `targetRevision: main` (never `HEAD`). For cross-repository
+references (e.g., core-catalog), pin to a specific commit SHA and update it consciously.
+
+**Cross-Repository Dependencies** — `core-catalog.git` is pinned to a specific commit SHA.
+When updating, validate API/CRD compatibility with the core wave 0–7 stack first.
 
 ### Quick Start (Local Development)
 

--- a/apps/platform/argocd.yaml
+++ b/apps/platform/argocd.yaml
@@ -13,7 +13,7 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core.git
-    targetRevision: HEAD
+    targetRevision: main
     path: platform/base/argocd
 
   destination:

--- a/apps/platform/backstage.yaml
+++ b/apps/platform/backstage.yaml
@@ -13,7 +13,7 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core.git
-    targetRevision: HEAD
+    targetRevision: main
     path: platform/base/backstage
 
   destination:

--- a/apps/platform/cert-manager.yaml
+++ b/apps/platform/cert-manager.yaml
@@ -13,7 +13,7 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core.git
-    targetRevision: HEAD
+    targetRevision: main
     path: platform/base/cert-manager
 
   destination:

--- a/apps/platform/core-catalog.yaml
+++ b/apps/platform/core-catalog.yaml
@@ -13,7 +13,9 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core-catalog.git
-    targetRevision: HEAD
+    # Pinned to specific commit to prevent silent breaking changes from HEAD.
+    # Update this SHA deliberately after validating compatibility with the core wave 0-7 stack.
+    targetRevision: 0ced57eb40a50ec170352ce4a59bffedd4a16a6c
     path: compositions/local
 
   destination:

--- a/apps/platform/crossplane-provider-configs.yaml
+++ b/apps/platform/crossplane-provider-configs.yaml
@@ -13,7 +13,7 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core.git
-    targetRevision: HEAD
+    targetRevision: main
     path: crossplane/providers/configs
 
   destination:

--- a/apps/platform/crossplane-providers.yaml
+++ b/apps/platform/crossplane-providers.yaml
@@ -13,7 +13,7 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core.git
-    targetRevision: HEAD
+    targetRevision: main
     path: crossplane/providers/packages
 
   destination:

--- a/apps/platform/crossplane-xrds.yaml
+++ b/apps/platform/crossplane-xrds.yaml
@@ -13,7 +13,7 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core.git
-    targetRevision: HEAD
+    targetRevision: main
     path: crossplane/xrds
 
   destination:

--- a/apps/platform/external-secrets.yaml
+++ b/apps/platform/external-secrets.yaml
@@ -27,7 +27,7 @@ spec:
 
     # Source 2: Values from Git repository
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       ref: values
 
   destination:

--- a/apps/platform/fluentd.yaml
+++ b/apps/platform/fluentd.yaml
@@ -13,7 +13,7 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core.git
-    targetRevision: HEAD
+    targetRevision: main
     path: platform/base/fluentd
 
   destination:

--- a/apps/platform/gitea.yaml
+++ b/apps/platform/gitea.yaml
@@ -27,7 +27,7 @@ spec:
     
     # Source 2: Values from Git repository
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       ref: values
   
   destination:

--- a/apps/platform/grafana.yaml
+++ b/apps/platform/grafana.yaml
@@ -20,7 +20,7 @@ spec:
         valueFiles:
           - $values/platform/base/grafana/values.yaml
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       ref: values
 
   destination:

--- a/apps/platform/harbor.yaml
+++ b/apps/platform/harbor.yaml
@@ -12,16 +12,16 @@ spec:
   sources:
     - repoURL: https://helm.goharbor.io
       chart: harbor
-      targetRevision: "1.*"
+      targetRevision: "1.19.1"
       helm:
         releaseName: harbor
         valueFiles:
           - $values/platform/base/harbor/values.yaml
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       path: platform/base/harbor
   destination:
     server: https://kubernetes.default.svc

--- a/apps/platform/jaeger.yaml
+++ b/apps/platform/jaeger.yaml
@@ -12,16 +12,16 @@ spec:
   sources:
     - repoURL: https://jaegertracing.github.io/helm-charts
       chart: jaeger
-      targetRevision: "4.x"
+      targetRevision: "4.11.1"
       helm:
         releaseName: jaeger
         valueFiles:
           - $values/platform/base/jaeger/values.yaml
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       path: platform/base/jaeger
   destination:
     server: https://kubernetes.default.svc

--- a/apps/platform/keycloak.yaml
+++ b/apps/platform/keycloak.yaml
@@ -13,7 +13,7 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core.git
-    targetRevision: HEAD
+    targetRevision: main
     path: platform/base/keycloak
 
   destination:

--- a/apps/platform/kyverno-policies.yaml
+++ b/apps/platform/kyverno-policies.yaml
@@ -15,7 +15,7 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core.git
-    targetRevision: HEAD
+    targetRevision: main
     path: policies/kyverno
 
   destination:

--- a/apps/platform/landingpage.yaml
+++ b/apps/platform/landingpage.yaml
@@ -13,7 +13,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/digiorg/core.git
-    targetRevision: HEAD
+    targetRevision: main
     path: platform/base/landingpage
   destination:
     server: https://kubernetes.default.svc

--- a/apps/platform/namespaces.yaml
+++ b/apps/platform/namespaces.yaml
@@ -1,33 +1,32 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: monitoring-extras
+  name: namespaces
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    # Wave 5: After grafana/kube-prometheus-stack (Wave 2) — ensures ServiceMonitor CRD is registered
-    argocd.argoproj.io/sync-wave: "5"
+    # Wave -1: Pre-create all platform namespaces before any workload app runs.
+    # This eliminates 409 Conflict races when multiple Wave 2 apps target the same namespace.
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   project: default
 
   source:
     repoURL: https://github.com/digiorg/core.git
     targetRevision: main
-    path: platform/base/monitoring-extras
+    path: platform/base/namespaces
 
   destination:
     server: https://kubernetes.default.svc
-    namespace: monitoring
+    namespace: argocd
 
   syncPolicy:
     automated:
       selfHeal: true
-      prune: true
+      prune: false  # Never prune namespaces — workloads may still be running
     syncOptions:
-      - CreateNamespace=true
       - ServerSideApply=true
-      - SkipDryRunOnMissingResource=true
     retry:
       limit: 5
       backoff:

--- a/apps/platform/nats.yaml
+++ b/apps/platform/nats.yaml
@@ -16,7 +16,7 @@ spec:
     # NATS Server via Helm chart
     - repoURL: https://nats-io.github.io/k8s/helm/charts
       chart: nats
-      targetRevision: "1.2.x"
+      targetRevision: "1.2.11"
       helm:
         releaseName: nats
         valueFiles:
@@ -24,12 +24,12 @@ spec:
 
     # Reference to values file in Git repo
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       ref: values
 
     # Surveyor, oauth2-proxy, namespace via Kustomize
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       path: platform/base/nats
 
   destination:

--- a/apps/platform/opencost.yaml
+++ b/apps/platform/opencost.yaml
@@ -12,16 +12,16 @@ spec:
   sources:
     - repoURL: https://opencost.github.io/opencost-helm-chart
       chart: opencost
-      targetRevision: "1.*"
+      targetRevision: "1.43.2"
       helm:
         releaseName: opencost
         valueFiles:
           - $values/platform/base/opencost/values.yaml
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       path: platform/base/opencost
   destination:
     server: https://kubernetes.default.svc

--- a/apps/platform/opensearch.yaml
+++ b/apps/platform/opensearch.yaml
@@ -23,12 +23,12 @@ spec:
 
     # Reference to values file in Git repo
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       ref: values
 
     # ServiceMonitor and supplementary resources via Kustomize
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       path: platform/base/opensearch
 
   destination:

--- a/apps/platform/postgresql.yaml
+++ b/apps/platform/postgresql.yaml
@@ -13,7 +13,7 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core.git
-    targetRevision: HEAD
+    targetRevision: main
     path: platform/base/postgresql
 
   destination:

--- a/apps/platform/sonarqube.yaml
+++ b/apps/platform/sonarqube.yaml
@@ -15,7 +15,7 @@ spec:
     # SonarQube Community Build Helm chart
     - repoURL: https://SonarSource.github.io/helm-chart-sonarqube
       chart: sonarqube
-      targetRevision: "10.*"
+      targetRevision: "10.8.1"
       helm:
         releaseName: sonarqube
         valueFiles:
@@ -23,12 +23,12 @@ spec:
 
     # Reference to values file in Git repo
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       ref: values
 
     # Namespace + additional manifests via Kustomize
     - repoURL: https://github.com/digiorg/core.git
-      targetRevision: HEAD
+      targetRevision: main
       path: platform/base/sonarqube
 
   destination:

--- a/platform/base/argocd/applications/root-app.yaml
+++ b/platform/base/argocd/applications/root-app.yaml
@@ -14,7 +14,7 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core.git
-    targetRevision: HEAD
+    targetRevision: main
     # Point to the apps/ directory — ArgoCD will discover all Application manifests here
     path: apps
     directory:

--- a/platform/base/namespaces/kustomization.yaml
+++ b/platform/base/namespaces/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespaces.yaml

--- a/platform/base/namespaces/namespaces.yaml
+++ b/platform/base/namespaces/namespaces.yaml
@@ -1,0 +1,163 @@
+# Pre-created platform namespaces (Wave -1)
+# Purpose: Eliminate 409 Conflict races when multiple Wave 2+ apps
+#          try to CreateNamespace=true for the same namespace simultaneously.
+#
+# Race conditions previously observed:
+#   - monitoring:       grafana (wave 2) + monitoring-extras (wave 5)
+#   - cost-monitoring:  opencost (wave 2)
+#   - tracing:          jaeger (wave 2)
+#   - harbor:           harbor (wave 2)
+#   - code-quality:     sonarqube (wave 2)
+#   - messaging:        nats (wave 0)
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: core
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: observability
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tracing
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: observability
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cost-monitoring
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: finops
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: harbor
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: registry
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: code-quality
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: platform-services
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: messaging
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: platform-services
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: security
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: security
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: auth
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: platform-db
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: data
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cnpg
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: data
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane-system
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: iac
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kyverno
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: policy
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitea
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: platform-services
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: backstage
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: developer-portal
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: landingpage
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: platform-services
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opensearch
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: observability
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logging
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: observability


### PR DESCRIPTION
## Summary

Implements all three phases from issue #270 to resolve persistent ArgoCD OutOfSync conditions.

## Changes

### Phase 1 — Pin floating Helm chart versions
- `opencost`: `1.*` → `1.43.2`
- `nats`: `1.2.x` → `1.2.11`
- `harbor`: `1.*` → `1.19.1`
- `sonarqube`: `10.*` → `10.8.1`
- `jaeger`: `4.x` → `4.11.1`

### Phase 2 — Stabilize Git references & eliminate namespace races
- Replaced all `targetRevision: HEAD` → `targetRevision: main` across all `apps/platform/*.yaml` and `root-app.yaml`
- Created `apps/platform/namespaces.yaml` (Wave -1) — pre-creates all platform namespaces
- Created `platform/base/namespaces/` — Namespace manifests for all platform components

### Phase 3 — Pin core-catalog cross-repo reference
- `core-catalog`: `targetRevision: HEAD` → pinned to commit `0ced57eb40a5` (latest main as of 2026-06-12)

### Documentation
- Added wave dependency graph and version pinning policy to README.md

## Acceptance Criteria
- [x] All 5 floating Helm version constraints replaced with pinned versions
- [x] Namespaces pre-created in Wave -1; namespace races eliminated
- [x] All `targetRevision: HEAD` replaced with `targetRevision: main` across `apps/platform/`
- [x] core-catalog references a pinned commit SHA of core-catalog.git (not HEAD)
- [x] README updated with wave dependency graph and version-pinning policy

Fixes digiorg/core#270