### PR TITLE
fix(opencost): support Parcel and Vite assets under /opencost

### DIFF
--- a/platform/base/ingress/opencost-assets-ingress.yaml
+++ b/platform/base/ingress/opencost-assets-ingress.yaml
@@ -4,23 +4,27 @@
 # Separate Ingress required because rewrite-target and configuration-snippet
 # cannot coexist on the same Ingress in NGINX Ingress Controller.
 #
-# This ingress strips the /opencost prefix when serving static assets:
-#   GET /opencost/index.6dd063c6.js → opencost:9090 at /index.6dd063c6.js
-#   GET /opencost/favicon.ico       → opencost:9090 at /favicon.ico
-#   GET /opencost/index.abc.js → opencost:9090 at /index.abc.js
+# This ingress strips the /opencost prefix when serving static assets, for
+# BOTH known OpenCost UI build layouts:
+#   Parcel v2 (root-level chunks):
+#     GET /opencost/index.6dd063c6.js → opencost:9090 at /index.6dd063c6.js
+#     GET /opencost/index.runtime.abc.js → opencost:9090 at /index.runtime.abc.js
+#     GET /opencost/favicon.ico       → opencost:9090 at /favicon.ico
+#   Vite (/assets/* chunks):
+#     GET /opencost/assets/index-abc.js → opencost:9090 at /assets/index-abc.js
 #
-# The deployed OpenCost UI is a Parcel v2 build that emits root-level chunks
-# (/index.*.js, /index.runtime.*.js, /index.*.css) rather than Vite's
-# /assets/* layout, so index.* and favicon.* are the patterns required today.
-# The assets/.+ alternative has been removed as the current build does not
-# emit /assets/* paths.
+# The currently deployed build is Parcel v2; the assets/.+ alternative is kept
+# so a future Vite-based OpenCost UI release keeps working without a manifest
+# change. The path uses a single capturing group (RE2-compatible — no
+# non-capturing (?:...) group) so rewrite-target: /$1 numbering stays correct.
 #
-# The matching HTML sub_filter (src="/index. → src="/opencost/index., etc.)
-# is applied via the opencost-ui-proxy ConfigMap on locations = /opencost and
-# /opencost/ — which uses the opencost-oauth2-proxy as backend.
+# The matching HTML sub_filter (src="/index. → src="/opencost/index., plus the
+# /assets/ equivalents) is applied via the opencost-ui-proxy ConfigMap on
+# locations = /opencost and /opencost/ — which uses the opencost-oauth2-proxy
+# as backend.
 #
 # Boot: applied by local-setup.nu bootstrap (not managed by ArgoCD).
-# Issue: #229 #231 #266 #268
+# Issue: #229 #231 #266 #268 #272
 # =============================================================================
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -42,10 +46,15 @@ spec:
     - host: digiorg.local
       http:
         paths:
-          # Routes /opencost/index.*, /opencost/favicon.* and /opencost/assets/*
-          # → opencost:9090. Static assets contain no sensitive data — bypass
-          # auth proxy intentionally.
-          - path: /opencost/((?:index|favicon)\..+)
+          # Routes /opencost/index.*, /opencost/favicon.* (Parcel) and
+          # /opencost/assets/* (Vite) → opencost:9090. Static assets contain no
+          # sensitive data — bypass auth proxy intentionally.
+          #
+          # The three alternatives sit inside a SINGLE capturing group so the
+          # rewrite-target keeps referencing $1 (the path after /opencost/).
+          # No non-capturing (?:...) group is used: ingress-nginx validates
+          # paths with RE2, which we keep strictly compatible here.
+          - path: /opencost/(assets/.+|index\..+|favicon\..+)
             pathType: ImplementationSpecific
             backend:
               service:

--- a/platform/base/opencost/ui-proxy.yaml
+++ b/platform/base/opencost/ui-proxy.yaml
@@ -9,18 +9,22 @@
 # Responsibilities:
 #   1. Strip the /opencost prefix when forwarding to opencost:9090
 #      (standard nginx proxy_pass with trailing / on location and upstream)
-#   2. Apply sub_filter to HTML responses:
-#        src="/index.    →  src="/opencost/index.
-#        href="/index.   →  href="/opencost/index.
-#        href="/favicon. →  href="/opencost/favicon.
-#      The deployed OpenCost UI is a Parcel v2 build that emits root-level
-#      chunks (e.g. /index.6dd063c6.js, /index.runtime.216fe643.js,
-#      /index.3406705b.css) rather than Vite's /assets/* layout. Without
-#      these rewrites the browser requests those chunks at the domain root
-#      (https://digiorg.local/index.*) and gets 404s — a white /opencost page.
-#      The src="/assets/ and href="/assets/ Vite-style rules have been
-#      removed as the current Parcel build does not emit /assets/* paths
-#      and nginx does not support duplicate sub_filter keys within a block.
+#   2. Apply sub_filter to HTML responses, covering BOTH UI build layouts:
+#        Parcel v2 (root-level chunks):
+#          src="/index.    →  src="/opencost/index.
+#          href="/index.   →  href="/opencost/index.
+#          href="/favicon. →  href="/opencost/favicon.
+#        Vite (/assets/* chunks):
+#          src="/assets/   →  src="/opencost/assets/
+#          href="/assets/  →  href="/opencost/assets/
+#      The currently deployed OpenCost UI is a Parcel v2 build that emits
+#      root-level chunks (e.g. /index.6dd063c6.js, /index.runtime.216fe643.js,
+#      /index.3406705b.css), while newer OpenCost UI releases ship a Vite build
+#      that emits /assets/*. Without these rewrites the browser requests those
+#      chunks at the domain root (https://digiorg.local/index.* or /assets/*)
+#      and gets 404s — a white /opencost page. nginx 1.27 supports multiple
+#      sub_filter directives at one level (they are NOT duplicate keys — each is
+#      a distinct search string), so both layouts' rules coexist in every block.
 #   3. Disable upstream gzip so sub_filter can operate on uncompressed HTML
 #      (Accept-Encoding "" is sent upstream, so the response body is never
 #      gzip-encoded and the ngx_http_gunzip_module is not required here).
@@ -31,7 +35,7 @@
 # opencost-assets-ingress (rewrite-target: /$1 strips the /opencost prefix
 # at the NGINX ingress level).
 #
-# Issue: #233 #266 #268
+# Issue: #233 #266 #268 #272
 # =============================================================================
 ---
 apiVersion: v1
@@ -101,11 +105,17 @@ data:
           proxy_set_header   Accept-Encoding   "";
           proxy_redirect http://opencost.cost-monitoring.svc.cluster.local:9090/
                          https://digiorg.local/opencost/;
+          # Rewrite root-absolute SPA asset paths for BOTH build layouts.
+          # nginx 1.27 applies every sub_filter directive at this level in a
+          # single pass, so the Parcel (/index.*, /favicon.*) and Vite
+          # (/assets/*) rules coexist without conflict.
           sub_filter_once off;
           sub_filter_types  text/html;
           sub_filter 'src="/index.'    'src="/opencost/index.';
           sub_filter 'href="/index.'   'href="/opencost/index.';
           sub_filter 'href="/favicon.' 'href="/opencost/favicon.';
+          sub_filter 'src="/assets/'   'src="/opencost/assets/';
+          sub_filter 'href="/assets/'  'href="/opencost/assets/';
         }
 
         location /opencost/ {
@@ -127,15 +137,24 @@ data:
                          https://digiorg.local/opencost/;
 
           # Rewrite root-absolute SPA asset paths to the /opencost/ prefix.
-          # OpenCost UI compiles with base '/' — the current Parcel v2 build
-          # emits root-level chunks referenced as /index.* (JS/CSS) and
-          # /favicon.*. The Vite-style /assets/ rules have been removed as
-          # they are not emitted by the current build.
+          # OpenCost UI compiles with base '/', so both known build layouts
+          # emit root-level references that must be prefixed:
+          #   * Parcel v2 — /index.*.js, /index.runtime.*.js, /index.*.css,
+          #                 /favicon.*
+          #   * Vite      — /assets/*.js, /assets/*.css
+          # nginx 1.27 supports multiple sub_filter directives at one level and
+          # applies them in a single pass, so keeping both layouts' rules here
+          # is robust across a UI toolchain switch. nginx does not recursively
+          # re-scan a sub_filter's replacement output, so an already-rewritten
+          # /opencost/index. or /opencost/assets/ reference cannot be prefixed a
+          # second time.
           sub_filter_once off;
           sub_filter_types  text/html;
           sub_filter 'src="/index.'    'src="/opencost/index.';
           sub_filter 'href="/index.'   'href="/opencost/index.';
           sub_filter 'href="/favicon.' 'href="/opencost/favicon.';
+          sub_filter 'src="/assets/'   'src="/opencost/assets/';
+          sub_filter 'href="/assets/'  'href="/opencost/assets/';
         }
       }
     }

--- a/platform/tests/README.md
+++ b/platform/tests/README.md
@@ -1,0 +1,33 @@
+# Platform manifest regression tests
+
+Deterministic tests that parse the platform manifests and assert their
+**behaviour** (not just the presence of a string), so subpath/proxy regressions
+are caught in review rather than in the cluster.
+
+## Requirements
+
+- Python 3
+- PyYAML (`pip install pyyaml`)
+
+No cluster, pytest, or network access required.
+
+## Scope of the HTML fixtures
+
+The Parcel and Vite HTML fixtures in `test_opencost_ui_subpath.py` are
+representative, hand-written snapshots of the two build layouts — they are
+**not** dynamically extracted from the exact OpenCost container image in use.
+They assert that the manifests correctly handle the *shapes* of root-absolute
+references each layout emits (`/index.*`, `/favicon.*`, `/assets/*`); they do
+not guarantee byte-for-byte parity with the pinned image's actual output.
+
+## Running
+
+```sh
+python3 platform/tests/test_opencost_ui_subpath.py
+```
+
+## Coverage
+
+| Test file | Manifests under test | What it proves |
+| --- | --- | --- |
+| `test_opencost_ui_subpath.py` | `platform/base/opencost/ui-proxy.yaml`, `platform/base/ingress/opencost-assets-ingress.yaml` | The `/opencost` subpath proxy rewrites root-absolute asset references for **both** the Parcel (`/index.*`, `/favicon.*`) and Vite (`/assets/*`) UI layouts in every serving location, keeps gzip disabled and the redirect rewrite intact, and the asset ingress routes both layouts with an RE2-compatible expression (no non-capturing groups) whose `rewrite-target: /$1` capture strips `/opencost/` correctly. See GitHub issue #272. |

--- a/platform/tests/test_opencost_ui_subpath.py
+++ b/platform/tests/test_opencost_ui_subpath.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# =============================================================================
+# Regression tests for the OpenCost /opencost subpath UI proxy and asset ingress
+#
+# These tests parse the real platform manifests and assert their *behaviour*
+# rather than grepping for a single arbitrary string:
+#
+#   * ui-proxy.yaml    — the nginx sub_filter rules are extracted per location
+#                        block and replayed against sample Parcel and Vite HTML
+#                        to prove root-absolute references get rewritten under
+#                        /opencost/ for BOTH UI layouts.
+#   * opencost-assets-ingress.yaml — the path regex is compiled and matched
+#                        against real Parcel (/index.*, /favicon.*) and Vite
+#                        (/assets/*) asset URLs, and the rewrite-target capture
+#                        is replayed to prove the /opencost/ prefix is stripped
+#                        correctly. The expression is also asserted to be
+#                        RE2-compatible (no non-capturing (?:...) groups).
+#
+# Context: GitHub issue #272 (Option B — robust dual Parcel + Vite support).
+#
+# NOTE: PARCEL_HTML and VITE_HTML below are representative, hand-written
+# snapshots of the two build layouts' index.html — they are NOT dynamically
+# extracted from the exact OpenCost container image in use. They exercise the
+# reference *shapes* the manifests must handle (root-absolute /index.*,
+# /favicon.*, /assets/* references); they do not guarantee byte-for-byte parity
+# with whatever the pinned image happens to emit.
+#
+# Runs with the standard library + PyYAML only (no pytest required):
+#     python3 platform/tests/test_opencost_ui_subpath.py
+# =============================================================================
+import os
+import re
+import unittest
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+UI_PROXY = os.path.join(REPO_ROOT, "platform", "base", "opencost", "ui-proxy.yaml")
+ASSETS_INGRESS = os.path.join(
+    REPO_ROOT, "platform", "base", "ingress", "opencost-assets-ingress.yaml"
+)
+
+# Representative index.html snapshots for the two UI build layouts the proxy
+# must support simultaneously (see module NOTE — these are illustrative, not
+# extracted from the exact container image).
+# Parcel v2 emits root-level chunks (/index.*.js|css, /favicon.*).
+PARCEL_HTML = (
+    '<!doctype html><html><head>'
+    '<link href="/favicon.a1b2c3.png" rel="icon">'
+    '<link href="/index.3406705b.css" rel="stylesheet">'
+    '</head><body>'
+    '<script src="/index.6dd063c6.js"></script>'
+    '<script src="/index.runtime.216fe643.js"></script>'
+    '</body></html>'
+)
+# Vite emits hashed assets under /assets/*.
+VITE_HTML = (
+    '<!doctype html><html><head>'
+    '<link rel="stylesheet" href="/assets/index-8f7e0a12.css">'
+    '</head><body>'
+    '<script type="module" src="/assets/index-4b3c2d1e.js"></script>'
+    '</body></html>'
+)
+
+
+def load_yaml_docs(path):
+    with open(path, "r", encoding="utf-8") as fh:
+        return [d for d in yaml.safe_load_all(fh) if d is not None]
+
+
+def extract_nginx_conf(path):
+    """Return the nginx.conf string from the opencost-ui-proxy ConfigMap."""
+    for doc in load_yaml_docs(path):
+        if doc.get("kind") == "ConfigMap" and "nginx.conf" in doc.get("data", {}):
+            return doc["data"]["nginx.conf"]
+    raise AssertionError("nginx.conf ConfigMap not found in %s" % path)
+
+
+def extract_location_blocks(nginx_conf):
+    """Parse `location ... { ... }` blocks into {header: body} by brace matching.
+
+    Keys are the raw location header text (e.g. '= /opencost', '/opencost/').
+    """
+    blocks = {}
+    for m in re.finditer(r"location\s+([^\{]+?)\s*\{", nginx_conf):
+        header = m.group(1).strip()
+        i = m.end() - 1  # position of the opening brace
+        depth = 0
+        for j in range(i, len(nginx_conf)):
+            c = nginx_conf[j]
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    blocks[header] = nginx_conf[i + 1 : j]
+                    break
+    return blocks
+
+
+def parse_sub_filters(block_body):
+    """Return list of (from, to) literal sub_filter pairs in a location block."""
+    pairs = []
+    for m in re.finditer(
+        r"sub_filter\s+(['\"])(.*?)\1\s+(['\"])(.*?)\3\s*;", block_body
+    ):
+        pairs.append((m.group(2), m.group(4)))
+    return pairs
+
+
+def apply_sub_filters(html, pairs):
+    """Replay nginx sub_filter literal replacements against an HTML string.
+
+    nginx applies every configured filter to the response buffer; replacement
+    output is not re-scanned, so a single ordered pass of str.replace is a
+    faithful simulation for non-overlapping rules.
+    """
+    for src, dst in pairs:
+        html = html.replace(src, dst)
+    return html
+
+
+class UiProxySubFilterTest(unittest.TestCase):
+    """The nginx sub_filter rules must rewrite BOTH Parcel and Vite assets."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.conf = extract_nginx_conf(UI_PROXY)
+        cls.blocks = extract_location_blocks(cls.conf)
+
+    # Both the bare-path exact match and the trailing-slash prefix serve HTML.
+    SERVING_LOCATIONS = ("= /opencost", "/opencost/")
+
+    def test_both_serving_locations_present(self):
+        for loc in self.SERVING_LOCATIONS:
+            self.assertIn(
+                loc, self.blocks, "expected a `location %s` block in nginx.conf" % loc
+            )
+
+    def test_parcel_layout_rewritten_in_all_locations(self):
+        for loc in self.SERVING_LOCATIONS:
+            pairs = parse_sub_filters(self.blocks[loc])
+            out = apply_sub_filters(PARCEL_HTML, pairs)
+            for ref in (
+                '/opencost/index.6dd063c6.js',
+                '/opencost/index.runtime.216fe643.js',
+                '/opencost/index.3406705b.css',
+                '/opencost/favicon.a1b2c3.png',
+            ):
+                self.assertIn(
+                    ref, out, "Parcel ref %s not rewritten in `location %s`" % (ref, loc)
+                )
+            # No root-absolute Parcel references may survive the rewrite.
+            for stale in ('src="/index.', 'href="/index.', 'href="/favicon.'):
+                self.assertNotIn(
+                    stale,
+                    out,
+                    "stale root-absolute %r remains in `location %s`" % (stale, loc),
+                )
+
+    def test_vite_layout_rewritten_in_all_locations(self):
+        for loc in self.SERVING_LOCATIONS:
+            pairs = parse_sub_filters(self.blocks[loc])
+            out = apply_sub_filters(VITE_HTML, pairs)
+            for ref in (
+                '/opencost/assets/index-4b3c2d1e.js',
+                '/opencost/assets/index-8f7e0a12.css',
+            ):
+                self.assertIn(
+                    ref, out, "Vite ref %s not rewritten in `location %s`" % (ref, loc)
+                )
+            for stale in ('src="/assets/', 'href="/assets/'):
+                self.assertNotIn(
+                    stale,
+                    out,
+                    "stale root-absolute %r remains in `location %s`" % (stale, loc),
+                )
+
+    def test_gzip_disabled_for_sub_filter(self):
+        # sub_filter only operates on uncompressed HTML, so upstream gzip must
+        # stay disabled via Accept-Encoding "" in both serving locations.
+        for loc in self.SERVING_LOCATIONS:
+            self.assertRegex(
+                self.blocks[loc],
+                r'proxy_set_header\s+Accept-Encoding\s+"";',
+                "Accept-Encoding gzip guard missing in `location %s`" % loc,
+            )
+
+    def test_redirect_rewrite_preserved(self):
+        # The upstream->public Location rewrite must survive (no port leak).
+        for loc in self.SERVING_LOCATIONS:
+            self.assertIn(
+                "https://digiorg.local/opencost/",
+                self.blocks[loc],
+                "proxy_redirect target missing in `location %s`" % loc,
+            )
+
+
+class AssetsIngressRegexTest(unittest.TestCase):
+    """The asset ingress must route Parcel AND Vite assets, RE2-compatibly."""
+
+    @classmethod
+    def setUpClass(cls):
+        docs = load_yaml_docs(ASSETS_INGRESS)
+        ing = next(d for d in docs if d.get("kind") == "Ingress")
+        cls.ingress = ing
+        ann = ing["metadata"]["annotations"]
+        cls.rewrite_target = ann["nginx.ingress.kubernetes.io/rewrite-target"]
+        paths = ing["spec"]["rules"][0]["http"]["paths"]
+        # The single asset path rule.
+        cls.path = paths[0]["path"]
+        # nginx/ingress-nginx anchors the location regex at the start.
+        cls.regex = re.compile("^" + cls.path)
+
+    def test_no_non_capturing_groups(self):
+        # RE2 as used by ingress-nginx path validation: reject (?:...).
+        self.assertNotIn(
+            "(?:",
+            self.path,
+            "non-capturing group (?:...) is not RE2/ingress-safe: %r" % self.path,
+        )
+
+    def test_rewrite_target_capture_numbering(self):
+        # Every $N referenced by the rewrite-target must exist as a capture group.
+        refs = [int(n) for n in re.findall(r"\$(\d+)", self.rewrite_target)]
+        self.assertTrue(refs, "rewrite-target must reference a capture group")
+        self.assertLessEqual(
+            max(refs),
+            self.regex.groups,
+            "rewrite-target %r references more groups than the path regex defines"
+            % self.rewrite_target,
+        )
+
+    def _rewritten(self, url):
+        """Return the upstream path after applying rewrite-target, or None."""
+        m = self.regex.match(url)
+        if not m:
+            return None
+        out = self.rewrite_target
+        for i in range(1, self.regex.groups + 1):
+            out = out.replace("$%d" % i, m.group(i) or "")
+        return out
+
+    def test_parcel_assets_routed_and_stripped(self):
+        cases = {
+            "/opencost/index.6dd063c6.js": "/index.6dd063c6.js",
+            "/opencost/index.runtime.216fe643.js": "/index.runtime.216fe643.js",
+            "/opencost/index.3406705b.css": "/index.3406705b.css",
+            "/opencost/favicon.ico": "/favicon.ico",
+        }
+        for url, expected in cases.items():
+            self.assertEqual(
+                self._rewritten(url), expected, "Parcel asset %s mis-routed" % url
+            )
+
+    def test_vite_assets_routed_and_stripped(self):
+        cases = {
+            "/opencost/assets/index-4b3c2d1e.js": "/assets/index-4b3c2d1e.js",
+            "/opencost/assets/index-8f7e0a12.css": "/assets/index-8f7e0a12.css",
+        }
+        for url, expected in cases.items():
+            self.assertEqual(
+                self._rewritten(url), expected, "Vite asset %s mis-routed" % url
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Implements **Option B** from #272 by making the OpenCost `/opencost` subpath integration compatible with both known UI build layouts:

- Parcel v2 root-level assets: `/index.*`, `/index.runtime.*`, `/favicon.*`
- Vite assets: `/assets/*`

The change intentionally does not implement Option A or C and does not modify Argo CD ownership, ConfigMap rollout behavior, or the public hostname architecture.

## Changes

### UI proxy

- Keeps the existing Parcel `sub_filter` rules.
- Adds Vite `/assets/*` rules in both HTML-serving nginx locations:
  - `location = /opencost`
  - `location /opencost/`
- Preserves the existing gzip guard, redirect rewrite, upstream proxy, authentication chain, and API base URL behavior.
- Corrects documentation that previously treated Parcel and Vite rules as mutually exclusive. NGINX 1.27 supports multiple `sub_filter` directives at one configuration level.

### Static asset ingress

Changes the asset path to the RE2-compatible expression:

```yaml
/opencost/(assets/.+|index\..+|favicon\..+)
```

This:

- routes both Parcel and Vite assets;
- removes the unsupported non-capturing `(?:...)` group;
- retains one capturing group so `rewrite-target: /$1` strips `/opencost/` correctly.

### Regression coverage

Adds a deterministic Python/PyYAML test suite that:

- parses the real Kubernetes manifests;
- extracts both nginx HTML-serving location blocks;
- replays the configured `sub_filter` rules against representative Parcel and Vite HTML fixtures;
- checks that root-absolute asset paths become `/opencost/...` paths;
- checks Parcel and Vite ingress routing and prefix stripping;
- verifies capture numbering, absence of `(?:...)`, gzip handling, and redirect preservation.

The fixtures are documented as representative snapshots rather than byte-for-byte extracts from the container image.

## TDD evidence

### RED

Before changing the production manifests:

```text
python3 platform/tests/test_opencost_ui_subpath.py
FAILED (failures=3)
```

Expected failures:

- Vite references were not rewritten by the UI proxy.
- `/opencost/assets/*` was not routed by the asset ingress.
- The ingress path contained the non-RE2 `(?:...)` group.

### GREEN

```text
python3 platform/tests/test_opencost_ui_subpath.py
Ran 9 tests in 0.015s
OK
```

Additional validation:

- `ui-proxy.yaml`: 3 YAML documents parsed successfully
- `opencost-assets-ingress.yaml`: 1 YAML document parsed successfully
- `git diff --check`: clean
- Independent Claude Opus 4.8 review: **PASS**, no blocking findings

## Remaining limitations

This PR implements Option B only. The delivery-path findings documented in #272 remain separate follow-up concerns:

- the asset ingress is still bootstrap-managed rather than reconciled by Argo CD;
- the UI proxy ConfigMap still uses a `subPath` mount without an automatic rollout trigger.

Those concerns should be addressed independently if runtime configuration remains stale after this PR is applied.

## Acceptance criteria covered

- [x] Parcel `/index.*` and `/favicon.*` references are rewritten and routed.
- [x] Vite `/assets/*` references are rewritten and routed.
- [x] The ingress expression avoids non-capturing groups.
- [x] `rewrite-target: /$1` preserves the correct upstream paths.
- [x] Existing API, redirect, gzip, and auth behavior remains unchanged.
- [x] Automated regression coverage exists for both layouts.

Addresses #272 (implements durable correction Option B only; the delivery-path follow-ups remain open).
