### PR TITLE
feat(platform): stage pinned component upgrades

### DIFF
--- a/.github/workflows/platform-validation.yml
+++ b/.github/workflows/platform-validation.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Install PyYAML
         run: |
-          printf '%s\n' 'PyYAML==6.0.3 --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc' |
-            python3 -m pip install --disable-pip-version-check --only-binary=:all: --require-hashes -r -
+          printf '%s\n' 'PyYAML==6.0.3 --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc' > /tmp/pyyaml-requirements.txt
+          python3 -m pip install --disable-pip-version-check --only-binary=:all: --require-hashes -r /tmp/pyyaml-requirements.txt
 
       - name: Pin policy (reject floating / unpinned references)
         run: python3 scripts/check_pins.py
@@ -115,6 +115,8 @@ jobs:
           git config core.whitespace trailing-space,space-before-tab
           base="${PR_BASE_SHA:-${PUSH_BEFORE_SHA:-}}"
           if [[ -z "$base" || "$base" =~ ^0+$ ]]; then
-            base="$(git rev-list --max-parents=0 HEAD | tail -1)"
+            # A newly created branch has an all-zero `before` SHA. Compare only
+            # the branch delta, not every historical whitespace issue in the repo.
+            base="$(git merge-base origin/main HEAD)"
           fi
           git diff --check "$base"...HEAD

--- a/.github/workflows/platform-validation.yml
+++ b/.github/workflows/platform-validation.yml
@@ -1,0 +1,120 @@
+# =============================================================================
+# Platform validation CI (Issue #275)
+# =============================================================================
+# Enforces the version-remediation guardrails on every push and pull request:
+#   * the pin policy (scripts/check_pins.py) rejects floating image tags,
+#     unpinned/range chart versions and non-immutable git sources;
+#   * the platform regression tests (platform/tests) lock the migrations,
+#     image build contracts, CNPG migration safety and the OpenCost /opencost
+#     contract;
+#   * kustomize renders every base (including pinned remote release assets);
+#   * Nushell scripts parse;
+#   * git diff --check catches whitespace/conflict-marker errors.
+#
+# All checks are static — no cluster, Helm install or registry credentials.
+# =============================================================================
+name: platform-validation
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  pin-policy-and-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install PyYAML
+        run: |
+          printf '%s\n' 'PyYAML==6.0.3 --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc' |
+            python3 -m pip install --disable-pip-version-check --only-binary=:all: --require-hashes -r -
+
+      - name: Pin policy (reject floating / unpinned references)
+        run: python3 scripts/check_pins.py
+
+      - name: Platform regression tests
+        run: python3 -m unittest discover -s platform/tests -p 'test_*.py' -v
+
+      - name: Install Helm
+        run: |
+          set -euo pipefail
+          curl -fsSL https://get.helm.sh/helm-v4.2.3-linux-amd64.tar.gz -o /tmp/helm.tgz
+          echo 'e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c  /tmp/helm.tgz' | sha256sum -c -
+          tar -xzf /tmp/helm.tgz -C /tmp
+          sudo install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
+
+      - name: Render every Helm source and reject floating chart images
+        run: python3 scripts/render_platform_charts.py
+
+  render-and-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Install kustomize
+        run: |
+          set -euo pipefail
+          KUSTOMIZE_VERSION=v5.8.1
+          curl -fsSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" -o /tmp/kustomize.tgz
+          echo '029a7f0f4e1932c52a0476cf02a0fd855c0bb85694b82c338fc648dcb53a819d  /tmp/kustomize.tgz' | sha256sum -c -
+          tar -xzf /tmp/kustomize.tgz -C /tmp
+          sudo install -m 0755 /tmp/kustomize /usr/local/bin/kustomize
+
+      - name: Kustomize build every base
+        run: |
+          set -euo pipefail
+          rc=0
+          for d in $(find platform/base -maxdepth 2 -name kustomization.yaml | xargs -n1 dirname | sort -u); do
+            echo "== kustomize build $d =="
+            kustomize build "$d" >/dev/null || { echo "FAILED: $d"; rc=1; }
+          done
+          exit $rc
+
+      - name: Install Nushell
+        run: |
+          set -euo pipefail
+          NU_VERSION=0.114.1
+          curl -fsSL "https://github.com/nushell/nushell/releases/download/${NU_VERSION}/nu-${NU_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o /tmp/nu.tgz
+          echo '8802b26edcdf1a64477567b5ce909fbae3d72d731c8f0847892ea16c6fa73c53  /tmp/nu.tgz' | sha256sum -c -
+          mkdir -p /tmp/nu && tar xzf /tmp/nu.tgz -C /tmp/nu --strip-components=1
+          sudo install -m 0755 /tmp/nu/nu /usr/local/bin/nu
+
+      - name: Nushell parse check
+        run: |
+          set -euo pipefail
+          rc=0
+          for f in $(find scripts platform/images platform/base -name '*.nu'); do
+            echo "== nu parse $f =="
+            output="$(nu --ide-check 999 "$f" 2>&1)" || { echo "$output"; rc=1; continue; }
+            if grep -Eq '"type":"(diagnostic|error)"' <<<"$output"; then
+              echo "$output"
+              echo "PARSE ERROR: $f"
+              rc=1
+            fi
+          done
+          exit $rc
+
+      - name: git diff --check (whitespace / conflict markers)
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          git config core.whitespace trailing-space,space-before-tab
+          base="${PR_BASE_SHA:-${PUSH_BEFORE_SHA:-}}"
+          if [[ -z "$base" || "$base" =~ ^0+$ ]]; then
+            base="$(git rev-list --max-parents=0 HEAD | tail -1)"
+          fi
+          git diff --check "$base"...HEAD

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #   nu scripts/local-setup.nu up|down|reset|status
 # This Makefile provides utility helpers only.
 
-.PHONY: help deps argocd-password port-forward-argocd port-forward-vault port-forward-grafana lint validate-policies validate-crossplane clean kubeconfig
+.PHONY: help deps argocd-password port-forward-argocd port-forward-vault port-forward-grafana lint check-pins test validate-policies validate-crossplane clean kubeconfig
 
 CLUSTER_NAME := digiorg-core-dev
 KUBECONFIG_LOCAL := $(PWD)/kubeconfig-local.yaml
@@ -41,6 +41,13 @@ port-forward-grafana: ## Port forward Grafana (http://localhost:3000)
 # =============================================================================
 # Linting & Validation
 # =============================================================================
+
+check-pins: ## Enforce the image/chart/git pin policy (Issue #275)
+	@python3 scripts/check_pins.py
+
+test: check-pins ## Run pin policy + platform regression tests (no cluster needed)
+	@echo "Running platform regression tests..."
+	@python3 -m unittest discover -s platform/tests -p 'test_*.py'
 
 lint: ## Lint all configurations
 	@echo "Linting YAML files..."

--- a/apps/platform/cnpg-cluster.yaml
+++ b/apps/platform/cnpg-cluster.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cnpg-cluster
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 1: the CNPG Cluster + database bootstrap. Must sync AFTER the CNPG
+    # operator (apps/platform/cnpg.yaml, wave 0) so the postgresql.cnpg.io CRDs
+    # exist. The consumer alias Service becomes authoritative only at cutover,
+    # when the legacy `postgresql` Application is disabled — see
+    # docs/guides/postgres-cnpg-migration.md.
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/digiorg/core.git
+    targetRevision: main
+    path: platform/base/cnpg
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: platform-db
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 5m

--- a/apps/platform/cnpg.yaml
+++ b/apps/platform/cnpg.yaml
@@ -14,7 +14,9 @@ spec:
   source:
     repoURL: https://cloudnative-pg.github.io/charts
     chart: cloudnative-pg
-    targetRevision: 0.22.0
+    # Issue #275 approved baseline (bumped from 0.22.0), revalidated against
+    # https://cloudnative-pg.github.io/charts and Helm-rendered with these values.
+    targetRevision: 0.29.0
     helm:
       releaseName: cnpg
       values: |

--- a/apps/platform/core-catalog.yaml
+++ b/apps/platform/core-catalog.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     # Wave 8: Depends on XRDs (Wave 7) being installed and CRDs available
     argocd.argoproj.io/sync-wave: "8"
+    platform.digiorg.io/upgrade-gate: "issue-275-manual"
 spec:
   project: default
 
@@ -23,9 +24,7 @@ spec:
     namespace: crossplane-system
 
   syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
+    # Manual until the v2 XRDs and pinned catalog commit are validated together.
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/platform/crossplane-provider-configs.yaml
+++ b/apps/platform/crossplane-provider-configs.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     # Wave 6: Depends on crossplane-providers (Wave 4) being installed and CRDs being available
     argocd.argoproj.io/sync-wave: "6"
+    platform.digiorg.io/upgrade-gate: "issue-275-manual"
 spec:
   project: default
 
@@ -21,9 +22,7 @@ spec:
     namespace: crossplane-system
 
   syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
+    # Manual until all upgraded Provider packages report Healthy.
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/platform/crossplane-providers.yaml
+++ b/apps/platform/crossplane-providers.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     # Wave 4: Depends on Crossplane (Wave 3) being installed and CRDs being available
     argocd.argoproj.io/sync-wave: "4"
+    platform.digiorg.io/upgrade-gate: "issue-275-manual"
 spec:
   project: default
 
@@ -21,9 +22,7 @@ spec:
     namespace: crossplane-system
 
   syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
+    # Manual until the Crossplane v2 provider packages report Healthy.
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/platform/crossplane-xrds.yaml
+++ b/apps/platform/crossplane-xrds.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     # Wave 7: Depends on Crossplane providers and ProviderConfigs (Wave 6) being ready
     argocd.argoproj.io/sync-wave: "7"
+    platform.digiorg.io/upgrade-gate: "issue-275-manual"
 spec:
   project: default
 
@@ -21,9 +22,7 @@ spec:
     namespace: crossplane-system
 
   syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
+    # Manual until providers and ProviderConfigs report Healthy.
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/platform/crossplane.yaml
+++ b/apps/platform/crossplane.yaml
@@ -8,13 +8,20 @@ metadata:
   annotations:
     # Wave 3: Extensions - no dependencies on other platform services
     argocd.argoproj.io/sync-wave: "3"
+    platform.digiorg.io/upgrade-gate: "issue-275-manual"
 spec:
   project: default
 
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.19.0
+    # Issue #275: migrated 1.19.0 -> 2.3.3 (highest-blast-radius migration, run
+    # last). Revalidated 2026-07-18 against https://charts.crossplane.io/stable.
+    # Crossplane v2 keeps apiextensions.crossplane.io/v1 XRDs in LegacyCluster
+    # scope, so the existing XRD + Claims (crossplane/xrds) are unchanged; the
+    # crossplane-contrib providers (pkg.crossplane.io/v1) install unchanged.
+    # See docs/guides/platform-versions.md for the CRD-ordering + rollback notes.
+    targetRevision: 2.3.3
     helm:
       releaseName: crossplane
       values: |
@@ -40,9 +47,8 @@ spec:
     namespace: crossplane-system
 
   syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
+    # Highest-blast-radius v2 migration: promote last and only after providers,
+    # XRDs and core-catalog have been validated against the v2 compatibility plan.
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/platform/external-secrets.yaml
+++ b/apps/platform/external-secrets.yaml
@@ -12,6 +12,7 @@ metadata:
   annotations:
     # Wave 0: CRD operator — must be ready before any ExternalSecret resources
     argocd.argoproj.io/sync-wave: "0"
+    platform.digiorg.io/upgrade-gate: "issue-275-manual"
 spec:
   project: default
 
@@ -19,7 +20,7 @@ spec:
     # Source 1: External Secrets Operator Helm chart
     - repoURL: https://charts.external-secrets.io
       chart: external-secrets
-      targetRevision: "0.14.4"
+      targetRevision: "2.7.0"
       helm:
         releaseName: external-secrets
         valueFiles:
@@ -35,9 +36,8 @@ spec:
     namespace: external-secrets
 
   syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
+    # ESO 0.x -> 2.x changes CRD storage/APIs. Promote manually after CR backup
+    # and v1 conversion validation; restore automation in the promotion commit.
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/platform/gitea.yaml
+++ b/apps/platform/gitea.yaml
@@ -12,6 +12,7 @@ metadata:
   annotations:
     # Wave 2: Depends on PostgreSQL (Wave 0) and Keycloak (Wave 1)
     argocd.argoproj.io/sync-wave: "2"
+    platform.digiorg.io/upgrade-gate: "issue-275-manual"
 spec:
   project: default
   
@@ -19,7 +20,11 @@ spec:
     # Source 1: Gitea Helm chart
     - repoURL: https://dl.gitea.com/charts/
       chart: gitea
-      targetRevision: "10.6.0"
+      # Issue #275: migrated 10.6.0 -> 12.6.0 (appVersion Gitea 1.26.1).
+      # Breaking change: bundled cache provider moved Redis -> Valkey; the
+      # values file disables the now-default valkey-cluster/valkey subcharts.
+      # Revalidated 2026-07-18 against https://dl.gitea.com/charts/index.yaml.
+      targetRevision: "12.6.0"
       helm:
         releaseName: gitea
         valueFiles:
@@ -35,9 +40,7 @@ spec:
     namespace: gitea
   
   syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
+    # Major chart/application DB migration: sync explicitly after backup.
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/platform/grafana.yaml
+++ b/apps/platform/grafana.yaml
@@ -8,13 +8,14 @@ metadata:
   annotations:
     # Wave 2: Platform Services - Grafana depends on Keycloak for OAuth
     argocd.argoproj.io/sync-wave: "2"
+    platform.digiorg.io/upgrade-gate: "issue-275-manual"
 spec:
   project: default
 
   sources:
     - repoURL: https://prometheus-community.github.io/helm-charts
       chart: kube-prometheus-stack
-      targetRevision: 72.6.2
+      targetRevision: 87.17.0
       helm:
         releaseName: prometheus
         valueFiles:
@@ -28,9 +29,7 @@ spec:
     namespace: monitoring
 
   syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
+    # Major Prometheus Operator/CRD migration: promote and validate manually.
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/platform/kyverno.yaml
+++ b/apps/platform/kyverno.yaml
@@ -14,13 +14,17 @@ spec:
   source:
     repoURL: https://kyverno.github.io/kyverno/
     chart: kyverno
-    targetRevision: 3.3.7
+    targetRevision: 3.8.1
     helm:
       releaseName: kyverno
       values: |
         # Kyverno Helm values for local development
         # Reduced resource requests for KinD
-        replicaCount: 1
+        # Keep the chart's v1.18 CRD migration hook explicit for this upgrade.
+        # The removed policyReportsCleanup value is intentionally not used.
+        crds:
+          migration:
+            enabled: true
         admissionController:
           replicas: 1
           container:
@@ -63,11 +67,16 @@ spec:
             limits:
               cpu: 100m
               memory: 128Mi
-        # Disabled: bitnami/kubectl:1.30.2 no longer available on Docker Hub
-        # Cleanup is only needed for Kyverno v1 -> v2 migrations (not applicable here)
-        # See: https://github.com/digiorg/core/issues/107
-        policyReportsCleanup:
-          enabled: false
+
+        # Chart 3.8.1 defaults both hook images to readiness-checker:latest.
+        # Pin the v1.18.1 OCI index used by this Kyverno release.
+        test:
+          image:
+            tag: "v1.18.1@sha256:455400758235cf448dd9be3374ecb9e8bf543ee0c39adc880d25ed28cc7eb69d"
+        webhooksCleanup:
+          image:
+            tag: "v1.18.1@sha256:455400758235cf448dd9be3374ecb9e8bf543ee0c39adc880d25ed28cc7eb69d"
+
 
   destination:
     server: https://kubernetes.default.svc

--- a/apps/platform/nats.yaml
+++ b/apps/platform/nats.yaml
@@ -9,6 +9,7 @@ metadata:
     # Wave 0: Deploy alongside cert-manager and postgresql
     # No Keycloak dependency — NATS must be ready before Wave 1
     argocd.argoproj.io/sync-wave: "0"
+    platform.digiorg.io/upgrade-gate: "issue-275-manual"
 spec:
   project: default
 
@@ -16,7 +17,7 @@ spec:
     # NATS Server via Helm chart
     - repoURL: https://nats-io.github.io/k8s/helm/charts
       chart: nats
-      targetRevision: "1.2.11"
+      targetRevision: "2.14.2"
       helm:
         releaseName: nats
         valueFiles:
@@ -37,9 +38,7 @@ spec:
     namespace: messaging
 
   syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
+    # Major chart migration with JetStream persistence: promote manually.
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/platform/opencost.yaml
+++ b/apps/platform/opencost.yaml
@@ -7,12 +7,18 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+    platform.digiorg.io/upgrade-gate: "issue-275-manual"
 spec:
   project: default
   sources:
     - repoURL: https://opencost.github.io/opencost-helm-chart
       chart: opencost
-      targetRevision: "1.43.2"
+      # Issue #275: migrated 1.43.2 -> 2.x. Chart 2.5.27 ships appVersion 1.120.4
+      # (the release our custom subpath UI is built from). Values schema for our
+      # overrides (opencost.ui.image/extraEnv/uiPath, exporter, prometheus.external,
+      # customPricing, mcp, service.extraPorts) validated against the 2.5.27 chart
+      # tarball. Revalidate the exact patch against the chart repo before release.
+      targetRevision: "2.5.27"
       helm:
         releaseName: opencost
         valueFiles:
@@ -27,9 +33,7 @@ spec:
     server: https://kubernetes.default.svc
     namespace: cost-monitoring
   syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
+    # Major chart migration: manually verify the /opencost contract before sync.
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/platform/opensearch.yaml
+++ b/apps/platform/opensearch.yaml
@@ -15,7 +15,7 @@ spec:
     # OpenSearch via official Helm chart (GitHub Pages — https://helm.opensearch.org does not exist)
     - repoURL: https://opensearch-project.github.io/helm-charts
       chart: opensearch
-      targetRevision: "3.6.0"
+      targetRevision: "3.7.0"
       helm:
         releaseName: opensearch
         valueFiles:

--- a/apps/platform/sonarqube.yaml
+++ b/apps/platform/sonarqube.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     # Wave 2: Code Quality tier — depends on PostgreSQL (wave 0) + Keycloak (wave 1)
     argocd.argoproj.io/sync-wave: "2"
+    platform.digiorg.io/upgrade-gate: "issue-275-manual"
 spec:
   project: default
 
@@ -15,7 +16,15 @@ spec:
     # SonarQube Community Build Helm chart
     - repoURL: https://SonarSource.github.io/helm-chart-sonarqube
       chart: sonarqube
-      targetRevision: "10.8.1"
+      # Issue #275: migrated 10.8.1 -> 2026.3.1 (SonarSource moved to calendar
+      # versioning). Community Build deployed via community.enabled + buildNumber
+      # in the values file. Revalidated 2026-07-18 against the chart index
+      # (https://SonarSource.github.io/helm-chart-sonarqube/index.yaml); the
+      # value keys this repo uses (jdbcOverwrite, monitoringPasscode*,
+      # sonarWebContext, deploymentType, initSysctl, sonarProperties) are all
+      # still valid in 2026.3.1. Follow the LTA/DB migration sequence in
+      # docs/guides/platform-versions.md before promoting real data.
+      targetRevision: "2026.3.1"
       helm:
         releaseName: sonarqube
         valueFiles:
@@ -36,9 +45,7 @@ spec:
     namespace: code-quality
 
   syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
+    # Calendar-version/DB migration: follow the LTA sequence and sync manually.
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/crossplane/providers/packages/provider-helm.yaml
+++ b/crossplane/providers/packages/provider-helm.yaml
@@ -3,7 +3,9 @@ kind: Provider
 metadata:
   name: provider-helm
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-helm:v1.2.0
+  # Issue #275: v1.2.0 -> v1.3.0 (latest crossplane-contrib release, no upper
+  # Crossplane bound, compatible with Crossplane v2.3.x). Revalidated 2026-07-18.
+  package: xpkg.upbound.io/crossplane-contrib/provider-helm:v1.3.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig

--- a/crossplane/providers/packages/provider-http.yaml
+++ b/crossplane/providers/packages/provider-http.yaml
@@ -3,4 +3,6 @@ kind: Provider
 metadata:
   name: provider-http
 spec:
+  # Issue #275: v1.0.14 is the latest crossplane-contrib release and installs on
+  # Crossplane v2.3.x (no upper Crossplane bound). Revalidated 2026-07-18.
   package: xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.14

--- a/crossplane/providers/packages/provider-kubernetes.yaml
+++ b/crossplane/providers/packages/provider-kubernetes.yaml
@@ -3,6 +3,8 @@ kind: Provider
 metadata:
   name: provider-kubernetes
 spec:
+  # Issue #275: v1.2.1 is the latest crossplane-contrib release and installs on
+  # Crossplane v2.3.x (no upper Crossplane bound). Revalidated 2026-07-18.
   package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v1.2.1
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1

--- a/docs/guides/platform-versions.md
+++ b/docs/guides/platform-versions.md
@@ -24,11 +24,12 @@ and **fails CI** on:
 - non-first-party git sources without an immutable 40-hex commit.
 
 The only allowed exceptions are the DigiOrg-built, kind-loaded images listed in
-`scripts/pin-policy-allowlist.yaml` (each with a rationale). They carry
-`pullPolicy: IfNotPresent`/`Never`, are never pulled from a registry, and their
-reproducibility is guaranteed by their build definition (pinned upstream release
-+ immutable base digest + OCI provenance). Use `scripts/resolve_digest.py <ref>`
-to obtain a digest for a tag without Docker.
+`scripts/pin-policy-allowlist.yaml` (each with a rationale). They use
+`pullPolicy: Never` and a digest-pinned upstream base. OCI labels record build
+inputs but are not attestations. Fluentd's two direct plugins are version-pinned;
+its live Ruby transitive dependency resolution still requires a lockfile or
+vendored/checksummed gems before the build is fully reproducible. Use
+`scripts/resolve_digest.py <ref>` to obtain a digest for a tag without Docker.
 
 `scripts/render_platform_charts.py` additionally renders every Argo CD Helm
 source with its real inline/repository values and fails CI if a chart introduces

--- a/docs/guides/platform-versions.md
+++ b/docs/guides/platform-versions.md
@@ -1,0 +1,245 @@
+# Platform component versions, pinning & upgrade/rollback
+
+**Issue:** #275 (update and pin all component versions)
+**Revalidated:** 2026-07-18 against upstream chart indexes, registries and
+release notes. Chart versions and direct image references below are pinned in
+Git; chart-managed transitive images and runtime promotion gates are called out
+explicitly in sections 6–7.
+
+This guide is the single reference for *what* is pinned, *why*, and *how* to
+upgrade or roll back safely. It is enforced mechanically by
+`scripts/check_pins.py` (run in CI, see `.github/workflows/platform-validation.yml`)
+and the `platform/tests/` regression suite.
+
+---
+
+## 1. Pinning policy (enforced by CI)
+
+`scripts/check_pins.py` scans source manifests under `apps/` and `platform/base/`
+and **fails CI** on:
+
+- direct container `image:` refs without an immutable `@sha256:` digest;
+- Argo CD Helm `chart:` sources without an exact SemVer (no `latest`, branch,
+  range `^ ~ >= *`, or `x` wildcard);
+- non-first-party git sources without an immutable 40-hex commit.
+
+The only allowed exceptions are the DigiOrg-built, kind-loaded images listed in
+`scripts/pin-policy-allowlist.yaml` (each with a rationale). They carry
+`pullPolicy: IfNotPresent`/`Never`, are never pulled from a registry, and their
+reproducibility is guaranteed by their build definition (pinned upstream release
++ immutable base digest + OCI provenance). Use `scripts/resolve_digest.py <ref>`
+to obtain a digest for a tag without Docker.
+
+`scripts/render_platform_charts.py` additionally renders every Argo CD Helm
+source with its real inline/repository values and fails CI if a chart introduces
+an untagged or floating (`latest`, `main`, `master`, `HEAD`) runtime image. Exact
+tag-only transitive chart images are reported as warnings until their charts
+expose digest overrides; they remain an explicit residual item in section 7.
+
+---
+
+## 2. Helm charts (Argo CD Applications)
+
+| Component | Chart | Pinned | appVersion | Source |
+| --- | --- | --- | --- | --- |
+| Argo CD (bootstrap) | argo-cd | **10.1.4** | v3.4.5 | pinned in `scripts/local-setup.nu` (`--version 10.1.4`, both helm calls) |
+| kube-prometheus-stack | kube-prometheus-stack | **87.17.0** | prometheus-operator v0.92.1 | `apps/platform/grafana.yaml`; CRDs pre-installed at v0.92.1 by `local-setup.nu` |
+| CloudNativePG operator | cloudnative-pg | **0.29.0** | 1.30.0 | `apps/platform/cnpg.yaml` |
+| External Secrets | external-secrets | **2.7.0** | v2.7.0 | `apps/platform/external-secrets.yaml` — CRs migrated v1beta1→v1 |
+| Kyverno | kyverno | **3.8.1** | v1.18.1 | `apps/platform/kyverno.yaml` (3.8.2 available; 3.8.x patch-compatible) |
+| OpenSearch | opensearch | **3.7.0** | 3.7.0 | `apps/platform/opensearch.yaml` |
+| NATS | nats | **2.14.2** | 2.14.2 | `apps/platform/nats.yaml` |
+| OpenCost | opencost | **2.5.27** | 1.120.4 | `apps/platform/opencost.yaml` — custom subpath UI preserved |
+| Gitea | gitea | **12.6.0** | 1.26.1 | `apps/platform/gitea.yaml` — Redis→Valkey subcharts disabled |
+| SonarQube | sonarqube | **2026.3.1** | 2026.3.1 | `apps/platform/sonarqube.yaml` — Community Build 26.5.0.122743 |
+| Crossplane | crossplane | **2.3.3** | 2.3.3 | `apps/platform/crossplane.yaml` — v2, XRD stays LegacyCluster |
+| Harbor | harbor | **1.19.1** | 2.15.x | `apps/platform/harbor.yaml` (retained — already current) |
+| Jaeger | jaeger | **4.11.1** | 2.19.0 | `apps/platform/jaeger.yaml` (retained — already current) |
+
+### cert-manager (raw manifest)
+
+Pinned to **v1.20.1** in `platform/base/cert-manager/kustomization.yaml` (remote
+release manifest URL). Routine update from v1.17.0.
+
+---
+
+## 3. Container images (digest-pinned)
+
+Third-party images record a human-readable tag **plus** an immutable digest:
+
+| Image | Tag | Used by |
+| --- | --- | --- |
+| `postgres` | 16-alpine | legacy PostgreSQL StatefulSet (transition; being replaced by CNPG) |
+| `ghcr.io/cloudnative-pg/postgresql` | 16.9 | CNPG Cluster + init/backup jobs |
+| `quay.io/oauth2-proxy/oauth2-proxy` | v7.15.3 | OpenCost + Jaeger auth proxies |
+| `nginx` | 1.30-alpine | Harbor UI reverse proxy |
+| `curlimages/curl` | 8.16.0 | Harbor OIDC/proxy-cache + OpenSearch bootstrap jobs |
+| `busybox` | 1.37.0 | init containers |
+| `natsio/nats-surveyor` | 0.9.10 | NATS Surveyor |
+| `nats` | 2.14.2-alpine | NATS server (chart fullImageName override) |
+| `natsio/nats-server-config-reloader` | 0.23.0 | NATS config reloader |
+| `opensearchproject/opensearch` | 3.7.0 | OpenSearch chart primary image |
+| `docker.gitea.com/gitea` | 1.26.1 | Gitea chart primary/init image |
+| `sonarqube` | 26.5.0.122743-community | SonarQube Community Build |
+| `ghcr.io/kyverno/readiness-checker` | v1.18.1 | Kyverno chart test/cleanup hooks |
+| `ghcr.io/digiorg/core-portal` | 48d262e | Backstage (release tag + digest, was `latest`) |
+| `ghcr.io/digiorg/core-landingpage` | 32a6777 | Landing page (release tag + digest, was `main`) |
+
+### Tier-1 DigiOrg-built images (allow-listed, kind-loaded)
+
+| Image | Upstream base (digest-pinned) | Build |
+| --- | --- | --- |
+| `opencost-ui:v1.120.4-basename-opencost` | opencost-ui v1.120.4 (commit 6384abbf) | `platform/base/opencost/ui-image/build.nu` |
+| `digiorg/keycloak:26.7.0-optimized` | quay.io/keycloak/keycloak:26.7.0 | `platform/images/keycloak/build.nu` (`kc.sh build`, `start --optimized`) |
+| `digiorg/fluentd:v1.19.2-debian-opensearch-1.0` | fluent/fluentd-kubernetes-daemonset:v1.19.2-debian-opensearch-1.0 | `platform/images/fluentd/build.nu` (pinned plugin gems) |
+
+All three are built + kind-loaded during `nu scripts/local-setup.nu up`
+(`build_opencost_ui_image`, `build_tier1_images`), docker-guarded and non-fatal.
+
+### Crossplane providers (pinned package tags)
+
+`provider-kubernetes:v1.2.1`, `provider-helm:v1.3.0`, `provider-http:v1.0.14`
+(`crossplane/providers/packages/`) — latest crossplane-contrib releases, no upper
+Crossplane bound, compatible with Crossplane v2.3.x.
+
+---
+
+## 4. Harbor proxy-cache (Tier 2)
+
+`platform/base/harbor/harbor-proxy-cache-job.yaml` (Argo CD PostSync hook)
+provisions pull-through proxy-cache projects via the Harbor REST API:
+
+| Project | Upstream | Registry type |
+| --- | --- | --- |
+| `dockerhub-proxy` | https://hub.docker.com | docker-hub |
+| `quay-proxy` | https://quay.io | quay |
+| `ghcr-proxy` | https://ghcr.io | github-ghcr |
+| `k8s-proxy` | https://registry.k8s.io | docker-registry |
+
+The Job is idempotent (HTTP 409 = already-exists = success) and self-heals on
+every sync.
+
+> **Bootstrap exception (documented):** workload manifests still reference
+> upstream registries by digest rather than the `harbor.harbor.svc/...proxy/...`
+> mirror path. Harbor only becomes Ready in wave 2, so components that schedule
+> earlier (and the kind node pulling their images) cannot route through Harbor
+> during a cold bootstrap. Rewriting image refs to mirror paths is a follow-up
+> that must keep the immutable digests and add a Harbor-independent bootstrap
+> path; until then the digest pin (section 3) provides the reproducibility the
+> proxy-cache would otherwise add.
+
+---
+
+## 5. Major migrations — breaking changes & validation
+
+Each migration below has a dedicated regression test under `platform/tests/`.
+They validate the manifests statically; **runtime data migration is deferred**
+where noted (this environment has no cluster — see section 7).
+
+### Gitea 10.6.0 → 12.6.0 (`test_gitea_migration.py`)
+- **Breaking:** bundled cache moved Redis → **Valkey**; `valkey-cluster` is
+  default-enabled. Disabled `valkey-cluster` + `valkey` (Gitea uses in-process
+  session/cache + level queue). Removed the dead `redis-cluster` key.
+- Bundled `postgresql`/`postgresql-ha` stay disabled (shared platform-db).
+- **Rollback:** revert the chart pin + values change; Gitea 1.26→1.24 downgrade
+  is not supported once DB migrations run, so snapshot the `gitea` DB first.
+
+### SonarQube 10.8.1 → 2026.3.1 (`test_sonarqube_migration.py`)
+- Calendar versioning; Community Build via `community.enabled` +
+  `buildNumber: 26.5.0.122743` (chart default). All value keys unchanged.
+- **DB migration:** SonarQube runs schema migrations on first start. Follow the
+  supported LTA sequence — do **not** skip across LTAs. Back up the `sonarqube`
+  DB before upgrading; downgrade is unsupported.
+- **Rollback:** restore the DB snapshot and revert the chart pin.
+
+### Crossplane 1.19.0 → 2.3.3 (`test_crossplane_migration.py`)
+- v2 keeps `apiextensions.crossplane.io/v1` XRDs in **LegacyCluster** scope, so
+  the existing XRD (`crossplane/xrds/application.yaml`) + Claims are unchanged.
+  **Do not** flip the XRD to `scope: Namespaced` — that drops Claims in v2.
+- Providers (`pkg.crossplane.io/v1`) + `DeploymentRuntimeConfig` unchanged.
+- **CRD ordering:** upgrade the Crossplane chart (CRDs) before providers/XRDs
+  (waves 3 → 4 → 6 → 7 already enforce this).
+- **core-catalog:** Compositions live in `core-catalog`; v2 removed native
+  patch-and-transform — any P&T Composition there must be converted to the
+  function pipeline (`crossplane beta convert pipeline-composition`). Out of
+  scope for this repo; validate `core-catalog` separately before promoting.
+- **Rollback:** revert the chart pin (2.3.3 → 1.19.0) and provider pins; v2→v1
+  downgrade of a cluster with namespaced XRs is unsupported, but this repo keeps
+  LegacyCluster semantics so no XR conversion occurs.
+
+### External Secrets 0.14.4 → 2.7.0 (`test_external_secrets_migration.py`)
+- **Breaking:** ESO ≥ 0.17.0 removed `external-secrets.io/v1beta1`. Migrated
+  `ClusterSecretStore` + `ExternalSecret` to `external-secrets.io/v1` (field-
+  compatible for the fake-provider dev store). Verify every `SecretStore`/
+  `ExternalSecret` in downstream repos is on `v1` before upgrading.
+- **Rollback:** revert the chart pin; v1 CRs are also accepted by 0.14.x.
+
+### kube-prometheus-stack 72.6.2 → 87.17.0
+- CRDs are pre-installed at prometheus-operator **v0.92.1** by `local-setup.nu`
+  (matches the chart appVersion) and upgraded before dependents. Verify
+  Prometheus, Grafana, ServiceMonitors, dashboards, persistence and the OpenCost
+  integration after upgrade.
+
+### PostgreSQL StatefulSet → CloudNativePG
+See the dedicated runbook: **[postgres-cnpg-migration.md](./postgres-cnpg-migration.md)**.
+Coexistence is conflict-free (the `postgresql` alias Service is not synced until
+cutover); cutover and rollback are single, symmetric Git commits.
+
+---
+
+## 6. Promotion gates and upgrade procedure
+
+The major migrations are deliberately **not auto-synced**. Their Applications
+carry `platform.digiorg.io/upgrade-gate: issue-275-manual` and omit
+`syncPolicy.automated`, so merging the version pins cannot launch every database,
+CRD and operator migration at once. Promote them one at a time in this order:
+
+1. External Secrets (back up CRs; verify all consumers use `v1`).
+2. NATS (back up JetStream; verify clients and Surveyor).
+3. kube-prometheus-stack (apply/verify CRDs first).
+4. OpenCost (verify exporter and the authenticated `/opencost/` UI contract).
+5. Gitea (database backup and restore evidence).
+6. SonarQube (follow every required LTA hop; database backup/restore evidence).
+7. Crossplane last, as five separately observed syncs: `crossplane`,
+   `crossplane-providers`, `crossplane-provider-configs`, `crossplane-xrds`, then
+   `core-catalog`. Do not promote the next Application until the previous one is
+   Healthy and its CRDs/providers are established.
+
+`nu scripts/local-setup.nu up` is the deliberate exception: it targets only the
+named disposable local KinD cluster and explicitly starts these gated Argo syncs
+one at a time, waiting for each Application to become Healthy before continuing.
+Shared and production clusters must use the manual procedure below.
+
+For each promotion:
+
+1. Revalidate the target against the upstream chart index / release notes /
+   security advisories (see the per-app comment for the source URL).
+2. Update the pin in Git (chart `targetRevision` or image digest via
+   `scripts/resolve_digest.py`). Update the matching `platform/tests/` test.
+3. Run `make test`, render the chart with its repository values, and run
+   `kustomize build platform/base/<component>`.
+4. Take the required backup and manually sync only that gated Application.
+5. Confirm `Synced`/`Healthy`, pods Ready without crash loops, and the
+   component's ingress/OAuth/persistence/integrations.
+6. Record restore/rollback evidence, then restore `syncPolicy.automated` for that
+   Application in the promotion commit before moving to the next gate.
+
+## 7. Rollback & residual validation
+
+- **Rollback** is `git revert` of the pin commit for stateless components; for
+  stateful ones follow the component-specific note in section 5 (restore the DB
+  snapshot first). The CNPG cutover/rollback is documented separately.
+- **Residual validation:** no Kubernetes cluster, Docker daemon or kind runtime is
+  available here, so cluster-side upgrade/rollback, data migration and workload
+  smoke tests were **not executed**. Static verification did include: all 12 Helm
+  charts rendered with their repository values using Helm 4.2.3; every render
+  passed kubeconform 0.8.0 in strict mode (with missing CRD schemas ignored);
+  every Kustomize base rendered and passed the same validation; all direct image
+  digests were resolved again from their registries; the pin checker, complete
+  regression suite, and Nushell 0.114.1 parse checks pass.
+- Exact chart packages transitively select additional operator/sidecar images that
+  do not all expose digest fields through their values schema. The direct images
+  and mutable chart defaults identified in this change are digest-pinned, but a
+  fully Harbor-rewritten render remains a gated follow-up after Harbor is
+  available during bootstrap. Do not mark the platform-wide Harbor mirror
+  criterion complete until a real-cluster promotion verifies that path.

--- a/docs/guides/postgres-cnpg-migration.md
+++ b/docs/guides/postgres-cnpg-migration.md
@@ -1,0 +1,291 @@
+# PostgreSQL -> CloudNativePG (CNPG) Migration Runbook
+
+**Issue:** #275 (Tier-3 migration of the shared PostgreSQL StatefulSet to a
+CloudNativePG `Cluster`)
+**Namespace:** `platform-db`
+**Status:** Manifests landed; **data migration and legacy removal are DEFERRED**
+until verified against a real cluster (see [Limitations](#limitations)).
+
+---
+
+## 1. What changes
+
+| Aspect | Legacy (retained) | CNPG (new) |
+| --- | --- | --- |
+| Workload | `StatefulSet/postgresql` (`platform/base/postgresql`) | `Cluster/postgresql-cnpg` (`platform/base/cnpg`) |
+| Image | `postgres:16-alpine@sha256:57c72f…` | `ghcr.io/cloudnative-pg/postgresql:16.9@sha256:cca50a…` |
+| Primary service | `postgresql` (selector `app: postgresql`) | `postgresql-cnpg-rw` (CNPG-managed) |
+| Consumer DNS | `postgresql.platform-db.svc.cluster.local:5432` | **unchanged after cutover** — `ExternalName` alias `postgresql` -> `postgresql-cnpg-rw` (enabled at cutover only) |
+| Databases/users | 6 via `init.sh` ConfigMap | 6 via idempotent init `Job` |
+| Per-service passwords | `postgresql-secrets` (Opaque) | **same** `postgresql-secrets` |
+| Superuser secret | env from `postgresql-secrets` | `postgresql-cnpg-superuser` (`kubernetes.io/basic-auth`) |
+| Storage | 5Gi PVC | 5Gi PVC |
+| Backup | none | scheduled `pg_dump` CronJob + runbook |
+
+Both PG majors are **16**, so the on-disk data format is compatible and no
+`pg_upgrade` is required — migration is a logical dump/restore (or a PVC data
+copy in a real cluster).
+
+### The six databases/users (must all keep working)
+
+| Database | Owner/user | Secret key (password) | Consumer |
+| --- | --- | --- | --- |
+| `keycloak` | `keycloak` | `KEYCLOAK_DB_PASSWORD` | keycloak |
+| `backstage` | `backstage` (CREATEDB) | `BACKSTAGE_DB_PASSWORD` | backstage |
+| `gitea` | `gitea` | `GITEA_DB_PASSWORD` | gitea |
+| `sonarqube` | `sonarqube` | `SONARQUBE_DB_PASSWORD` | sonarqube |
+| `registry` | `harbor` | `HARBOR_DB_PASSWORD` | harbor |
+| (superuser) | `postgres` | `POSTGRES_PASSWORD` | init/backup jobs |
+
+### Secret format
+
+`postgresql-secrets` (Opaque) already carries the six `*_DB_PASSWORD` /
+`POSTGRES_PASSWORD` keys used by the init `Job` and the legacy StatefulSet — the
+CNPG init `Job` reuses it unchanged.
+
+CNPG's `enableSuperuserAccess` + `superuserSecret`, however, **requires a
+`kubernetes.io/basic-auth` Secret** with keys `username` (=`postgres`) and
+`password`. The Opaque `postgresql-secrets` cannot be reused for this: a Secret's
+`type` is immutable, and it has no `username`/`password` keys. The setup script
+therefore provisions a **dedicated** secret `postgresql-cnpg-superuser`:
+
+```bash
+kubectl create secret generic postgresql-cnpg-superuser -n platform-db \
+  --type=kubernetes.io/basic-auth \
+  --from-literal=username=postgres \
+  --from-literal=password="$POSTGRES_PASSWORD"      # same value as postgresql-secrets
+```
+
+`password` **MUST equal** `postgresql-secrets.POSTGRES_PASSWORD` so the init /
+backup jobs (which authenticate with `PGPASSWORD=$POSTGRES_PASSWORD`) still
+connect. `scripts/local-setup.nu` creates both secrets from the same generated
+`postgres_password`, so they always match on a clean bootstrap.
+
+---
+
+## 2. Prerequisites / baseline capture
+
+Run against the **legacy** primary before touching anything.
+
+```bash
+# Confirm consumers are healthy and the six databases exist.
+kubectl -n platform-db exec statefulset/postgresql -- \
+  psql -U postgres -c '\l' | grep -E 'keycloak|backstage|gitea|sonarqube|registry'
+
+# Record row counts / a schema fingerprint per db for later comparison.
+for db in keycloak backstage gitea sonarqube registry; do
+  echo "== $db =="
+  kubectl -n platform-db exec statefulset/postgresql -- \
+    psql -U postgres -d "$db" -c \
+    "SELECT count(*) AS tables FROM information_schema.tables WHERE table_schema='public';"
+done
+```
+
+Save this output as the migration baseline.
+
+---
+
+## 3. Backup (logical dump of all six databases)
+
+No object store is available in the local/dev environment, so backups are
+**logical** (`pg_dump`), not `barmanObjectStore`. Take a full dump from the
+**legacy** primary:
+
+```bash
+POD=$(kubectl -n platform-db get pod -l app=postgresql -o jsonpath='{.items[0].metadata.name}')
+mkdir -p ./pgbackup
+for db in keycloak backstage gitea sonarqube registry; do
+  kubectl -n platform-db exec "$POD" -- \
+    pg_dump -U postgres -Fc "$db" > "./pgbackup/${db}.dump"
+done
+# Roles/globals (passwords + grants).
+kubectl -n platform-db exec "$POD" -- \
+  pg_dumpall -U postgres --globals-only > ./pgbackup/globals.sql
+```
+
+The CNPG stack keeps this going automatically: `CronJob/postgresql-cnpg-pgdump`
+runs nightly (02:00) and writes `pg_dump -Fc` of all six databases plus
+`pg_dumpall --globals-only` to PVC `postgresql-cnpg-backups`.
+
+---
+
+## 4. Deploy the CNPG operator + Cluster
+
+The operator and the Cluster are two separate ArgoCD Applications with ordered
+sync waves:
+
+| App | File | Wave | Source |
+| --- | --- | --- | --- |
+| `cnpg` (operator) | `apps/platform/cnpg.yaml` | 0 | Helm chart `cloudnative-pg` **0.29.0** |
+| `cnpg-cluster` | `apps/platform/cnpg-cluster.yaml` | 1 | git `platform/base/cnpg` |
+
+During coexistence the `cnpg-cluster` Application deploys **only** the Cluster +
+init `Job` (see `platform/base/cnpg/kustomization.yaml`). The `postgresql`
+`ExternalName` alias (`service.yaml`) is deliberately **not** synced yet — if it
+were, both the legacy `postgresql` Application and `cnpg-cluster` would own a
+Service named `postgresql` in `platform-db` and fight over it. The CNPG database
+is reachable directly at `postgresql-cnpg-rw` until cutover.
+
+```bash
+kubectl apply -f apps/platform/cnpg.yaml           # operator (wave 0)
+kubectl apply -f apps/platform/cnpg-cluster.yaml   # Cluster + init Job (wave 1)
+
+# Wait for the Cluster to reach a healthy primary.
+kubectl -n platform-db wait --for=condition=Ready cluster/postgresql-cnpg --timeout=600s
+kubectl -n platform-db get pods -l cnpg.io/cluster=postgresql-cnpg
+```
+
+`Job/postgresql-cnpg-init` (sync-wave 3, a Sync hook) then creates the six
+databases/users idempotently, sourcing every password from `postgresql-secrets`.
+Re-running it is safe — it guards on `pg_roles` / `pg_database`.
+
+```bash
+kubectl -n platform-db logs job/postgresql-cnpg-init
+kubectl -n platform-db exec deploy/postgresql-cnpg-1 -- psql -U postgres -c '\l' # sanity
+```
+
+---
+
+## 5. Restore / migrate the data
+
+With the empty databases created by the init `Job`, load the dumps taken in
+step 3 into the CNPG primary (reach it directly at `postgresql-cnpg-rw` — the
+`postgresql` alias is not yet authoritative during coexistence):
+
+```bash
+CNPG=$(kubectl -n platform-db get pod -l cnpg.io/instanceRole=primary -o jsonpath='{.items[0].metadata.name}')
+
+# Globals first (roles already exist from the Job; this is a no-op fill for any
+# missing grants — safe to skip if the Job succeeded).
+# Then per-database data:
+for db in keycloak backstage gitea sonarqube registry; do
+  kubectl -n platform-db exec -i "$CNPG" -- \
+    pg_restore -U postgres -d "$db" --clean --if-exists --no-owner < "./pgbackup/${db}.dump"
+done
+```
+
+Verify against the baseline from step 2 (row/table counts must match).
+
+---
+
+## 6. Cut consumers over
+
+Consumers reference `postgresql.platform-db.svc.cluster.local:5432` and need no
+manifest change. Argo CD Applications reconcile independently, so a Git commit
+alone is **not atomic**. Perform this observed handoff while writes stay frozen:
+
+1. Scale every database-writing consumer to zero. Do not stop the legacy
+   PostgreSQL pod yet.
+2. Take a **mandatory final full dump** (there is no `pg_dump` delta mode) using
+   the commands in section 3, writing to a new `pgbackup-final/` directory.
+3. Restore that final dump into clean CNPG target databases and repeat the
+   baseline counts/checksums. Keep consumers stopped until they match.
+4. Commit both cutover manifest changes, but do not let either Application sync
+   automatically:
+   - remove the legacy `service.yaml` from
+     `platform/base/postgresql/kustomization.yaml` while retaining its
+     StatefulSet and PVC;
+   - enable `service.yaml` in `platform/base/cnpg/kustomization.yaml`;
+   - suspend automated sync/self-heal for both `postgresql` and `cnpg-cluster`.
+5. Manually sync **only** the legacy `postgresql` Application with prune, then
+   observe that `Service/postgresql` is gone:
+   ```bash
+   kubectl -n argocd patch application postgresql --type merge \
+     -p '{"spec":{"syncPolicy":{"automated":null}}}'
+   kubectl -n argocd patch application cnpg-cluster --type merge \
+     -p '{"spec":{"syncPolicy":{"automated":null}}}'
+   # Trigger/sync postgresql using the Argo CD UI/CLI, then:
+   kubectl -n platform-db wait --for=delete service/postgresql --timeout=120s
+   ```
+6. Manually sync `cnpg-cluster`; verify that the new ExternalName Service exists
+   and resolves to `postgresql-cnpg-rw` before restarting consumers.
+7. Scale consumers up one at a time and run section 7. Re-enable automation only
+   after all checks pass.
+
+The legacy StatefulSet and PVC remain managed and available for rollback; only
+its selector Service is handed off during this phase.
+
+---
+
+## 7. Validate each consumer
+
+```bash
+# DNS alias resolves to the CNPG primary
+kubectl -n platform-db run dns --rm -it --image=busybox --restart=Never -- \
+  nslookup postgresql.platform-db.svc.cluster.local
+
+# Per-consumer smoke checks
+kubectl -n keycloak   rollout status deploy/keycloak
+kubectl -n backstage  rollout status deploy/backstage
+kubectl -n gitea      get pods
+kubectl -n sonarqube  get pods
+kubectl -n harbor     get pods   # connects to db "registry" as user "harbor"
+```
+
+Confirm each app logs a successful DB connection and serves traffic.
+
+---
+
+## 8. Rollback procedure
+
+Keep consumers stopped. Reverse the same ordered handoff; do not rely on a Git
+revert to sequence two Applications:
+
+1. Suspend automated sync for both Applications. Revert the cutover manifest
+   commit so the legacy kustomization contains its selector Service and the CNPG
+   kustomization no longer contains the alias.
+2. Manually sync `cnpg-cluster` first and wait until the alias is deleted:
+   ```bash
+   kubectl -n platform-db wait --for=delete service/postgresql --timeout=120s
+   ```
+3. Manually sync the retained legacy `postgresql` Application, verify its
+   StatefulSet is Ready, and confirm its selector Service endpoints point at the
+   legacy pod.
+4. Restart consumers one at a time, validate database connections, then restore
+   automation. Any writes accepted by CNPG after cutover must be reconciled before
+   rollback; this is why rollback is performed while writes remain frozen.
+
+Both clusters use PG16 and the same application credentials, so connection
+strings do not change. The rollback is not considered tested until this ordered
+procedure has been exercised on a real cluster and evidence recorded.
+
+---
+
+## 9. Deferred: removing the legacy StatefulSet
+
+**Do NOT delete `platform/base/postgresql` yet.** Issue #275 requires legacy
+removal only *after* data is verified in a real cluster. This environment has no
+Kubernetes cluster/kubectl/kind runtime, so the cutover/verification in steps
+5–7 cannot be executed here. Once a real run confirms every consumer on CNPG and
+the baseline matches:
+
+1. Delete `apps/platform/postgresql.yaml` and `platform/base/postgresql/**` only
+   after rollback evidence is accepted; let Argo CD prune the legacy workload.
+2. Reclaim the legacy PVC after the agreed retention window.
+3. Simplify the coexistence note in `platform/base/cnpg/service.yaml` because the
+   alias is then the sole owner of the `postgresql` name.
+
+---
+
+## Limitations
+
+- **No cluster / kubectl / kind / Docker runtime** in this environment: the data
+  migration, consumer cutover and rollback were **not executed**. The CNPG chart
+  and repository resources were Helm/Kustomize-rendered and passed strict
+  kubeconform validation (missing CRD schemas ignored), plus
+  `python3 platform/tests/test_cnpg_migration.py` and
+  `python3 scripts/check_pins.py`.
+- **Operator chart 0.29.0** was revalidated against the chart index
+  `https://cloudnative-pg.github.io/charts/index.yaml` on 2026-07-18: `0.29.0` is the
+  newest release (appVersion 1.30.0). The Cluster image
+  `ghcr.io/cloudnative-pg/postgresql:16.9@sha256:cca50a…` was verified against
+  GHCR via `scripts/resolve_digest.py`.
+- **Superuser secret**: CNPG requires a **`kubernetes.io/basic-auth`** Secret
+  (`username=postgres` + `password`). The Opaque `postgresql-secrets` cannot be
+  reused (immutable type), so `scripts/local-setup.nu` provisions a dedicated
+  `postgresql-cnpg-superuser` with the same password value (see
+  [Secret format](#secret-format)).
+- **Backups are logical (`pg_dump`)**, not `barmanObjectStore`, because no object
+  store is available in dev. Add a `backup.barmanObjectStore` block + a
+  `ScheduledBackup` when an S3/MinIO target exists.
+- **Legacy removal is deferred** (section 9) until real-cluster verification.

--- a/docs/guides/postgres-cnpg-migration.md
+++ b/docs/guides/postgres-cnpg-migration.md
@@ -141,7 +141,8 @@ Re-running it is safe — it guards on `pg_roles` / `pg_database`.
 
 ```bash
 kubectl -n platform-db logs job/postgresql-cnpg-init
-kubectl -n platform-db exec deploy/postgresql-cnpg-1 -- psql -U postgres -c '\l' # sanity
+CNPG=$(kubectl -n platform-db get pod -l cnpg.io/instanceRole=primary -o jsonpath='{.items[0].metadata.name}')
+kubectl -n platform-db exec "$CNPG" -- psql -U postgres -c '\l' # sanity
 ```
 
 ---
@@ -154,13 +155,25 @@ step 3 into the CNPG primary (reach it directly at `postgresql-cnpg-rw` — the
 
 ```bash
 CNPG=$(kubectl -n platform-db get pod -l cnpg.io/instanceRole=primary -o jsonpath='{.items[0].metadata.name}')
+BACKUP_DIR=${BACKUP_DIR:-./pgbackup}
 
-# Globals first (roles already exist from the Job; this is a no-op fill for any
-# missing grants — safe to skip if the Job succeeded).
-# Then per-database data:
+# Roles already exist with the same names from the bootstrap Job. Preserve the
+# ownership metadata recorded by pg_dump. Restoring without ownership metadata or
+# as an application role would break owner-only schema migrations.
 for db in keycloak backstage gitea sonarqube registry; do
   kubectl -n platform-db exec -i "$CNPG" -- \
-    pg_restore -U postgres -d "$db" --clean --if-exists --no-owner < "./pgbackup/${db}.dump"
+    pg_restore -U postgres -d "$db" --clean --if-exists --exit-on-error < "${BACKUP_DIR}/${db}.dump"
+done
+
+# Verify that no application objects were silently reassigned to postgres.
+for spec in "keycloak:keycloak" "backstage:backstage" "gitea:gitea" \
+            "sonarqube:sonarqube" "registry:harbor"; do
+  db=${spec%%:*}; owner=${spec##*:}
+  kubectl -n platform-db exec "$CNPG" -- psql -U postgres -d "$db" -v ON_ERROR_STOP=1 -c \
+    "SELECT n.nspname, c.relname, pg_get_userbyid(c.relowner) AS owner
+       FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+      WHERE n.nspname='public' AND c.relkind IN ('r','S','v','m','f','p')
+        AND pg_get_userbyid(c.relowner) <> '$owner';"
 done
 ```
 
@@ -178,8 +191,9 @@ alone is **not atomic**. Perform this observed handoff while writes stay frozen:
    PostgreSQL pod yet.
 2. Take a **mandatory final full dump** (there is no `pg_dump` delta mode) using
    the commands in section 3, writing to a new `pgbackup-final/` directory.
-3. Restore that final dump into clean CNPG target databases and repeat the
-   baseline counts/checksums. Keep consumers stopped until they match.
+3. Restore that final dump into clean CNPG target databases by repeating section
+   5 with `BACKUP_DIR=./pgbackup-final`; repeat the ownership and baseline
+   counts/checksums. Keep consumers stopped until every check matches.
 4. Commit both cutover manifest changes, but do not let either Application sync
    automatically:
    - remove the legacy `service.yaml` from
@@ -229,7 +243,12 @@ Confirm each app logs a successful DB connection and serves traffic.
 ## 8. Rollback procedure
 
 Keep consumers stopped. Reverse the same ordered handoff; do not rely on a Git
-revert to sequence two Applications:
+revert to sequence two Applications. If CNPG accepted any writes after cutover,
+first take a full dump from the frozen CNPG primary, restore it into clean legacy
+databases with the ownership-preserving section-5 procedure, and verify counts
+and ownership. The declared RPO is therefore zero only while this write freeze
+and reverse restore succeed; otherwise stop and escalate rather than repointing
+to stale legacy data.
 
 1. Suspend automated sync for both Applications. Revert the cutover manifest
    commit so the legacy kustomization contains its selector Service and the CNPG

--- a/platform/base/backstage/deployment.yaml
+++ b/platform/base/backstage/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       # Wait for PostgreSQL to be ready before starting Backstage
       initContainers:
         - name: wait-for-postgres
-          image: busybox:1.36
+          image: busybox:1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
           command:
             - sh
             - -c
@@ -32,7 +32,7 @@ spec:
               echo "PostgreSQL is ready!"
       containers:
         - name: backstage
-          image: ghcr.io/digiorg/core-portal:latest
+          image: ghcr.io/digiorg/core-portal:48d262e@sha256:8736f4195b06ab8fe0dbe3b806cd538771f61e7f53dedd4f11dc6ad7e2ff644f
           imagePullPolicy: Always
           ports:
             - containerPort: 7007

--- a/platform/base/cert-manager/certificate-dev.yaml
+++ b/platform/base/cert-manager/certificate-dev.yaml
@@ -38,6 +38,8 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
+    # Preserve pre-1.18 behaviour so local trust stores do not silently break.
+    rotationPolicy: Never
   issuerRef:
     name: selfsigned-bootstrap
     kind: ClusterIssuer
@@ -63,6 +65,8 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
+    # Preserve pre-1.18 behaviour so local trust stores do not silently break.
+    rotationPolicy: Never
   issuerRef:
     name: digiorg-local-ca-issuer
     kind: ClusterIssuer

--- a/platform/base/cert-manager/kustomization.yaml
+++ b/platform/base/cert-manager/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  # cert-manager upstream manifest (v1.17.0)
-  - https://github.com/cert-manager/cert-manager/releases/download/v1.17.0/cert-manager.yaml
+  # cert-manager upstream manifest (v1.20.1) — Issue #275 routine update
+  - https://github.com/cert-manager/cert-manager/releases/download/v1.20.1/cert-manager.yaml
   # Issuers and certificates (applied after cert-manager CRDs are ready)
   - cluster-issuers.yaml
   - certificate-dev.yaml

--- a/platform/base/cnpg/cluster.yaml
+++ b/platform/base/cnpg/cluster.yaml
@@ -1,0 +1,75 @@
+# =============================================================================
+# CloudNativePG Cluster — shared PostgreSQL for the DigiOrg platform (Issue #275)
+# =============================================================================
+# Tier-3 migration target replacing the raw StatefulSet under
+# platform/base/postgresql. It reproduces the SAME six databases/users the legacy
+# init.sh created (keycloak, backstage, gitea, sonarqube and harbor -> database
+# "registry"/user "harbor"), sourcing every password from the SAME Secret
+# `postgresql-secrets`, so no consumer manifest or password changes.
+#
+# Image: PG16 (matches legacy postgres:16 major -> no on-disk data-format
+# migration). Digest-pinned per the pin policy (scripts/check_pins.py).
+#
+# The six databases/users are created by the companion Job in
+# init-databases.yaml (it can read the per-service passwords from
+# postgresql-secrets via env, which static initdb SQL cannot). The Cluster's own
+# initdb only bootstraps an empty `app` database.
+# =============================================================================
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-cnpg
+  namespace: platform-db
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/part-of: digiorg-platform
+spec:
+  instances: 1
+
+  # PG16, digest-pinned. Matches the legacy postgres:16 major version so the
+  # migrated data files are read without an upgrade step.
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.9@sha256:cca50a94e2da46ddcaefb23260c805ed3b466763bd2a25e1617410176d5fd0ab
+
+  # Enable password auth for the postgres superuser. CNPG REQUIRES the
+  # superuserSecret to be a `kubernetes.io/basic-auth` Secret whose username is
+  # `postgres` plus a `password` key. The legacy `postgresql-secrets` is Opaque
+  # (and a Secret's type is immutable), so it cannot be reused here. The setup
+  # script provisions a dedicated basic-auth secret `postgresql-cnpg-superuser`
+  # with the SAME password value as postgresql-secrets.POSTGRES_PASSWORD, so the
+  # init Job (which authenticates as postgres with POSTGRES_PASSWORD) still
+  # connects. See docs/guides/postgres-cnpg-migration.md ("Secret format").
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: postgresql-cnpg-superuser
+
+  # Match the legacy StatefulSet footprint for local development.
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 512Mi
+
+  storage:
+    size: 5Gi
+
+  # Modest tuning for a single-instance dev database.
+  postgresql:
+    parameters:
+      max_connections: "200"
+      shared_buffers: 128MB
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+      # The real platform databases/users are created by the init Job in
+      # init-databases.yaml (needs Secret-sourced passwords). Keep initdb minimal.
+
+  # Backup: no object store is available in the local kind/dev environment, so
+  # barmanObjectStore is intentionally omitted (it would make the spec invalid
+  # without a reachable S3/MinIO target). Backups are handled instead by the
+  # scheduled pg_dump CronJob in init-databases.yaml and the runbook in
+  # docs/guides/postgres-cnpg-migration.md. When an object store is introduced,
+  # add a `backup.barmanObjectStore` block and a `ScheduledBackup` here.

--- a/platform/base/cnpg/init-databases.yaml
+++ b/platform/base/cnpg/init-databases.yaml
@@ -1,0 +1,227 @@
+# =============================================================================
+# CNPG database/user bootstrap + scheduled pg_dump backup (Issue #275)
+# =============================================================================
+# CNPG's static `bootstrap.initdb` SQL cannot read per-service passwords from a
+# Secret, so the six platform databases/users are (re)created by this idempotent
+# Job, which sources every password from `postgresql-secrets` exactly as the
+# legacy StatefulSet's init.sh did. Re-running is safe (guards on pg_roles /
+# pg_database), so it doubles as a self-heal reconciler under ArgoCD.
+# =============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgresql-cnpg-init-scripts
+  namespace: platform-db
+data:
+  init.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    # Wait for the CNPG primary to accept connections.
+    until pg_isready -h "$PGHOST" -U "$PGUSER"; do
+      echo "waiting for $PGHOST ..."; sleep 3
+    done
+
+    # Bind every password as a psql variable. The :'name' form produces a safely
+    # quoted SQL literal, so arbitrary Secret values cannot break or inject SQL.
+    # CREATE is guarded; ALTER always reconciles a rotated password.
+    psql -v ON_ERROR_STOP=1 --username "$PGUSER" --dbname postgres \
+      -v keycloak_password="$KEYCLOAK_DB_PASSWORD" \
+      -v backstage_password="$BACKSTAGE_DB_PASSWORD" \
+      -v gitea_password="$GITEA_DB_PASSWORD" \
+      -v sonarqube_password="$SONARQUBE_DB_PASSWORD" \
+      -v harbor_password="$HARBOR_DB_PASSWORD" <<-'EOSQL'
+        SELECT format('CREATE ROLE keycloak LOGIN PASSWORD %L', :'keycloak_password')
+          WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname='keycloak')\gexec
+        SELECT format('ALTER ROLE keycloak LOGIN PASSWORD %L', :'keycloak_password')\gexec
+
+        SELECT format('CREATE ROLE backstage LOGIN CREATEDB PASSWORD %L', :'backstage_password')
+          WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname='backstage')\gexec
+        SELECT format('ALTER ROLE backstage LOGIN CREATEDB PASSWORD %L', :'backstage_password')\gexec
+
+        SELECT format('CREATE ROLE gitea LOGIN PASSWORD %L', :'gitea_password')
+          WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname='gitea')\gexec
+        SELECT format('ALTER ROLE gitea LOGIN PASSWORD %L', :'gitea_password')\gexec
+
+        SELECT format('CREATE ROLE sonarqube LOGIN PASSWORD %L', :'sonarqube_password')
+          WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname='sonarqube')\gexec
+        SELECT format('ALTER ROLE sonarqube LOGIN PASSWORD %L', :'sonarqube_password')\gexec
+
+        SELECT format('CREATE ROLE harbor LOGIN PASSWORD %L', :'harbor_password')
+          WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname='harbor')\gexec
+        SELECT format('ALTER ROLE harbor LOGIN PASSWORD %L', :'harbor_password')\gexec
+
+        SELECT 'CREATE DATABASE keycloak OWNER keycloak'
+          WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname='keycloak')\gexec
+        SELECT 'CREATE DATABASE backstage OWNER backstage'
+          WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname='backstage')\gexec
+        SELECT 'CREATE DATABASE gitea OWNER gitea'
+          WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname='gitea')\gexec
+        SELECT 'CREATE DATABASE sonarqube OWNER sonarqube'
+          WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname='sonarqube')\gexec
+        SELECT 'CREATE DATABASE registry OWNER harbor'
+          WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname='registry')\gexec
+
+        GRANT ALL PRIVILEGES ON DATABASE keycloak  TO keycloak;
+        GRANT ALL PRIVILEGES ON DATABASE backstage TO backstage;
+        GRANT ALL PRIVILEGES ON DATABASE gitea     TO gitea;
+        GRANT ALL PRIVILEGES ON DATABASE sonarqube TO sonarqube;
+        GRANT ALL PRIVILEGES ON DATABASE registry  TO harbor;
+    EOSQL
+
+    # Schema-level grants, matching the legacy init.sh.
+    for pair in "keycloak keycloak" "backstage backstage" "gitea gitea" \
+                "sonarqube sonarqube" "registry harbor"; do
+      set -- $pair
+      psql -v ON_ERROR_STOP=1 --username "$PGUSER" --dbname "$1" \
+        -c "GRANT ALL ON SCHEMA public TO $2;"
+    done
+
+    echo "database bootstrap complete"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: postgresql-cnpg-init
+  namespace: platform-db
+  annotations:
+    # Run after the Cluster is healthy (operator = wave 0, Cluster app = wave 1).
+    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 10
+  activeDeadlineSeconds: 900
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgresql-cnpg-init
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: init
+          image: ghcr.io/cloudnative-pg/postgresql:16.9@sha256:cca50a94e2da46ddcaefb23260c805ed3b466763bd2a25e1617410176d5fd0ab
+          command: ["/bin/bash", "/scripts/init.sh"]
+          env:
+            - name: PGHOST
+              value: postgresql-cnpg-rw
+            - name: PGUSER
+              value: postgres
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-secrets
+                  key: POSTGRES_PASSWORD
+            - name: KEYCLOAK_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-secrets
+                  key: KEYCLOAK_DB_PASSWORD
+            - name: BACKSTAGE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-secrets
+                  key: BACKSTAGE_DB_PASSWORD
+            - name: GITEA_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-secrets
+                  key: GITEA_DB_PASSWORD
+            - name: SONARQUBE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-secrets
+                  key: SONARQUBE_DB_PASSWORD
+            - name: HARBOR_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-secrets
+                  key: HARBOR_DB_PASSWORD
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: scripts
+          configMap:
+            name: postgresql-cnpg-init-scripts
+            defaultMode: 0755
+---
+# Persistent target for the scheduled logical (pg_dump) backups. In dev this
+# replaces an object store; the restore runbook reads from this PVC.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgresql-cnpg-backups
+  namespace: platform-db
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+# Scheduled logical backup: nightly pg_dump of all six databases to the PVC
+# above. See docs/guides/postgres-cnpg-migration.md for restore steps.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgresql-cnpg-pgdump
+  namespace: platform-db
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 1800
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: pgdump
+              image: ghcr.io/cloudnative-pg/postgresql:16.9@sha256:cca50a94e2da46ddcaefb23260c805ed3b466763bd2a25e1617410176d5fd0ab
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+                  umask 077
+                  ts="$(date +%Y%m%d-%H%M%S)"
+                  tmp="/backups/.${ts}.tmp"
+                  dest="/backups/${ts}"
+                  trap 'rm -rf "$tmp"' EXIT
+                  mkdir -p "$tmp"
+                  for db in keycloak backstage gitea sonarqube registry; do
+                    echo "dumping $db ..."
+                    pg_dump -h "$PGHOST" -U "$PGUSER" -Fc "$db" > "$tmp/$db.dump"
+                    pg_restore --list "$tmp/$db.dump" > /dev/null
+                  done
+                  # Cluster-wide roles/globals (contains password hashes; umask 077).
+                  pg_dumpall -h "$PGHOST" -U "$PGUSER" --globals-only > "$tmp/globals.sql"
+                  test -s "$tmp/globals.sql"
+                  touch "$tmp/COMPLETE"
+                  mv "$tmp" "$dest"
+                  trap - EXIT
+                  # Dev retention: remove completed backups older than seven days.
+                  find /backups -mindepth 1 -maxdepth 1 -type d -name '20*' -mtime +7 -exec rm -rf {} +
+                  echo "verified backup written to $dest"
+              env:
+                - name: PGHOST
+                  value: postgresql-cnpg-rw
+                - name: PGUSER
+                  value: postgres
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgresql-secrets
+                      key: POSTGRES_PASSWORD
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: postgresql-cnpg-backups

--- a/platform/base/cnpg/kustomization.yaml
+++ b/platform/base/cnpg/kustomization.yaml
@@ -1,8 +1,28 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# CNPG Operator is installed via Helm by ArgoCD.
-# This kustomization provides supplementary resources if needed.
-# See: apps/platform/cnpg.yaml
+# CNPG Cluster + database bootstrap for the shared PostgreSQL (Issue #275). The
+# CNPG *operator* is installed via Helm by the `cnpg` ArgoCD Application
+# (apps/platform/cnpg.yaml); this base is deployed by the `cnpg-cluster`
+# Application (apps/platform/cnpg-cluster.yaml).
+#
+# COEXISTENCE SAFETY: `service.yaml` (the ExternalName alias named `postgresql`)
+# is DELIBERATELY NOT listed below. The legacy `postgresql` Application already
+# owns a Service named `postgresql` in this namespace; syncing the alias here at
+# the same time would make two ArgoCD Applications fight over that one object
+# (selfHeal ping-pong). During coexistence the CNPG database is reachable
+# directly at `postgresql-cnpg-rw`. The alias is enabled only at CUTOVER, in the
+# same commit that removes the legacy app/base — see
+# docs/guides/postgres-cnpg-migration.md.
+#
+# Secrets: `postgresql-secrets` (per-service passwords, Opaque) and
+# `postgresql-cnpg-superuser` (CNPG basic-auth superuser) are created by the
+# setup script before ArgoCD bootstrap, so they are not committed to Git but are
+# available when ArgoCD syncs this base.
 
-resources: []
+namespace: platform-db
+
+resources:
+  - cluster.yaml
+  - init-databases.yaml
+  # - service.yaml   # enabled only at cutover (see runbook) — do NOT sync yet

--- a/platform/base/cnpg/service.yaml
+++ b/platform/base/cnpg/service.yaml
@@ -1,0 +1,37 @@
+# =============================================================================
+# Consumer-facing alias Service (Issue #275)
+# =============================================================================
+# Every platform consumer (keycloak, backstage, gitea, sonarqube, harbor)
+# connects to host `postgresql.platform-db.svc.cluster.local:5432`. CNPG names
+# its primary service `<cluster>-rw` (here `postgresql-cnpg-rw`), so this
+# ExternalName alias keeps the original DNS name resolving to the CNPG primary
+# with NO change to any consumer manifest.
+#
+# CUTOVER-ONLY ARTIFACT — NOT SYNCED DURING COEXISTENCE.
+# The legacy StatefulSet (platform/base/postgresql) still defines its own
+# `postgresql` Service. Both are named `postgresql` in platform-db, so if BOTH
+# the legacy `postgresql` Application and the `cnpg-cluster` Application synced a
+# Service by this name, the two ArgoCD apps would continuously fight over the
+# object. To avoid that, this file is intentionally EXCLUDED from
+# kustomization.yaml until cutover. Until then the CNPG stack is reachable
+# directly at `postgresql-cnpg-rw`.
+#
+# CUTOVER (single atomic commit, see docs/guides/postgres-cnpg-migration.md):
+#   1. uncomment `- service.yaml` in platform/base/cnpg/kustomization.yaml
+#   2. delete apps/platform/postgresql.yaml and platform/base/postgresql/
+# Reverting that commit rolls the cutover back.
+# =============================================================================
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  namespace: platform-db
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/part-of: digiorg-platform
+spec:
+  type: ExternalName
+  externalName: postgresql-cnpg-rw.platform-db.svc.cluster.local
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/platform/base/external-secrets/cluster-secret-store-dev.yaml
+++ b/platform/base/external-secrets/cluster-secret-store-dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: digiorg-dev-store

--- a/platform/base/external-secrets/example-external-secret.yaml
+++ b/platform/base/external-secrets/example-external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: example-secret

--- a/platform/base/fluentd/daemonset.yaml
+++ b/platform/base/fluentd/daemonset.yaml
@@ -24,7 +24,10 @@ spec:
           effect: NoSchedule
       containers:
         - name: fluentd
-          image: fluent/fluentd-kubernetes-daemonset:v1.19-debian-opensearch-1
+          # Locally built + kind-loaded DigiOrg image with pinned plugin gems
+          # (built by platform/images/fluentd/build.nu). Never pulled.
+          image: digiorg/fluentd:v1.19.2-debian-opensearch-1.0
+          imagePullPolicy: Never
           env:
             - name: FLUENT_ELASTICSEARCH_HOST
               value: "opensearch-cluster-master.platform-db.svc.cluster.local"

--- a/platform/base/gitea/values.yaml
+++ b/platform/base/gitea/values.yaml
@@ -6,8 +6,13 @@
 replicaCount: 1
 
 image:
-  repository: gitea/gitea
-  tag: ""  # Use chart default (latest stable)
+  # Chart 12 changed the default registry/repository layout from the historical
+  # Docker Hub-style gitea/gitea path. Pin the actual 1.26.1 OCI index so the
+  # rendered image is reproducible and pullable.
+  registry: docker.gitea.com
+  repository: gitea
+  tag: "1.26.1"
+  digest: "sha256:d8667667b4ccbd1f67b86a376bffcc0a17b16cf71309ed04e3918231776d47dd"
   pullPolicy: IfNotPresent
   rootless: false
 
@@ -15,12 +20,16 @@ image:
 postgresql:
   enabled: false
 
-# Disable built-in PostgreSQL HA
+# Disable built-in PostgreSQL HA (default-enabled in chart 12.x)
 postgresql-ha:
   enabled: false
 
-# Disable Redis cluster — use in-memory cache for local dev
-redis-cluster:
+# Chart 12.x replaced the bundled Redis with Valkey; valkey-cluster is enabled by
+# default. Gitea here uses in-process session/cache (memory) + level queue, so no
+# Valkey is needed — disable both bundled subcharts (Issue #275).
+valkey-cluster:
+  enabled: false
+valkey:
   enabled: false
 
 # Persistence for Git repositories
@@ -103,9 +112,32 @@ gitea:
     actions:
       ENABLED: true
 
+  # Chart 12.x nests probes below `gitea`; top-level probe keys are ignored.
+  livenessProbe:
+    enabled: true
+    tcpSocket:
+      port: http
+    initialDelaySeconds: 200
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 10
+  readinessProbe:
+    enabled: true
+    tcpSocket:
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
 # Note: Database password is injected via gitea.additionalConfigFromEnvs above,
 # NOT via extraEnvVars. extraEnvVars only applies to the main container,
 # but the configure-gitea init container needs the password for migrations.
+
+# Optional Helm test hook defaults to busybox:latest in chart 12.x. Disable it;
+# platform smoke tests are run by the dedicated validation workflow instead.
+test:
+  enabled: false
 
 # Ingress disabled — using platform-wide ingress
 ingress:
@@ -128,18 +160,3 @@ resources:
   limits:
     cpu: 500m
     memory: 512Mi
-
-# Probes
-livenessProbe:
-  enabled: true
-  initialDelaySeconds: 200
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 10
-
-readinessProbe:
-  enabled: true
-  initialDelaySeconds: 5
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 3

--- a/platform/base/grafana/values.yaml
+++ b/platform/base/grafana/values.yaml
@@ -77,8 +77,12 @@ prometheus:
     # (default: only monitoring namespace). Required for NATS Surveyor in messaging ns.
     serviceMonitorNamespaceSelector: {}
     serviceMonitorSelector:
-      matchLabels:
-        release: prometheus
+      matchExpressions:
+        - key: release
+          operator: In
+          values:
+            - prometheus
+            - harbor
 
 alertmanager:
   enabled: false

--- a/platform/base/harbor/harbor-oidc-config-job.yaml
+++ b/platform/base/harbor/harbor-oidc-config-job.yaml
@@ -27,7 +27,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: configure-oidc
-          image: curlimages/curl:8.7.1
+          image: curlimages/curl:8.16.0@sha256:463eaf6072688fe96ac64fa623fe73e1dbe25d8ad6c34404a669ad3ce1f104b6
           env:
             - name: HARBOR_ADMIN_PASSWORD
               valueFrom:

--- a/platform/base/harbor/harbor-proxy-cache-job.yaml
+++ b/platform/base/harbor/harbor-proxy-cache-job.yaml
@@ -1,0 +1,132 @@
+# =============================================================================
+# Harbor Proxy-Cache Configuration Job (Issue #275, Tier 2)
+#
+# ArgoCD PostSync hook: after every Harbor deployment, provisions pull-through
+# proxy-cache projects for the upstream registries the platform pulls from —
+# Docker Hub, Quay, GHCR and registry.k8s.io — via Harbor's REST API. Harbor
+# stores registries/projects in PostgreSQL (not env/config), so — exactly like
+# the OIDC config (Issue #262) — a REST-API Job is the only GitOps-compatible
+# path.
+#
+# Each proxy-cache project pulls-through and caches its upstream:
+#   dockerhub-proxy  -> https://hub.docker.com      (type docker-hub)
+#   quay-proxy       -> https://quay.io             (type quay)
+#   ghcr-proxy       -> https://ghcr.io             (type github-ghcr)
+#   k8s-proxy        -> https://registry.k8s.io     (type docker-registry)
+#
+# Registry `type` strings are the exact Harbor constants from
+# src/pkg/reg/model/registry.go. A Harbor project becomes a proxy cache only
+# when created with a `registry_id`. The Job is bounded and idempotent: HTTP 409
+# triggers a read-back that verifies the existing registry/project matches the
+# desired type, URL and registry binding; stale name collisions fail closed.
+#
+# NOTE: consuming these mirror paths from workload manifests (e.g.
+# harbor.harbor.svc/dockerhub-proxy/library/busybox@sha256:…) is a follow-up;
+# bootstrap components that run before Harbor is Ready are a documented
+# exception (see docs/guides/platform-versions.md, "Harbor proxy-cache").
+# =============================================================================
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: harbor-proxy-cache-config
+  namespace: harbor
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  ttlSecondsAfterFinished: 300
+  activeDeadlineSeconds: 600
+  backoffLimit: 2
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: configure-proxy-cache
+          image: curlimages/curl:8.16.0@sha256:463eaf6072688fe96ac64fa623fe73e1dbe25d8ad6c34404a669ad3ce1f104b6
+          env:
+            - name: HARBOR_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: harbor-admin-secret
+                  key: HARBOR_ADMIN_PASSWORD
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              HARBOR_API="http://harbor.harbor.svc.cluster.local/api/v2.0"
+              AUTH="admin:${HARBOR_ADMIN_PASSWORD}"
+
+              CURL="curl --connect-timeout 5 --max-time 30 --retry 2"
+
+              echo "Waiting for Harbor API to be ready..."
+              ready=false
+              for attempt in $(seq 1 60); do
+                if ${CURL} -sf "${HARBOR_API}/ping" > /dev/null 2>&1; then
+                  ready=true; break
+                fi
+                echo "  Harbor not ready (${attempt}/60), retrying in 5s..."
+                sleep 5
+              done
+              [ "$ready" = true ] || { echo "ERROR: Harbor API readiness timeout"; exit 1; }
+              echo "Harbor API is ready."
+
+              # Create or verify an upstream registry endpoint.
+              create_registry() {
+                name="$1"; rtype="$2"; url="$3"
+                code=$(${CURL} -s -o /dev/null -w "%{http_code}" -X POST \
+                  -u "${AUTH}" -H "Content-Type: application/json" \
+                  -d "{\"name\":\"${name}\",\"type\":\"${rtype}\",\"url\":\"${url}\",\"insecure\":false}" \
+                  "${HARBOR_API}/registries")
+                case "$code" in
+                  201) echo "  registry ${name} created" ;;
+                  409)
+                    existing=$(${CURL} -sf -u "${AUTH}" "${HARBOR_API}/registries?q=name%3D${name}" | tr -d '[:space:]')
+                    echo "$existing" | grep -Fq "\"type\":\"${rtype}\"" || { echo "ERROR: registry ${name} has wrong type"; exit 1; }
+                    echo "$existing" | grep -Fq "\"url\":\"${url}\"" || { echo "ERROR: registry ${name} has wrong URL"; exit 1; }
+                    echo "  registry ${name} already exists and matches"
+                    ;;
+                  *) echo "ERROR: registry ${name} -> HTTP ${code}"; exit 1 ;;
+                esac
+              }
+
+              # Resolve a registry's numeric id by name (curl-only, no jq).
+              registry_id() {
+                ${CURL} -sf -u "${AUTH}" "${HARBOR_API}/registries?q=name%3D$1" \
+                  | tr ',' '\n' | grep -o '"id":[0-9]*' | head -1 | grep -o '[0-9]*'
+              }
+
+              # Create or verify a proxy-cache project bound to the registry.
+              create_proxy_project() {
+                project="$1"; regid="$2"
+                if [ -z "${regid}" ]; then
+                  echo "ERROR: could not resolve registry id for project ${project}"; exit 1
+                fi
+                code=$(${CURL} -s -o /dev/null -w "%{http_code}" -X POST \
+                  -u "${AUTH}" -H "Content-Type: application/json" \
+                  -d "{\"project_name\":\"${project}\",\"registry_id\":${regid},\"public\":true,\"metadata\":{\"public\":\"true\"},\"storage_limit\":-1}" \
+                  "${HARBOR_API}/projects")
+                case "$code" in
+                  201) echo "  proxy project ${project} created" ;;
+                  409)
+                    existing=$(${CURL} -sf -u "${AUTH}" "${HARBOR_API}/projects/${project}" | tr -d '[:space:]')
+                    echo "$existing" | grep -Fq "\"registry_id\":${regid}" || { echo "ERROR: project ${project} is not bound to registry ${regid}"; exit 1; }
+                    echo "  proxy project ${project} already exists and matches"
+                    ;;
+                  *) echo "ERROR: project ${project} -> HTTP ${code}"; exit 1 ;;
+                esac
+              }
+
+              echo "Configuring upstream registry endpoints..."
+              create_registry docker-hub      docker-hub      https://hub.docker.com
+              create_registry quay            quay            https://quay.io
+              create_registry ghcr            github-ghcr     https://ghcr.io
+              create_registry registry-k8s-io docker-registry https://registry.k8s.io
+
+              echo "Configuring proxy-cache projects..."
+              create_proxy_project dockerhub-proxy "$(registry_id docker-hub)"
+              create_proxy_project quay-proxy      "$(registry_id quay)"
+              create_proxy_project ghcr-proxy      "$(registry_id ghcr)"
+              create_proxy_project k8s-proxy       "$(registry_id registry-k8s-io)"
+
+              echo "Harbor proxy-cache configuration complete."

--- a/platform/base/harbor/harbor-ui-proxy.yaml
+++ b/platform/base/harbor/harbor-ui-proxy.yaml
@@ -132,7 +132,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.27-alpine
+          image: nginx:1.30-alpine@sha256:ec664813a30459a8e7176315268a623f6b31abc370eeac51c7de81cd4ec4d451
           ports:
             - name: http
               containerPort: 9091

--- a/platform/base/harbor/kustomization.yaml
+++ b/platform/base/harbor/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - harbor-oidc-secret.yaml
   - harbor-admin-secret.yaml
   - harbor-oidc-config-job.yaml
+  - harbor-proxy-cache-job.yaml

--- a/platform/base/harbor/values.yaml
+++ b/platform/base/harbor/values.yaml
@@ -49,8 +49,10 @@ metrics:
   enabled: true
   serviceMonitor:
     enabled: true
-    additionalLabels:
-      release: prometheus
+    # Harbor chart 1.19 emits `release: harbor` itself. Do not add another
+    # release key here; duplicate YAML keys make the rendered ServiceMonitor
+    # invalid. Prometheus accepts both labels via its selector below.
+    additionalLabels: {}
 
 trace:
   enabled: true

--- a/platform/base/jaeger/oauth2-proxy.yaml
+++ b/platform/base/jaeger/oauth2-proxy.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           args:
             - --provider=oidc
             - --oidc-issuer-url=https://digiorg.local/keycloak/realms/digiorg-core-platform

--- a/platform/base/keycloak/keycloak-deployment.yaml
+++ b/platform/base/keycloak/keycloak-deployment.yaml
@@ -1,6 +1,9 @@
 # =============================================================================
-# Keycloak Deployment — official image quay.io/keycloak/keycloak:26.0
-# Dev mode: HTTP only, realm import on first start
+# Keycloak Deployment — DigiOrg production-optimized image (Issue #275, Tier 1)
+# Built by platform/images/keycloak/build.nu from the digest-pinned upstream
+# base quay.io/keycloak/keycloak:26.7.0 with `kc.sh build` (db=postgres, health,
+# metrics), then started with `start --optimized`. HTTP enabled for local dev;
+# realm data stays in the mounted keycloak-realm-import configMap (not baked in).
 # =============================================================================
 apiVersion: v1
 kind: Service
@@ -33,9 +36,14 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:26.0
+          # Locally built + kind-loaded DigiOrg optimized image (never pulled).
+          image: digiorg/keycloak:26.7.0-optimized
+          imagePullPolicy: Never
           args:
-            - start-dev
+            # Production start against the pre-built optimized distribution.
+            - start
+            - --optimized
+            # Realm data stays in the mounted configMap volume (imported at boot).
             - --import-realm
           env:
             # Database

--- a/platform/base/landingpage/deployment.yaml
+++ b/platform/base/landingpage/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: landingpage
-          image: ghcr.io/digiorg/core-landingpage:main
+          image: ghcr.io/digiorg/core-landingpage:32a6777@sha256:a54c0d8cb01f27be93803ca883e4be6240fe19e82ee73c28023ed52da7b16b9f
           imagePullPolicy: Always
           ports:
             - name: http

--- a/platform/base/nats/surveyor.yaml
+++ b/platform/base/nats/surveyor.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: nats-surveyor
-          image: natsio/nats-surveyor:latest
+          image: natsio/nats-surveyor:0.9.10@sha256:3ba1d0e1f9e29a9f7481451097e39246d322cfd2e085aadefaec3b5141691746
           args:
             - --servers
             - nats://nats.messaging.svc.cluster.local:4222

--- a/platform/base/nats/values.yaml
+++ b/platform/base/nats/values.yaml
@@ -6,10 +6,12 @@ config:
   # Enable JetStream for persistent messaging
   jetstream:
     enabled: true
-    fileStorage:
+    fileStore:
       enabled: true
-      size: 1Gi
-      storageDirectory: /data
+      dir: /data
+      pvc:
+        enabled: true
+        size: 1Gi
 
   # Single-node for local dev (no clustering needed)
   cluster:
@@ -40,6 +42,8 @@ natsBox:
 # Use container.merge (not podTemplate.merge.spec.containers) to avoid
 # generating a container entry without an image field (causes StatefulSet validation failure)
 container:
+  image:
+    fullImageName: "nats:2.14.2-alpine@sha256:952d157e28d5394a211229bd57a7b37ff9f184e58e2c8486a08fa909fd254e32"
   merge:
     resources:
       requests:
@@ -49,14 +53,7 @@ container:
         cpu: 500m
         memory: 256Mi
 
-# Service configuration
-service:
-  ports:
-    client:
-      port: 4222
-    monitor:
-      port: 8222
-    leafnode:
-      enabled: false
-    websocket:
-      enabled: false
+# Pin the chart's enabled config reloader sidecar.
+reloader:
+  image:
+    fullImageName: "natsio/nats-server-config-reloader:0.23.0@sha256:64cb6c858e794906d3167378e02b7e0feb83c4e14c07b371eb8d921ef8c4a60b"

--- a/platform/base/opencost/oauth2-proxy.yaml
+++ b/platform/base/opencost/oauth2-proxy.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           args:
             - --provider=oidc
             - --oidc-issuer-url=https://digiorg.local/keycloak/realms/digiorg-core-platform

--- a/platform/base/opencost/values.yaml
+++ b/platform/base/opencost/values.yaml
@@ -48,6 +48,10 @@ opencost:
 
   ui:
     enabled: true
+    # Chart 2.x exposes uiPath as a first-class value (Issue #275). Pin it to the
+    # platform subpath so the serving path is set through the supported chart
+    # value in addition to the UI_PATH env below.
+    uiPath: /opencost
     # -- Custom subpath-aware UI image (Issue #272 Option B).
     #    Built from upstream v1.120.4 with `--build-arg vite_basename=/opencost`
     #    so the router basename, Vite asset base and nginx UI_PATH are all

--- a/platform/base/opensearch/index-template-job.yaml
+++ b/platform/base/opensearch/index-template-job.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: index-template-bootstrap
-          image: curlimages/curl:8.10.1
+          image: curlimages/curl:8.16.0@sha256:463eaf6072688fe96ac64fa623fe73e1dbe25d8ad6c34404a669ad3ce1f104b6
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/platform/base/opensearch/ism-retention-job.yaml
+++ b/platform/base/opensearch/ism-retention-job.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: ism-bootstrap
-          image: curlimages/curl:8.10.1
+          image: curlimages/curl:8.16.0@sha256:463eaf6072688fe96ac64fa623fe73e1dbe25d8ad6c34404a669ad3ce1f104b6
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/platform/base/opensearch/values.yaml
+++ b/platform/base/opensearch/values.yaml
@@ -25,6 +25,15 @@ nodeGroup: "master"
 singleNode: true
 replicas: 1
 
+# Pin the OpenSearch OCI index. Chart 3.7.0 otherwise derives a mutable tag from
+# appVersion without a digest. majorVersion prevents the chart helper from
+# semver-parsing the digest-qualified tag.
+majorVersion: "3"
+image:
+  repository: opensearchproject/opensearch
+  tag: "3.7.0@sha256:44ba7ea58a319adf61c33ab16873f9ef5dbb30b291a832d375172f0b2d24e3c9"
+  pullPolicy: IfNotPresent
+
 # =============================================================================
 # Java Heap
 # =============================================================================
@@ -64,6 +73,9 @@ resources:
 persistence:
   enabled: true
   size: 8Gi
+  # Chart defaults its volume-permission init container to busybox:latest.
+  image: busybox
+  imageTag: "1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028"
   # storageClass: "" — uses cluster default (standard on KinD)
 
 # =============================================================================

--- a/platform/base/postgresql/statefulset.yaml
+++ b/platform/base/postgresql/statefulset.yaml
@@ -77,7 +77,7 @@ spec:
         runAsGroup: 70
       containers:
         - name: postgresql
-          image: postgres:16-alpine
+          image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
           ports:
             - containerPort: 5432
           env:

--- a/platform/base/sonarqube/values.yaml
+++ b/platform/base/sonarqube/values.yaml
@@ -9,8 +9,15 @@
 community:
   enabled: true
   # buildNumber pins the Community Build version (year.month.patch.buildid format).
-  # Update to the desired Community Build release.
-  buildNumber: "26.4.0.121862"
+  # Aligned with the chart 2026.3.1 default Community Build (Issue #275).
+  buildNumber: "26.5.0.122743"
+
+# Explicitly pin the Community Build OCI index; the chart otherwise derives a
+# mutable tag from community.buildNumber.
+image:
+  repository: sonarqube
+  tag: "26.5.0.122743-community@sha256:223d0090322edce6211a5328298b6f646920f1535025ef8dd880cab6647bb1fa"
+  pullPolicy: IfNotPresent
 
 # ── Deployment ─────────────────────────────────────────────────────────────────
 replicaCount: 1

--- a/platform/images/fluentd/Dockerfile
+++ b/platform/images/fluentd/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1
+# =============================================================================
+# DigiOrg pinned Fluentd log-forwarder image — Issue #275 (Tier 1)
+# =============================================================================
+# The platform ran fluent/fluentd-kubernetes-daemonset on a FLOATING minor tag
+# (v1.19-debian-opensearch-1) and inherited whatever plugin versions the image
+# happened to ship. This pins the base by immutable digest and installs
+# EXPLICITLY versioned plugin gems, so a clean bootstrap forwards logs with the
+# same, reproducible plugin set every time.
+#
+# The base image entrypoint/cmd and its bundled config are inherited unchanged
+# (no COPY, no ENTRYPOINT override) — only the plugin gem set is pinned on top.
+# =============================================================================
+
+ARG UPSTREAM_IMAGE=fluent/fluentd-kubernetes-daemonset
+ARG UPSTREAM_TAG=v1.19.2-debian-opensearch-1.0
+ARG UPSTREAM_DIGEST=sha256:f7a636ae892cab78b0e63fcb4d89f68a84bd602609a7f38b00fcc5c65f487de2
+
+FROM ${UPSTREAM_IMAGE}:${UPSTREAM_TAG}@${UPSTREAM_DIGEST}
+
+# --- Explicitly pinned plugin gem versions ---------------------------------- #
+# Sourced from rubygems.org (latest releases, verified mutually compatible with
+# the base fluentd 1.19.2 — see ./README.md):
+#   * fluent-plugin-opensearch 1.1.6            (requires fluentd >= 0.14.22)
+#   * fluent-plugin-kubernetes_metadata_filter 3.8.0 (requires fluentd >= 0.14.0, < 1.20)
+USER root
+RUN gem install fluent-plugin-opensearch -v 1.1.6 --no-document \
+ && gem install fluent-plugin-kubernetes_metadata_filter -v 3.8.0 --no-document \
+ && gem sources --clear-all \
+ && rm -rf /var/lib/gems/*/cache/*.gem
+
+# --- Provenance (baked as OCI labels) --------------------------------------- #
+ARG version=v1.19.2-debian-opensearch-1.0
+ARG base_digest=sha256:f7a636ae892cab78b0e63fcb4d89f68a84bd602609a7f38b00fcc5c65f487de2
+LABEL org.opencontainers.image.title="digiorg/fluentd" \
+      org.opencontainers.image.description="DigiOrg Fluentd with pinned opensearch + kubernetes_metadata_filter plugins" \
+      org.opencontainers.image.source="https://github.com/digiorg/core" \
+      org.opencontainers.image.version="${version}" \
+      org.opencontainers.image.revision="${base_digest}" \
+      org.opencontainers.image.base.name="fluent/fluentd-kubernetes-daemonset:v1.19.2-debian-opensearch-1.0"

--- a/platform/images/fluentd/Dockerfile
+++ b/platform/images/fluentd/Dockerfile
@@ -5,8 +5,9 @@
 # The platform ran fluent/fluentd-kubernetes-daemonset on a FLOATING minor tag
 # (v1.19-debian-opensearch-1) and inherited whatever plugin versions the image
 # happened to ship. This pins the base by immutable digest and installs
-# EXPLICITLY versioned plugin gems, so a clean bootstrap forwards logs with the
-# same, reproducible plugin set every time.
+# EXPLICITLY versioned top-level plugin gems. Their Ruby transitive dependencies
+# are still resolved live; add a lockfile/vendor checksums before claiming a fully
+# reproducible plugin graph.
 #
 # The base image entrypoint/cmd and its bundled config are inherited unchanged
 # (no COPY, no ENTRYPOINT override) — only the plugin gem set is pinned on top.

--- a/platform/images/fluentd/README.md
+++ b/platform/images/fluentd/README.md
@@ -1,8 +1,9 @@
 # DigiOrg pinned Fluentd image
 
 Pinned Fluentd log-forwarder image built for **Issue #275 — Tier 1**. It fixes
-the base image by immutable digest and installs **explicitly versioned** plugin
-gems, so a clean bootstrap ships the same, reproducible plugin set every time.
+the base image by immutable digest and installs explicitly versioned top-level
+plugin gems. Their transitive Ruby dependencies are still resolved live; a
+lockfile or vendored checksummed gems remain required for full reproducibility.
 
 ## Why this exists
 
@@ -42,7 +43,7 @@ only the plugin gem set is pinned on top.
 | Upstream base digest (immutable) | `sha256:f7a636ae892cab78b0e63fcb4d89f68a84bd602609a7f38b00fcc5c65f487de2` |
 | Pinned plugins | `fluent-plugin-opensearch=1.1.6`, `fluent-plugin-kubernetes_metadata_filter=3.8.0` |
 
-The local image + `IfNotPresent` pull policy are consumed by
+The local image + `Never` pull policy are consumed by
 `platform/base/fluentd/daemonset.yaml` and asserted by
 `platform/tests/test_fluentd_image.py`. The exact ref is allow-listed in
 `scripts/pin-policy-allowlist.yaml` (locally built, kind-loaded, never pulled).

--- a/platform/images/fluentd/README.md
+++ b/platform/images/fluentd/README.md
@@ -1,0 +1,90 @@
+# DigiOrg pinned Fluentd image
+
+Pinned Fluentd log-forwarder image built for **Issue #275 — Tier 1**. It fixes
+the base image by immutable digest and installs **explicitly versioned** plugin
+gems, so a clean bootstrap ships the same, reproducible plugin set every time.
+
+## Why this exists
+
+The daemonset previously ran
+`fluent/fluentd-kubernetes-daemonset:v1.19-debian-opensearch-1` — a **floating**
+minor tag — and inherited whatever plugin versions that image happened to ship.
+Two logging-critical plugins are now pinned on top of a digest-pinned base:
+
+| Plugin | Pinned version | Requires | Source |
+| --- | --- | --- | --- |
+| `fluent-plugin-opensearch` | `1.1.6` | `fluentd >= 0.14.22` | rubygems.org (latest release) |
+| `fluent-plugin-kubernetes_metadata_filter` | `3.8.0` | `fluentd >= 0.14.0, < 1.20` | rubygems.org (latest release) |
+
+Both are mutually compatible with the base image's **fluentd 1.19.2** (1.19.2
+satisfies `>= 0.14.22` and is `< 1.20`). Versions and their fluentd requirements
+were read from the rubygems.org API:
+
+```sh
+python3 -c "import urllib.request,json; \
+  print(json.load(urllib.request.urlopen('https://rubygems.org/api/v1/gems/fluent-plugin-opensearch.json'))['version'])"
+# → 1.1.6
+python3 -c "import urllib.request,json; \
+  print(json.load(urllib.request.urlopen('https://rubygems.org/api/v1/gems/fluent-plugin-kubernetes_metadata_filter.json'))['version'])"
+# → 3.8.0
+```
+
+The base image entrypoint, command and bundled config are inherited unchanged —
+only the plugin gem set is pinned on top.
+
+## Image coordinates
+
+| | Value |
+| --- | --- |
+| Local (kind) image | `digiorg/fluentd:v1.19.2-debian-opensearch-1.0` |
+| Registry path (Harbor) | `digiorg.local/library/fluentd:v1.19.2-debian-opensearch-1.0` |
+| Upstream base | `fluent/fluentd-kubernetes-daemonset:v1.19.2-debian-opensearch-1.0` |
+| Upstream base digest (immutable) | `sha256:f7a636ae892cab78b0e63fcb4d89f68a84bd602609a7f38b00fcc5c65f487de2` |
+| Pinned plugins | `fluent-plugin-opensearch=1.1.6`, `fluent-plugin-kubernetes_metadata_filter=3.8.0` |
+
+The local image + `IfNotPresent` pull policy are consumed by
+`platform/base/fluentd/daemonset.yaml` and asserted by
+`platform/tests/test_fluentd_image.py`. The exact ref is allow-listed in
+`scripts/pin-policy-allowlist.yaml` (locally built, kind-loaded, never pulled).
+
+The base digest was resolved with
+`python3 scripts/resolve_digest.py fluent/fluentd-kubernetes-daemonset:v1.19.2-debian-opensearch-1.0`.
+
+## Build & publish
+
+`build.nu` is a cross-platform [Nushell](https://www.nushell.sh) script, so the
+same commands work on Linux, macOS and Windows (with Docker Desktop and kind on
+`PATH`). Run them from a Nushell prompt:
+
+```nu
+# Build + load into the local kind cluster (default)
+nu build.nu
+
+# Build only
+with-env {LOAD: "0"} { nu build.nu }
+
+# Build + push to Harbor (run `docker login digiorg.local` first — no
+# credentials are stored in this repo)
+with-env {PUSH: "1"} { nu build.nu }
+```
+
+Before building, `build.nu` calls `scripts/resolve_digest.py` and **verifies**
+the pinned tag still resolves to `UPSTREAM_DIGEST`, so an upstream re-tag cannot
+silently change the base. `version`/`base_digest` build args bake the provenance
+into OCI labels. The local kind image and optional Harbor target are separate:
+`digiorg/fluentd:<tag>` locally and `digiorg.local/library/fluentd:<tag>` in
+Harbor.
+
+## Upgrade procedure
+
+1. Pick the new upstream tag; resolve its digest:
+   `python3 scripts/resolve_digest.py fluent/fluentd-kubernetes-daemonset:<tag>`
+2. Check the newest compatible plugin versions on rubygems.org (the
+   `kubernetes_metadata_filter` `< 1.20` fluentd bound in particular).
+3. Update `UPSTREAM_TAG` / `UPSTREAM_DIGEST` / `TAG` in `build.nu`, the
+   Dockerfile `ARG` defaults + labels, and the plugin version ARGs.
+4. Bump the image tag in `daemonset.yaml` and the
+   `scripts/pin-policy-allowlist.yaml` entry.
+5. Run `python3 platform/tests/test_fluentd_image.py` and
+   `python3 scripts/check_pins.py`.
+6. `with-env {PUSH: "1"} { nu build.nu }`, scan in Harbor, then roll out.

--- a/platform/images/fluentd/build.nu
+++ b/platform/images/fluentd/build.nu
@@ -1,0 +1,103 @@
+#!/usr/bin/env nu
+
+# =============================================================================
+# Build the DigiOrg pinned Fluentd image — Issue #275 (Tier 1)
+# =============================================================================
+# The daemonset ran fluent/fluentd-kubernetes-daemonset on a FLOATING minor tag
+# and inherited whatever plugin versions the upstream image shipped. This builds
+# a pinned image FROM the digest-pinned upstream base into which EXPLICITLY
+# versioned plugin gems (opensearch + kubernetes_metadata_filter) are installed.
+# See ./README.md for the gem-version sources and compatibility notes.
+#
+# This script is the single source of truth for HOW the pinned image is built.
+# It is written in Nushell so it runs identically on Linux, macOS and Windows
+# with Docker Desktop and kind on PATH — no bash or Unix-only utilities.
+# It is intentionally credential-free: authenticate to the registry out-of-band
+# (`docker login` / `nu scripts/local-setup.nu`) before running with PUSH set.
+#
+# Reproducibility / provenance:
+#   * UPSTREAM_TAG    — the upstream image tag we track.
+#   * UPSTREAM_DIGEST — the immutable digest that tag resolves to. The Dockerfile
+#                       FROM pins the digest, and this script verifies the tag
+#                       still resolves to it before building, so an upstream
+#                       re-tag cannot silently change the base. The version +
+#                       base digest are baked into OCI labels.
+#
+# Usage (identical on Linux, macOS and Windows — no shell-specific env syntax):
+#   nu build.nu                             # build + `kind load` into local dev cluster
+#   with-env {PUSH: "1"} { nu build.nu }    # also push to $REGISTRY (needs prior docker login)
+#   with-env {LOAD: "0"} { nu build.nu }    # build only (no kind load, no push)
+# =============================================================================
+
+# --- Pinned upstream base --------------------------------------------------- #
+const UPSTREAM_IMAGE = "fluent/fluentd-kubernetes-daemonset"
+const UPSTREAM_TAG = "v1.19.2-debian-opensearch-1.0"
+const UPSTREAM_DIGEST = "sha256:f7a636ae892cab78b0e63fcb4d89f68a84bd602609a7f38b00fcc5c65f487de2"
+
+# --- Image coordinates ------------------------------------------------------ #
+# IMAGE/TAG are the local (kind-loaded) coordinates and MUST match the image
+# selected in platform/base/fluentd/daemonset.yaml. REGISTRY and
+# REGISTRY_REPOSITORY form the separate Harbor target used only on PUSH.
+const IMAGE = "digiorg/fluentd"
+const TAG = "v1.19.2-debian-opensearch-1.0"
+const REGISTRY_REPOSITORY = "fluentd"
+
+def main [] {
+    # --- Behaviour toggles / registry (overridable via environment) --------- #
+    let registry = ($env.REGISTRY? | default "digiorg.local/library")
+    let kind_cluster = ($env.KIND_CLUSTER? | default "digiorg-core-dev")
+    let load = ($env.LOAD? | default "1")
+    let push = ($env.PUSH? | default "0")
+
+    print $">> Building ($IMAGE):($TAG)"
+    print $"   base   : ($UPSTREAM_IMAGE):($UPSTREAM_TAG)@($UPSTREAM_DIGEST)"
+    print "   plugins: fluent-plugin-opensearch + fluent-plugin-kubernetes_metadata_filter (pinned)"
+
+    # Verify the pinned tag still resolves to the pinned digest before building,
+    # so provenance is guaranteed even though Docker resolves the base by tag.
+    # The repo's resolve_digest.py talks to the registry v2 API without Docker
+    # and prints "<registry>/<repo>:<tag>@sha256:<digest>"; compare the digest.
+    let repo_root = ($env.FILE_PWD | path join ".." ".." "..")
+    let resolver = ($repo_root | path join "scripts" "resolve_digest.py")
+    if ($resolver | path exists) {
+        let resolved = (python3 $resolver $"($UPSTREAM_IMAGE):($UPSTREAM_TAG)" | str trim)
+        let resolved_digest = ($resolved | split row "@" | last | str trim)
+        if ($resolved_digest != $UPSTREAM_DIGEST) {
+            print -e $"ERROR: ($UPSTREAM_IMAGE):($UPSTREAM_TAG) resolves to ($resolved_digest),"
+            print -e $"       expected ($UPSTREAM_DIGEST). Upstream re-tagged the release."
+            print -e "       Review the change and update UPSTREAM_DIGEST deliberately."
+            exit 1
+        }
+        print $"   verified: tag resolves to ($UPSTREAM_DIGEST)"
+    } else {
+        print -e "WARN: scripts/resolve_digest.py not found — skipping tag/digest verification"
+    }
+
+    # version/base_digest bake provenance into the image OCI labels. The base is
+    # pinned by digest in the Dockerfile's FROM line.
+    (
+        docker build
+            --build-arg $"UPSTREAM_IMAGE=($UPSTREAM_IMAGE)"
+            --build-arg $"UPSTREAM_TAG=($UPSTREAM_TAG)"
+            --build-arg $"UPSTREAM_DIGEST=($UPSTREAM_DIGEST)"
+            --build-arg $"version=($UPSTREAM_TAG)"
+            --build-arg $"base_digest=($UPSTREAM_DIGEST)"
+            --tag $"($IMAGE):($TAG)"
+            $env.FILE_PWD
+    )
+
+    print $">> Built ($IMAGE):($TAG)"
+
+    if $load == "1" {
+        print $">> Loading ($IMAGE):($TAG) into kind cluster '($kind_cluster)'"
+        kind load docker-image $"($IMAGE):($TAG)" --name $kind_cluster
+    }
+
+    if $push == "1" {
+        print $">> Pushing to ($registry)/($REGISTRY_REPOSITORY):($TAG)"
+        docker tag $"($IMAGE):($TAG)" $"($registry)/($REGISTRY_REPOSITORY):($TAG)"
+        docker push $"($registry)/($REGISTRY_REPOSITORY):($TAG)"
+    }
+
+    print ">> Done."
+}

--- a/platform/images/keycloak/Dockerfile
+++ b/platform/images/keycloak/Dockerfile
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1
+# =============================================================================
+# DigiOrg production-optimized Keycloak image — Issue #275 (Tier 1)
+# =============================================================================
+# Multi-stage build that produces a Keycloak server pre-augmented for the
+# platform's build-time options, so the deployment can run `start --optimized`
+# (production start with no per-boot re-augmentation) instead of `start-dev`.
+#
+# Realm/user data is intentionally NOT baked in — it stays in the realm-import
+# configMap the deployment mounts at /opt/keycloak/data/import at runtime.
+#
+# Both stages pin the SAME immutable base digest, so an upstream re-tag can
+# never silently change the source. build.nu verifies the tag still resolves to
+# UPSTREAM_DIGEST before invoking this Dockerfile.
+# =============================================================================
+
+ARG UPSTREAM_IMAGE=quay.io/keycloak/keycloak
+ARG UPSTREAM_TAG=26.7.0
+ARG UPSTREAM_DIGEST=sha256:2eb3cd316835c990e69e26ade292ffa78f6fb0db7d5fc6377463c162e1979ac0
+
+# --- Stage 1: build the optimized server ------------------------------------ #
+FROM ${UPSTREAM_IMAGE}:${UPSTREAM_TAG}@${UPSTREAM_DIGEST} AS builder
+
+# Build-time options that `start --optimized` then relies on being fixed. These
+# MUST match the runtime intent (KC_DB=postgres etc.); changing them requires a
+# rebuild, which is exactly the production contract we want.
+ENV KC_DB=postgres
+ENV KC_HEALTH_ENABLED=true
+ENV KC_METRICS_ENABLED=true
+
+# Produce the augmented/optimized distribution under /opt/keycloak.
+RUN /opt/keycloak/bin/kc.sh build
+
+# --- Stage 2: final runtime image (same pinned base) ------------------------ #
+FROM ${UPSTREAM_IMAGE}:${UPSTREAM_TAG}@${UPSTREAM_DIGEST}
+
+# Copy ONLY the optimized build — no realm/user JSON is ever added here.
+COPY --from=builder /opt/keycloak/ /opt/keycloak/
+
+# Provenance (baked as OCI labels). base_digest records the immutable source.
+ARG version=26.7.0
+ARG base_digest=sha256:2eb3cd316835c990e69e26ade292ffa78f6fb0db7d5fc6377463c162e1979ac0
+LABEL org.opencontainers.image.title="digiorg/keycloak" \
+      org.opencontainers.image.description="DigiOrg production-optimized Keycloak (kc.sh build --optimized)" \
+      org.opencontainers.image.source="https://github.com/digiorg/core" \
+      org.opencontainers.image.version="${version}" \
+      org.opencontainers.image.revision="${base_digest}" \
+      org.opencontainers.image.base.name="quay.io/keycloak/keycloak:26.7.0"
+
+ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]

--- a/platform/images/keycloak/README.md
+++ b/platform/images/keycloak/README.md
@@ -1,0 +1,90 @@
+# DigiOrg production-optimized Keycloak image
+
+Pinned, multi-stage Keycloak image built for **Issue #275 — Tier 1**. It runs
+`kc.sh build` once at image-build time so the deployment can start with
+`start --optimized` (a production start) instead of the unsupported `start-dev`.
+
+## Why this exists
+
+The platform previously ran the stock `quay.io/keycloak/keycloak` image with
+`start-dev`. Dev mode:
+
+- re-runs the augmentation/build step on **every** boot (slow, non-reproducible);
+- relaxes production safeguards (hostname/HTTP/TLS strictness).
+
+Keycloak's production model is to **fix the build-time options once** with
+`kc.sh build`, then boot with `start --optimized` — the server skips
+re-augmentation because the optimized distribution is already baked in. This
+image does exactly that:
+
+| Stage | Base | Action |
+| --- | --- | --- |
+| `builder` | `quay.io/keycloak/keycloak:26.7.0` (digest-pinned) | `ENV KC_DB=postgres / KC_HEALTH_ENABLED=true / KC_METRICS_ENABLED=true` then `kc.sh build` |
+| final | the **same** digest-pinned base | `COPY --from=builder /opt/keycloak/` |
+
+Because the build-time options are fixed in the image, the deployment keeps
+`KC_DB=postgres` (and friends) at runtime and boots with `start --optimized`.
+See the Keycloak 26.7 "Configuring Keycloak for production" / "Optimize the
+Keycloak startup" docs for the `kc.sh build` + `start --optimized` contract.
+
+### Realm data stays out of the image
+
+Realm/user JSON is **not** baked in. The deployment continues to mount it from
+the `keycloak-realm-import` configMap at `/opt/keycloak/data/import` and imports
+it at runtime (`--import-realm`). This keeps the image environment-agnostic and
+avoids shipping credentials in a layer.
+
+## Image coordinates
+
+| | Value |
+| --- | --- |
+| Local (kind) image | `digiorg/keycloak:26.7.0-optimized` |
+| Registry path (Harbor) | `digiorg.local/library/keycloak:26.7.0-optimized` |
+| Upstream base | `quay.io/keycloak/keycloak:26.7.0` |
+| Upstream base digest (immutable) | `sha256:2eb3cd316835c990e69e26ade292ffa78f6fb0db7d5fc6377463c162e1979ac0` |
+| Build-time options | `KC_DB=postgres`, `KC_HEALTH_ENABLED=true`, `KC_METRICS_ENABLED=true` |
+
+The local image + `IfNotPresent` pull policy are consumed by
+`platform/base/keycloak/keycloak-deployment.yaml` and asserted by
+`platform/tests/test_keycloak_image.py`. The exact ref is allow-listed in
+`scripts/pin-policy-allowlist.yaml` (locally built, kind-loaded, never pulled).
+
+The base digest was resolved with
+`python3 scripts/resolve_digest.py quay.io/keycloak/keycloak:26.7.0`.
+
+## Build & publish
+
+`build.nu` is a cross-platform [Nushell](https://www.nushell.sh) script, so the
+same commands work on Linux, macOS and Windows (with Docker Desktop and kind on
+`PATH`). Run them from a Nushell prompt:
+
+```nu
+# Build + load into the local kind cluster (default)
+nu build.nu
+
+# Build only
+with-env {LOAD: "0"} { nu build.nu }
+
+# Build + push to Harbor (run `docker login digiorg.local` first — no
+# credentials are stored in this repo)
+with-env {PUSH: "1"} { nu build.nu }
+```
+
+Before building, `build.nu` calls `scripts/resolve_digest.py` and **verifies**
+the pinned tag still resolves to `UPSTREAM_DIGEST`, so an upstream re-tag cannot
+silently change the base. `version`/`base_digest` build args bake the provenance
+into OCI labels. The local kind image and optional Harbor target are separate:
+`digiorg/keycloak:<tag>` locally and `digiorg.local/library/keycloak:<tag>` in
+Harbor.
+
+## Upgrade procedure
+
+1. Pick the new upstream tag; resolve its digest:
+   `python3 scripts/resolve_digest.py quay.io/keycloak/keycloak:<tag>`
+2. Update `UPSTREAM_TAG` / `UPSTREAM_DIGEST` / `TAG` in `build.nu` **and** the
+   Dockerfile `ARG` defaults + `org.opencontainers.image.base.name` label.
+3. Bump the image tag in `keycloak-deployment.yaml` and the
+   `scripts/pin-policy-allowlist.yaml` entry.
+4. Run `python3 platform/tests/test_keycloak_image.py` and
+   `python3 scripts/check_pins.py`.
+5. `with-env {PUSH: "1"} { nu build.nu }`, scan in Harbor, then roll out.

--- a/platform/images/keycloak/build.nu
+++ b/platform/images/keycloak/build.nu
@@ -1,0 +1,105 @@
+#!/usr/bin/env nu
+
+# =============================================================================
+# Build the DigiOrg production-optimized Keycloak image — Issue #275 (Tier 1)
+# =============================================================================
+# The platform ran the stock image with `start-dev`. Dev mode re-augments the
+# server on every boot and disables production safeguards, so it is unsupported
+# for real use. This builds a pinned, multi-stage image that runs `kc.sh build`
+# with the platform's build-time options (db=postgres, health, metrics) against
+# a digest-pinned upstream base; the deployment then runs `start --optimized`.
+# Realm/user data is NOT baked in — it stays in the mounted realm-import
+# configMap. See ./README.md for the full rationale.
+#
+# This script is the single source of truth for HOW the pinned image is built.
+# It is written in Nushell so it runs identically on Linux, macOS and Windows
+# with Docker Desktop and kind on PATH — no bash or Unix-only utilities.
+# It is intentionally credential-free: authenticate to the registry out-of-band
+# (`docker login` / `nu scripts/local-setup.nu`) before running with PUSH set.
+#
+# Reproducibility / provenance:
+#   * UPSTREAM_TAG    — the upstream release we track.
+#   * UPSTREAM_DIGEST — the immutable digest that tag resolves to. Both stages of
+#                       the Dockerfile pin the digest, and this script verifies
+#                       the tag still resolves to it before building, so an
+#                       upstream re-tag cannot silently change the base. The
+#                       version + base digest are baked into OCI labels.
+#
+# Usage (identical on Linux, macOS and Windows — no shell-specific env syntax):
+#   nu build.nu                             # build + `kind load` into local dev cluster
+#   with-env {PUSH: "1"} { nu build.nu }    # also push to $REGISTRY (needs prior docker login)
+#   with-env {LOAD: "0"} { nu build.nu }    # build only (no kind load, no push)
+# =============================================================================
+
+# --- Pinned upstream base --------------------------------------------------- #
+const UPSTREAM_IMAGE = "quay.io/keycloak/keycloak"
+const UPSTREAM_TAG = "26.7.0"
+const UPSTREAM_DIGEST = "sha256:2eb3cd316835c990e69e26ade292ffa78f6fb0db7d5fc6377463c162e1979ac0"
+
+# --- Image coordinates ------------------------------------------------------ #
+# IMAGE/TAG are the local (kind-loaded) coordinates and MUST match the image
+# selected in platform/base/keycloak/keycloak-deployment.yaml. REGISTRY and
+# REGISTRY_REPOSITORY form the separate Harbor target used only on PUSH.
+const IMAGE = "digiorg/keycloak"
+const TAG = "26.7.0-optimized"
+const REGISTRY_REPOSITORY = "keycloak"
+
+def main [] {
+    # --- Behaviour toggles / registry (overridable via environment) --------- #
+    let registry = ($env.REGISTRY? | default "digiorg.local/library")
+    let kind_cluster = ($env.KIND_CLUSTER? | default "digiorg-core-dev")
+    let load = ($env.LOAD? | default "1")
+    let push = ($env.PUSH? | default "0")
+
+    print $">> Building ($IMAGE):($TAG)"
+    print $"   base   : ($UPSTREAM_IMAGE):($UPSTREAM_TAG)@($UPSTREAM_DIGEST)"
+    print "   mode   : start --optimized (db=postgres, health, metrics baked at build)"
+
+    # Verify the pinned tag still resolves to the pinned digest before building,
+    # so provenance is guaranteed even though Docker resolves the base by tag.
+    # The repo's resolve_digest.py talks to the registry v2 API without Docker
+    # and prints "<registry>/<repo>:<tag>@sha256:<digest>"; compare the digest.
+    let repo_root = ($env.FILE_PWD | path join ".." ".." "..")
+    let resolver = ($repo_root | path join "scripts" "resolve_digest.py")
+    if ($resolver | path exists) {
+        let resolved = (python3 $resolver $"($UPSTREAM_IMAGE):($UPSTREAM_TAG)" | str trim)
+        let resolved_digest = ($resolved | split row "@" | last | str trim)
+        if ($resolved_digest != $UPSTREAM_DIGEST) {
+            print -e $"ERROR: ($UPSTREAM_IMAGE):($UPSTREAM_TAG) resolves to ($resolved_digest),"
+            print -e $"       expected ($UPSTREAM_DIGEST). Upstream re-tagged the release."
+            print -e "       Review the change and update UPSTREAM_DIGEST deliberately."
+            exit 1
+        }
+        print $"   verified: tag resolves to ($UPSTREAM_DIGEST)"
+    } else {
+        print -e "WARN: scripts/resolve_digest.py not found — skipping tag/digest verification"
+    }
+
+    # version/base_digest bake provenance into the image OCI labels. The base is
+    # pinned by digest in the Dockerfile's FROM lines (both stages).
+    (
+        docker build
+            --build-arg $"UPSTREAM_IMAGE=($UPSTREAM_IMAGE)"
+            --build-arg $"UPSTREAM_TAG=($UPSTREAM_TAG)"
+            --build-arg $"UPSTREAM_DIGEST=($UPSTREAM_DIGEST)"
+            --build-arg $"version=($UPSTREAM_TAG)"
+            --build-arg $"base_digest=($UPSTREAM_DIGEST)"
+            --tag $"($IMAGE):($TAG)"
+            $env.FILE_PWD
+    )
+
+    print $">> Built ($IMAGE):($TAG)"
+
+    if $load == "1" {
+        print $">> Loading ($IMAGE):($TAG) into kind cluster '($kind_cluster)'"
+        kind load docker-image $"($IMAGE):($TAG)" --name $kind_cluster
+    }
+
+    if $push == "1" {
+        print $">> Pushing to ($registry)/($REGISTRY_REPOSITORY):($TAG)"
+        docker tag $"($IMAGE):($TAG)" $"($registry)/($REGISTRY_REPOSITORY):($TAG)"
+        docker push $"($registry)/($REGISTRY_REPOSITORY):($TAG)"
+    }
+
+    print ">> Done."
+}

--- a/platform/tests/test_chart_image_overrides.py
+++ b/platform/tests/test_chart_image_overrides.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Guard chart value overrides that would otherwise render mutable images."""
+
+import os
+import re
+import unittest
+import yaml
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+DIGEST_TAG = re.compile(r"^[^@]+@sha256:[0-9a-f]{64}$")
+
+
+def load(path):
+    with open(os.path.join(ROOT, path), encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+class OpenSearchImagePinsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.values = load("platform/base/opensearch/values.yaml")
+
+    def test_main_image_and_volume_init_are_immutable(self):
+        # The chart tries to semver-parse image.tag unless majorVersion is set;
+        # digest-qualified tags therefore require this explicit major override.
+        self.assertEqual(str(self.values["majorVersion"]), "3")
+        self.assertRegex(self.values["image"]["tag"], DIGEST_TAG)
+        self.assertEqual(self.values["persistence"]["image"], "busybox")
+        self.assertRegex(self.values["persistence"]["imageTag"], DIGEST_TAG)
+
+
+class NatsImagePinsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.values = load("platform/base/nats/values.yaml")
+
+    def test_server_and_reloader_have_real_digests(self):
+        server = self.values["container"]["image"]
+        reloader = self.values["reloader"]["image"]
+        self.assertEqual(
+            server["fullImageName"],
+            "nats:2.14.2-alpine@sha256:952d157e28d5394a211229bd57a7b37ff9f184e58e2c8486a08fa909fd254e32",
+        )
+        self.assertEqual(
+            reloader["fullImageName"],
+            "natsio/nats-server-config-reloader:0.23.0@sha256:64cb6c858e794906d3167378e02b7e0feb83c4e14c07b371eb8d921ef8c4a60b",
+        )
+
+    def test_chart_2_jetstream_storage_schema_is_used(self):
+        js = self.values["config"]["jetstream"]
+        self.assertNotIn("fileStorage", js)
+        self.assertEqual(js["fileStore"]["dir"], "/data")
+        self.assertTrue(js["fileStore"]["pvc"]["enabled"])
+        self.assertEqual(js["fileStore"]["pvc"]["size"], "1Gi")
+
+    def test_removed_service_port_schema_is_not_present(self):
+        self.assertNotIn("service", self.values)
+
+
+class KyvernoHookImagePinsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        app = load("apps/platform/kyverno.yaml")
+        cls.values = yaml.safe_load(app["spec"]["source"]["helm"]["values"])
+
+    def test_test_and_cleanup_hooks_do_not_use_latest(self):
+        self.assertRegex(self.values["test"]["image"]["tag"], DIGEST_TAG)
+        self.assertRegex(self.values["webhooksCleanup"]["image"]["tag"], DIGEST_TAG)
+
+    def test_current_crd_migration_key_is_explicit(self):
+        self.assertTrue(self.values["crds"]["migration"]["enabled"])
+        self.assertNotIn("replicaCount", self.values)
+        self.assertNotIn("policyReportsCleanup", self.values)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_ci_pin_policy.py
+++ b/platform/tests/test_ci_pin_policy.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""The pin-policy checker and platform regression tests must run in CI (Issue #275).
+
+Issue #275 requires "CI checks that reject `latest`, branch tags, wildcard/range
+chart versions, and non-digest-pinned image references". A checker that never
+runs in CI does not satisfy that, so this test asserts a GitHub Actions workflow
+exists that actually invokes ``scripts/check_pins.py`` and the platform test
+suite, on pushes and pull requests.
+
+Pure python3 + PyYAML::
+
+    python3 platform/tests/test_ci_pin_policy.py
+"""
+
+import glob
+import os
+import re
+import sys
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+WORKFLOW_DIR = os.path.join(REPO_ROOT, ".github", "workflows")
+
+
+def _workflow_texts():
+    out = {}
+    for path in glob.glob(os.path.join(WORKFLOW_DIR, "*.y*ml")):
+        with open(path, encoding="utf-8") as fh:
+            out[path] = fh.read()
+    return out
+
+
+class CiWorkflowTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.texts = _workflow_texts()
+
+    def test_a_workflow_exists(self):
+        self.assertTrue(self.texts, "expected a GitHub Actions workflow under .github/workflows")
+
+    def test_some_workflow_runs_check_pins(self):
+        self.assertTrue(
+            any("scripts/check_pins.py" in t for t in self.texts.values()),
+            "a CI workflow must run scripts/check_pins.py",
+        )
+
+    def test_some_workflow_renders_helm_and_checks_chart_images(self):
+        workflow = next(
+            text for text in self.texts.values() if "scripts/check_pins.py" in text
+        )
+        self.assertIn("scripts/render_platform_charts.py", workflow)
+        self.assertIn("helm-v4.2.3-linux-amd64.tar.gz", workflow)
+
+    def test_some_workflow_runs_platform_tests(self):
+        self.assertTrue(
+            any(("platform/tests" in t or "unittest discover" in t)
+                for t in self.texts.values()),
+            "a CI workflow must run the platform/tests suite",
+        )
+
+    def test_triggers_on_push_and_pull_request(self):
+        found_pr = found_push = False
+        for text in self.texts.values():
+            if "scripts/check_pins.py" not in text:
+                continue
+            doc = yaml.safe_load(text)
+            # YAML parses the `on:` key as the boolean True.
+            on = doc.get("on", doc.get(True, {}))
+            if isinstance(on, list):
+                keys = set(on)
+            elif isinstance(on, dict):
+                keys = set(on.keys())
+            else:
+                keys = {on}
+            found_pr = found_pr or "pull_request" in keys
+            found_push = found_push or "push" in keys
+        self.assertTrue(found_pr, "CI must trigger on pull_request")
+        self.assertTrue(found_push, "CI must trigger on push")
+
+    def test_github_actions_are_commit_pinned(self):
+        workflow = next(
+            text for text in self.texts.values() if "scripts/check_pins.py" in text
+        )
+        uses = re.findall(r"^\s*-?\s*uses:\s*[^@\s]+@([^\s#]+)", workflow, re.MULTILINE)
+        self.assertTrue(uses)
+        for ref in uses:
+            self.assertRegex(ref, r"^[0-9a-f]{40}$")
+
+    def test_validation_tool_versions_are_reproducible_and_compatible(self):
+        workflow = next(
+            text for text in self.texts.values() if "scripts/check_pins.py" in text
+        )
+        # OpenCost's build.nu uses Nushell syntax supported by the repository's
+        # current toolchain (0.114.1); CI 0.98.0 reports an IDE parse diagnostic.
+        self.assertIn("NU_VERSION=0.114.1", workflow)
+        # Never install kustomize from a floating master-branch script.
+        self.assertIn("KUSTOMIZE_VERSION=v5.8.1", workflow)
+        self.assertNotIn("kustomize/master/hack/install_kustomize.sh", workflow)
+
+    def test_workflows_are_valid_yaml(self):
+        for path, text in self.texts.items():
+            try:
+                yaml.safe_load(text)
+            except yaml.YAMLError as exc:  # pragma: no cover
+                self.fail(f"{path} is invalid YAML: {exc}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_cnpg_migration.py
+++ b/platform/tests/test_cnpg_migration.py
@@ -346,6 +346,10 @@ class CoexistenceSafetyTest(unittest.TestCase):
         self.assertIn("wait --for=delete service/postgresql", text)
         self.assertNotIn("final delta dump", text)
         self.assertNotIn("single atomic git commit", text)
+        self.assertNotIn("--no-owner", text)
+        self.assertIn("pg_get_userbyid", text)
+        self.assertIn("backup_dir=./pgbackup-final", text)
+        self.assertIn("rpo", text)
 
     def test_logical_backups_are_private_verified_atomic_and_retained(self):
         cron = _find(_docs(INIT_YAML), "CronJob")

--- a/platform/tests/test_cnpg_migration.py
+++ b/platform/tests/test_cnpg_migration.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Tests for the CloudNativePG (CNPG) migration of the shared PostgreSQL (Issue #275).
+
+The legacy raw ``StatefulSet`` under ``platform/base/postgresql`` hosts SIX
+databases/users (keycloak, backstage, gitea, sonarqube and harbor -> db
+``registry``/user ``harbor``) created by an ``init.sh`` ConfigMap and backed by
+the ``postgresql-secrets`` Secret. This module locks the Tier-3 migration to a
+CNPG ``Cluster`` that must reproduce ALL of them with the SAME passwords sourced
+from the SAME secret, keep the ``postgresql`` service name reachable for every
+consumer, and pin every reference immutably.
+
+Pure ``python3`` + PyYAML — no pytest, cluster or network access::
+
+    python3 platform/tests/test_cnpg_migration.py
+"""
+
+import os
+import re
+import sys
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment guard
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+CLUSTER_YAML = os.path.join(REPO_ROOT, "platform", "base", "cnpg", "cluster.yaml")
+INIT_YAML = os.path.join(REPO_ROOT, "platform", "base", "cnpg", "init-databases.yaml")
+SERVICE_YAML = os.path.join(REPO_ROOT, "platform", "base", "cnpg", "service.yaml")
+KUSTOMIZATION_YAML = os.path.join(REPO_ROOT, "platform", "base", "cnpg", "kustomization.yaml")
+OPERATOR_APP_YAML = os.path.join(REPO_ROOT, "apps", "platform", "cnpg.yaml")
+CLUSTER_APP_YAML = os.path.join(REPO_ROOT, "apps", "platform", "cnpg-cluster.yaml")
+
+# The digest-pinned PG16 image mandated by the issue (matches legacy postgres:16
+# major, so no on-disk data-format migration is required).
+EXPECTED_IMAGE = (
+    "ghcr.io/cloudnative-pg/postgresql:16.9"
+    "@sha256:cca50a94e2da46ddcaefb23260c805ed3b466763bd2a25e1617410176d5fd0ab"
+)
+
+# Every database + owning role the legacy StatefulSet creates. Note harbor owns
+# database "registry".
+EXPECTED_DATABASES = ("keycloak", "backstage", "gitea", "sonarqube", "registry")
+EXPECTED_USERS = ("keycloak", "backstage", "gitea", "sonarqube", "harbor")
+
+# The exact secret + keys the legacy init.sh consumes; the CNPG init Job must
+# reuse them so no consumer password changes.
+SECRET_NAME = "postgresql-secrets"
+
+# CNPG requires the superuserSecret to be a `kubernetes.io/basic-auth` Secret
+# with username=postgres + password (a Secret's type is immutable, so the
+# existing Opaque `postgresql-secrets` cannot be reused for this). A dedicated
+# basic-auth secret is provisioned by the setup script with the SAME password as
+# postgresql-secrets.POSTGRES_PASSWORD, so the init Job (which authenticates with
+# POSTGRES_PASSWORD) still connects. See docs/guides/postgres-cnpg-migration.md.
+SUPERUSER_SECRET_NAME = "postgresql-cnpg-superuser"
+
+SETUP_SCRIPT = os.path.join(REPO_ROOT, "scripts", "local-setup.nu")
+PASSWORD_KEYS = (
+    "POSTGRES_PASSWORD",
+    "KEYCLOAK_DB_PASSWORD",
+    "BACKSTAGE_DB_PASSWORD",
+    "GITEA_DB_PASSWORD",
+    "SONARQUBE_DB_PASSWORD",
+    "HARBOR_DB_PASSWORD",
+)
+
+DIGEST_RE = re.compile(r"@sha256:[0-9a-f]{64}$")
+EXACT_SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _docs(path):
+    with open(path, encoding="utf-8") as fh:
+        return [d for d in yaml.safe_load_all(fh) if d]
+
+
+def _find(docs, kind, name=None):
+    for d in docs:
+        if d.get("kind") == kind and (name is None or d.get("metadata", {}).get("name") == name):
+            return d
+    return None
+
+
+class ClusterSpecTest(unittest.TestCase):
+    def setUp(self):
+        self.docs = _docs(CLUSTER_YAML)
+        self.cluster = _find(self.docs, "Cluster")
+        self.assertIsNotNone(self.cluster, "no CNPG Cluster document in cluster.yaml")
+
+    def test_api_version_and_kind(self):
+        self.assertEqual(self.cluster["apiVersion"], "postgresql.cnpg.io/v1")
+        self.assertEqual(self.cluster["kind"], "Cluster")
+
+    def test_namespace_is_platform_db(self):
+        self.assertEqual(self.cluster["metadata"]["namespace"], "platform-db")
+
+    def test_instances_set(self):
+        self.assertEqual(self.cluster["spec"]["instances"], 1)
+
+    def test_image_is_digest_pinned_and_exact(self):
+        image = self.cluster["spec"]["imageName"]
+        self.assertRegex(image, DIGEST_RE, "imageName must be pinned to an @sha256 digest")
+        self.assertEqual(image, EXPECTED_IMAGE)
+
+    def test_storage_size_matches_legacy(self):
+        self.assertEqual(self.cluster["spec"]["storage"]["size"], "5Gi")
+
+    def test_resources_are_modest(self):
+        res = self.cluster["spec"]["resources"]
+        self.assertEqual(res["requests"]["memory"], "256Mi")
+        self.assertEqual(res["limits"]["memory"], "512Mi")
+
+    def test_superuser_secret_is_dedicated_basic_auth(self):
+        self.assertTrue(self.cluster["spec"].get("enableSuperuserAccess"),
+                        "superuser access must be enabled for the init/migration path")
+        # CNPG requires a kubernetes.io/basic-auth secret (username=postgres +
+        # password). The existing Opaque `postgresql-secrets` cannot be reused
+        # (secret type is immutable and it lacks username/password keys), so the
+        # cluster must point at the dedicated basic-auth secret.
+        self.assertEqual(
+            self.cluster["spec"]["superuserSecret"]["name"], SUPERUSER_SECRET_NAME,
+            "superuserSecret must be the dedicated basic-auth secret, not the "
+            "Opaque postgresql-secrets",
+        )
+        self.assertNotEqual(
+            self.cluster["spec"]["superuserSecret"]["name"], SECRET_NAME,
+            "the Opaque postgresql-secrets is not a valid CNPG basic-auth secret",
+        )
+
+
+class SuperuserSecretProvisioningTest(unittest.TestCase):
+    """The setup script must create the CNPG superuser secret as basic-auth,
+    with username=postgres and the SAME password as postgresql-secrets so the
+    init Job authenticates."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.setup = _read(SETUP_SCRIPT)
+
+    def test_creates_basic_auth_superuser_secret(self):
+        self.assertIn(SUPERUSER_SECRET_NAME, self.setup,
+                      "setup script must provision the CNPG superuser secret")
+        # kubectl create secret ... --type=kubernetes.io/basic-auth (or an
+        # equivalent typed secret) named postgresql-cnpg-superuser.
+        m = re.search(
+            r"secret[\s\S]{0,400}?" + re.escape(SUPERUSER_SECRET_NAME) + r"[\s\S]{0,400}",
+            self.setup,
+        )
+        self.assertIsNotNone(m)
+        block = m.group(0)
+        self.assertIn("kubernetes.io/basic-auth", block,
+                      "the superuser secret must be type kubernetes.io/basic-auth")
+        self.assertRegex(block, r"username=postgres",
+                         "CNPG requires the superuser username to be 'postgres'")
+
+    def test_superuser_password_matches_postgres_password(self):
+        # The init Job connects as postgres using postgresql-secrets.POSTGRES_PASSWORD,
+        # so the basic-auth password must be the same value.
+        m = re.search(
+            re.escape(SUPERUSER_SECRET_NAME) + r"[\s\S]{0,400}?password=\(([^)]+)\)",
+            self.setup,
+        )
+        self.assertIsNotNone(m, "superuser secret must set password=(...)")
+        self.assertIn("postgres_password", m.group(1),
+                      "superuser password must reuse the postgres_password variable")
+
+
+class BootstrapCreatesAllDatabasesTest(unittest.TestCase):
+    """All six db/users must be (re)created, sourcing passwords from the secret."""
+
+    def setUp(self):
+        # The init material may live in the Cluster (postInitApplicationSQL) or a
+        # companion ConfigMap+Job; accept whichever carries the SQL, but the env
+        # wiring to the secret must be present somewhere in the CNPG base.
+        self.blob = _read(CLUSTER_YAML)
+        if os.path.exists(INIT_YAML):
+            self.blob += "\n" + _read(INIT_YAML)
+
+    def test_every_database_is_created(self):
+        for db in EXPECTED_DATABASES:
+            self.assertRegex(
+                self.blob,
+                re.compile(rf"CREATE\s+DATABASE\s+{db}\b", re.IGNORECASE),
+                f"missing CREATE DATABASE for {db}",
+            )
+
+    def test_every_user_is_created(self):
+        for user in EXPECTED_USERS:
+            self.assertRegex(
+                self.blob,
+                re.compile(rf"CREATE\s+(USER|ROLE)\s+{user}\b", re.IGNORECASE),
+                f"missing CREATE USER/ROLE for {user}",
+            )
+
+    def test_harbor_owns_registry_database(self):
+        self.assertRegex(
+            self.blob,
+            re.compile(r"CREATE\s+DATABASE\s+registry\s+OWNER\s+harbor", re.IGNORECASE),
+        )
+
+    def test_passwords_reference_secret_keys(self):
+        # Each per-service password key from postgresql-secrets must be wired in
+        # (as an env var sourced from the secret) so plaintext never appears.
+        for key in PASSWORD_KEYS:
+            self.assertIn(key, self.blob, f"password key {key} is not referenced")
+
+    def test_passwords_are_psql_bound_not_shell_interpolated_into_sql(self):
+        # Environment overrides may contain quotes or SQL metacharacters. Bind
+        # them as psql variables (:'name') rather than expanding ${...} inside
+        # SQL string literals.
+        bindings = {
+            "KEYCLOAK_DB_PASSWORD": "keycloak_password",
+            "BACKSTAGE_DB_PASSWORD": "backstage_password",
+            "GITEA_DB_PASSWORD": "gitea_password",
+            "SONARQUBE_DB_PASSWORD": "sonarqube_password",
+            "HARBOR_DB_PASSWORD": "harbor_password",
+        }
+        for env_name, variable in bindings.items():
+            self.assertIn(f'-v {variable}="${env_name}"', self.blob)
+            self.assertIn(f":'{variable}'", self.blob)
+            self.assertNotIn(f"PASSWORD '${{{env_name}}}'", self.blob)
+
+    def test_secret_name_referenced(self):
+        self.assertIn(SECRET_NAME, self.blob)
+
+    def test_init_env_sourced_from_secret(self):
+        """The init workload must pull the password keys from the Secret, not inline."""
+        docs = _docs(INIT_YAML) if os.path.exists(INIT_YAML) else _docs(CLUSTER_YAML)
+        found = 0
+        text = yaml.safe_dump_all(docs)
+        for key in PASSWORD_KEYS:
+            # secretKeyRef.key: <KEY> pairing
+            if re.search(rf"key:\s*{key}\b", text):
+                found += 1
+        self.assertEqual(found, len(PASSWORD_KEYS),
+                         "all password keys must be sourced via secretKeyRef")
+
+
+class ConsumerServiceTest(unittest.TestCase):
+    """Consumers connect to postgresql.platform-db.svc.cluster.local:5432."""
+
+    def test_postgresql_service_exists_in_platform_db(self):
+        docs = _docs(SERVICE_YAML)
+        svc = _find(docs, "Service", "postgresql")
+        self.assertIsNotNone(svc, "a Service named 'postgresql' must exist for consumers")
+        self.assertEqual(svc["metadata"]["namespace"], "platform-db")
+
+    def test_service_targets_the_cnpg_rw_service(self):
+        svc = _find(_docs(SERVICE_YAML), "Service", "postgresql")
+        spec = svc["spec"]
+        # ExternalName alias pointing at the CNPG -rw service, or a selector-based
+        # service onto the CNPG pods — either way it must reference the rw target.
+        target = spec.get("externalName", "")
+        self.assertIn("-rw", target, "alias must point at the CNPG <cluster>-rw service")
+        self.assertIn("platform-db", target)
+
+    def test_port_5432_reachable(self):
+        svc = _find(_docs(SERVICE_YAML), "Service", "postgresql")
+        ports = svc["spec"].get("ports", [])
+        self.assertTrue(any(p.get("port") == 5432 for p in ports),
+                        "service must expose 5432")
+
+
+class OperatorChartPinTest(unittest.TestCase):
+    def _operator_source(self):
+        app = _find(_docs(OPERATOR_APP_YAML), "Application", "cnpg")
+        self.assertIsNotNone(app)
+        src = app["spec"]["source"]
+        self.assertEqual(src["chart"], "cloudnative-pg")
+        return src
+
+    def test_operator_chart_pinned_to_exact_semver_0_29_0(self):
+        rev = str(self._operator_source()["targetRevision"])
+        self.assertRegex(rev, EXACT_SEMVER_RE, "operator chart must pin an exact SemVer")
+        self.assertEqual(rev, "0.29.0")
+
+    def test_reduced_resources_retained(self):
+        values = self._operator_source()["helm"]["values"]
+        self.assertIn("resources", values)
+        self.assertIn("128Mi", values)
+
+
+class KustomizationTest(unittest.TestCase):
+    def test_kustomization_deploys_cluster_and_init_not_alias(self):
+        k = _docs(KUSTOMIZATION_YAML)[0]
+        resources = k.get("resources", [])
+        self.assertIn("cluster.yaml", resources)
+        self.assertIn("init-databases.yaml", resources)
+        self.assertEqual(k.get("namespace"), "platform-db")
+        # COEXISTENCE SAFETY: the ExternalName alias `service.yaml` must NOT be
+        # synced while the legacy postgresql Application is still active. Both the
+        # legacy base and service.yaml define a Service named `postgresql` in
+        # platform-db; syncing both would make two ArgoCD Applications fight over
+        # same object (selfHeal ping-pong). The alias is enabled only during the
+        # observed, ordered handoff documented in the migration runbook.
+        self.assertNotIn(
+            "service.yaml", resources,
+            "the postgresql alias Service must not be synced during coexistence "
+            "with the legacy postgresql Application (ArgoCD ownership conflict)",
+        )
+
+
+class CoexistenceSafetyTest(unittest.TestCase):
+    """The CNPG stack must be deployable ALONGSIDE the legacy postgresql
+    Application without two ArgoCD apps claiming the same object."""
+
+    def test_no_synced_cnpg_resource_named_postgresql(self):
+        # Walk everything the kustomization actually deploys and prove none of it
+        # is a Service named `postgresql` (which the legacy app owns).
+        k = _docs(KUSTOMIZATION_YAML)[0]
+        for rel in k.get("resources", []):
+            path = os.path.join(REPO_ROOT, "platform", "base", "cnpg", rel)
+            for doc in _docs(path):
+                same = (doc.get("kind") == "Service"
+                        and doc.get("metadata", {}).get("name") == "postgresql")
+                self.assertFalse(
+                    same,
+                    f"{rel} is synced and defines Service/postgresql — this "
+                    "collides with the legacy postgresql Application",
+                )
+
+    def test_alias_service_exists_as_cutover_artifact(self):
+        # The alias file must still exist (committed cutover artifact) and be a
+        # correct ExternalName onto the CNPG -rw service, ready to be enabled.
+        self.assertTrue(os.path.exists(SERVICE_YAML),
+                        "the alias service.yaml cutover artifact must exist")
+        svc = _find(_docs(SERVICE_YAML), "Service", "postgresql")
+        self.assertEqual(svc["spec"]["type"], "ExternalName")
+
+    def test_cutover_documented(self):
+        guide = os.path.join(REPO_ROOT, "docs", "guides", "postgres-cnpg-migration.md")
+        self.assertTrue(os.path.exists(guide), "migration runbook must exist")
+        text = _read(guide).lower()
+        self.assertIn("cutover", text)
+        self.assertIn("service.yaml", text)
+        self.assertIn("rollback", text)
+        self.assertIn("mandatory final full dump", text)
+        self.assertIn("wait --for=delete service/postgresql", text)
+        self.assertNotIn("final delta dump", text)
+        self.assertNotIn("single atomic git commit", text)
+
+    def test_logical_backups_are_private_verified_atomic_and_retained(self):
+        cron = _find(_docs(INIT_YAML), "CronJob")
+        if cron is None:
+            self.fail("CNPG logical-backup CronJob is missing")
+        script = cron["spec"]["jobTemplate"]["spec"]["template"]["spec"]["containers"][0]["command"][-1]
+        self.assertIn("umask 077", script)
+        self.assertIn("pg_restore --list", script)
+        self.assertIn("COMPLETE", script)
+        self.assertIn("mv \"$tmp\" \"$dest\"", script)
+        self.assertIn("-mtime +7", script)
+
+
+class ClusterAppTest(unittest.TestCase):
+    """A dedicated Argo CD Application deploys the CNPG base after the operator."""
+
+    def test_cluster_app_points_at_cnpg_base(self):
+        app = _find(_docs(CLUSTER_APP_YAML), "Application")
+        self.assertIsNotNone(app)
+        src = app["spec"]["source"]
+        self.assertEqual(src["path"], "platform/base/cnpg")
+        self.assertEqual(app["spec"]["destination"]["namespace"], "platform-db")
+
+    def test_cluster_app_is_in_local_bootstrap_health_wait(self):
+        setup = _read(SETUP_SCRIPT)
+        self.assertIn('"cnpg-cluster"', setup)
+
+    def test_cluster_app_syncs_after_operator(self):
+        app = _find(_docs(CLUSTER_APP_YAML), "Application")
+        wave = int(app["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"])
+        self.assertGreaterEqual(wave, 1, "cluster must sync after the operator (wave 0)")
+
+
+class LegacyStatefulSetRetainedTest(unittest.TestCase):
+    """The legacy StatefulSet MUST remain until data is verified in a real cluster."""
+
+    def test_legacy_statefulset_still_present(self):
+        legacy = os.path.join(REPO_ROOT, "platform", "base", "postgresql", "statefulset.yaml")
+        self.assertTrue(os.path.exists(legacy), "legacy StatefulSet must be retained")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_crossplane_migration.py
+++ b/platform/tests/test_crossplane_migration.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Tests for the Crossplane 1.19.0 -> 2.x migration (Issue #275).
+
+Crossplane v2 is the highest-blast-radius migration. Key facts revalidated
+against upstream on 2026-07-18:
+
+  * Chart: https://charts.crossplane.io/stable/index.yaml — 2.3.3 (appVersion
+    2.3.3) is the newest 2.x. The Helm values keys this repo sets (`replicas`,
+    `resourcesCrossplane`, `resourcesRBACManager`) are unchanged in the 2.3.x
+    chart (verified against cluster/charts/crossplane/values.yaml @ v2.3.3).
+  * XRD compatibility: Crossplane v2 keeps `apiextensions.crossplane.io/v1`
+    XRDs in **LegacyCluster** scope — cluster-scoped composite resources that
+    still support Claims. So the existing XRD (`apiextensions.crossplane.io/v1`
+    + `claimNames`) works unchanged; it must NOT be flipped to Namespaced (which
+    drops Claims in v2). https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/
+  * Providers keep `pkg.crossplane.io/v1` + `DeploymentRuntimeConfig`
+    (`pkg.crossplane.io/v1beta1`); crossplane-contrib providers declare no upper
+    Crossplane bound, so they install on 2.3.x. Latest compatible releases:
+    provider-kubernetes v1.2.1, provider-helm v1.3.0, provider-http v1.0.14.
+
+Pure python3 + PyYAML::
+
+    python3 platform/tests/test_crossplane_migration.py
+"""
+
+import os
+import re
+import sys
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+APP = os.path.join(REPO_ROOT, "apps", "platform", "crossplane.yaml")
+PKG_DIR = os.path.join(REPO_ROOT, "crossplane", "providers", "packages")
+XRD = os.path.join(REPO_ROOT, "crossplane", "xrds", "application.yaml")
+
+# Revalidated compatible provider package versions (exact pins).
+EXPECTED_PROVIDERS = {
+    "provider-kubernetes": "v1.2.1",
+    "provider-helm": "v1.3.0",
+    "provider-http": "v1.0.14",
+}
+
+
+def _docs(path):
+    with open(path, encoding="utf-8") as fh:
+        return [d for d in yaml.safe_load_all(fh) if d]
+
+
+class ChartPinTest(unittest.TestCase):
+    def test_chart_pinned_to_2_x_exact(self):
+        app = _docs(APP)[0]
+        rev = str(app["spec"]["source"]["targetRevision"])
+        self.assertRegex(rev, r"^2\.\d+\.\d+$",
+                         "crossplane chart must pin an exact 2.x SemVer, got %r" % rev)
+
+
+class ProviderVersionTest(unittest.TestCase):
+    """Every provider package must pin an exact, v2-compatible release tag."""
+
+    def _providers(self):
+        found = {}
+        for name in os.listdir(PKG_DIR):
+            if not name.endswith(".yaml"):
+                continue
+            for doc in _docs(os.path.join(PKG_DIR, name)):
+                if doc.get("kind") == "Provider":
+                    pkg = doc["spec"]["package"]
+                    found[doc["metadata"]["name"]] = pkg
+        return found
+
+    def test_provider_versions_pinned_and_compatible(self):
+        providers = self._providers()
+        for name, want in EXPECTED_PROVIDERS.items():
+            self.assertIn(name, providers, "missing Provider %s" % name)
+            pkg = providers[name]
+            self.assertTrue(
+                pkg.endswith(":" + want) or (":" + want + "@sha256:") in pkg,
+                "%s must pin %s, got %r" % (name, want, pkg),
+            )
+
+    def test_no_floating_provider_tags(self):
+        for name, pkg in self._providers().items():
+            tag = pkg.split("@")[0].rsplit(":", 1)[-1]
+            self.assertNotIn(tag, ("latest", "main", ""),
+                             "%s must not use a floating package tag" % name)
+            self.assertRegex(tag, r"^v\d+\.\d+\.\d+",
+                             "%s package tag must be an exact version" % name)
+
+
+class XrdLegacyClusterCompatTest(unittest.TestCase):
+    """The XRD must stay v1/LegacyCluster so Claims keep working under v2."""
+
+    def setUp(self):
+        self.xrd = next(d for d in _docs(XRD)
+                        if d.get("kind") == "CompositeResourceDefinition")
+
+    def test_uses_v1_api(self):
+        # v1 XRDs map to LegacyCluster scope in v2 (cluster-scoped XR + Claims).
+        self.assertEqual(self.xrd["apiVersion"], "apiextensions.crossplane.io/v1")
+
+    def test_claims_preserved(self):
+        # Claims (AppClaim) are only supported by LegacyCluster XRs in v2; the XRD
+        # must keep claimNames and must NOT declare scope: Namespaced.
+        self.assertIn("claimNames", self.xrd["spec"],
+                      "claimNames must be retained for LegacyCluster claim support")
+        self.assertNotEqual(self.xrd["spec"].get("scope"), "Namespaced",
+                            "Namespaced scope drops Claims support in Crossplane v2")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_external_secrets_migration.py
+++ b/platform/tests/test_external_secrets_migration.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Tests for the External Secrets Operator 0.14.4 -> 2.x migration (Issue #275).
+
+ESO stopped serving ``external-secrets.io/v1beta1`` at 0.17.0; the 2.x operator
+(chart 2.7.0, appVersion v2.7.0) only serves the stable ``external-secrets.io/v1``
+API. Every ExternalSecret / (Cluster)SecretStore manifest in the repo must
+therefore be on ``external-secrets.io/v1`` or it will be rejected by the API
+server after the upgrade.
+
+Sources (revalidated 2026-07-18):
+  * chart index https://charts.external-secrets.io/index.yaml — 2.7.0 newest.
+  * https://external-secrets.io/latest/guides/v1beta1/ — v1beta1 removed.
+
+Pure python3 + PyYAML::
+
+    python3 platform/tests/test_external_secrets_migration.py
+"""
+
+import os
+import sys
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+APP = os.path.join(REPO_ROOT, "apps", "platform", "external-secrets.yaml")
+ESO_DIR = os.path.join(REPO_ROOT, "platform", "base", "external-secrets")
+ESO_KINDS = {"ExternalSecret", "SecretStore", "ClusterSecretStore", "PushSecret"}
+
+
+def _docs(path):
+    with open(path, encoding="utf-8") as fh:
+        return [d for d in yaml.safe_load_all(fh) if d]
+
+
+class ChartPinTest(unittest.TestCase):
+    def test_chart_pinned_to_2_x_exact(self):
+        app = _docs(APP)[0]
+        src = next(s for s in app["spec"]["sources"] if s.get("chart") == "external-secrets")
+        rev = str(src["targetRevision"])
+        self.assertRegex(rev, r"^2\.\d+\.\d+$",
+                         "external-secrets chart must pin an exact 2.x SemVer, got %r" % rev)
+
+
+class ApiVersionMigrationTest(unittest.TestCase):
+    """No ESO CR may remain on the removed v1beta1/v1alpha1 API."""
+
+    def _eso_docs(self):
+        out = []
+        for name in os.listdir(ESO_DIR):
+            if not name.endswith((".yaml", ".yml")):
+                continue
+            for doc in _docs(os.path.join(ESO_DIR, name)):
+                if doc.get("kind") in ESO_KINDS:
+                    out.append((name, doc))
+        return out
+
+    def test_at_least_one_cr_present(self):
+        self.assertTrue(self._eso_docs(), "expected ESO CR manifests to validate")
+
+    def test_all_crs_on_stable_v1_api(self):
+        for name, doc in self._eso_docs():
+            api = doc["apiVersion"]
+            self.assertEqual(
+                api, "external-secrets.io/v1",
+                f"{name}: {doc['kind']} must be external-secrets.io/v1 "
+                f"(v1beta1 is removed in ESO 2.x), got {api}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_fluentd_image.py
+++ b/platform/tests/test_fluentd_image.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# =============================================================================
+# Regression tests for the DigiOrg pinned Fluentd image — Issue #275 (Tier 1)
+#
+# Architecture under test (DigiOrg-owned Fluentd log-forwarder image):
+#
+#   * The stock daemonset ran fluent/fluentd-kubernetes-daemonset with a FLOATING
+#     minor tag (v1.19-debian-opensearch-1) and relied on whatever plugin
+#     versions the upstream image happened to ship — non-reproducible.
+#
+#   * Tier 1 replaces it with a pinned image built by
+#     platform/images/fluentd/build.nu FROM the digest-pinned upstream base, into
+#     which EXPLICITLY PINNED plugin gem versions are installed. The daemonset
+#     selects the exact allow-listed local image with IfNotPresent and keeps all
+#     of its env/volumes/ports/resources intact.
+#
+# These tests parse/assert the REAL build definition and the REAL daemonset
+# (behaviour, not a single grepped string):
+#
+#   BuildContractTest      build.nu (Nushell, cross-platform) pins the upstream
+#                          tag + immutable base digest, verifies the tag still
+#                          resolves to that digest before building, passes
+#                          version/base-digest provenance args, keeps local kind
+#                          and Harbor coordinates aligned, exposes REGISTRY/
+#                          KIND_CLUSTER/LOAD/PUSH overrides, and embeds no
+#                          credentials.
+#   DockerfileContractTest a build FROM the digest-pinned base installs EXACT,
+#                          version-pinned plugin gems (opensearch +
+#                          kubernetes_metadata_filter) and emits OCI labels.
+#   DaemonsetWiringTest    daemonset.yaml selects the exact allow-listed image
+#                          with IfNotPresent and preserves every env var, volume,
+#                          port and resource request/limit.
+#
+# Runs with the standard library + PyYAML only (no pytest, cluster or network):
+#     python3 platform/tests/test_fluentd_image.py
+# =============================================================================
+import os
+import re
+import unittest
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+IMAGE_DIR = os.path.join(REPO_ROOT, "platform", "images", "fluentd")
+BUILD_NU = os.path.join(IMAGE_DIR, "build.nu")
+DOCKERFILE = os.path.join(IMAGE_DIR, "Dockerfile")
+DAEMONSET = os.path.join(REPO_ROOT, "platform", "base", "fluentd", "daemonset.yaml")
+
+UPSTREAM_IMAGE = "fluent/fluentd-kubernetes-daemonset"
+UPSTREAM_TAG = "v1.19.2-debian-opensearch-1.0"
+UPSTREAM_DIGEST = "sha256:f7a636ae892cab78b0e63fcb4d89f68a84bd602609a7f38b00fcc5c65f487de2"
+IMAGE = "digiorg/fluentd"
+TAG = "v1.19.2-debian-opensearch-1.0"
+FULL_IMAGE = "%s:%s" % (IMAGE, TAG)
+
+# Plugins that MUST be explicitly version-pinned in the image.
+REQUIRED_PINNED_PLUGINS = (
+    "fluent-plugin-opensearch",
+    "fluent-plugin-kubernetes_metadata_filter",
+)
+
+
+def read_text(path):
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def load_yaml_docs(path):
+    with open(path, "r", encoding="utf-8") as fh:
+        return [d for d in yaml.safe_load_all(fh) if d is not None]
+
+
+# =========================================================================== #
+class BuildContractTest(unittest.TestCase):
+    """The build must be pinned, reproducible, credential-free, cross-platform."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.script = read_text(BUILD_NU)
+
+    def _const(self, name):
+        m = re.search(
+            r'^\s*const\s+%s\s*=\s*"([^"\n]+)"' % re.escape(name), self.script, re.M
+        )
+        self.assertIsNotNone(m, "build.nu must define const %s" % name)
+        return m.group(1).strip()
+
+    def _env_default(self, name):
+        m = re.search(
+            r'\$env\.%s\??\s*\|\s*default\s+"([^"\n]+)"' % re.escape(name), self.script
+        )
+        self.assertIsNotNone(
+            m, "build.nu must expose an $env.%s override with a default" % name
+        )
+        return m.group(1).strip()
+
+    def test_is_cross_platform_nushell_not_bash(self):
+        self.assertTrue(os.path.exists(BUILD_NU), "the builder must be build.nu (Nushell)")
+        self.assertRegex(
+            self.script.splitlines()[0], r"^#!.*\bnu\b",
+            "build.nu must carry a Nushell (`nu`) shebang",
+        )
+        for raw in self.script.splitlines():
+            line = raw.strip()
+            if line.startswith("#"):
+                continue
+            for tool in ("bash", "awk", "sed", "grep"):
+                self.assertNotRegex(
+                    line, r"(^|[\s|(])%s\b" % tool,
+                    "build.nu must not invoke the non-cross-platform tool "
+                    "%r: %r" % (tool, raw),
+                )
+
+    def test_supports_environment_overrides(self):
+        for name in ("REGISTRY", "KIND_CLUSTER", "LOAD", "PUSH"):
+            self._env_default(name)
+
+    def test_pins_upstream_image_tag_and_digest(self):
+        self.assertEqual(self._const("UPSTREAM_IMAGE"), UPSTREAM_IMAGE)
+        self.assertEqual(self._const("UPSTREAM_TAG"), UPSTREAM_TAG)
+        digest = self._const("UPSTREAM_DIGEST")
+        self.assertEqual(digest, UPSTREAM_DIGEST)
+        self.assertRegex(
+            digest, r"^sha256:[0-9a-f]{64}$",
+            "UPSTREAM_DIGEST must be a full immutable sha256 digest for provenance",
+        )
+
+    def test_image_coordinates(self):
+        self.assertEqual(self._const("IMAGE"), IMAGE)
+        self.assertEqual(self._const("TAG"), TAG)
+
+    def test_verifies_tag_resolves_to_pinned_digest_before_build(self):
+        self.assertIn(
+            "resolve_digest.py", self.script,
+            "build.nu must resolve the pinned tag (scripts/resolve_digest.py) "
+            "before building",
+        )
+        self.assertIn(
+            "UPSTREAM_DIGEST", self.script,
+            "the resolved digest must be compared against UPSTREAM_DIGEST",
+        )
+        self.assertRegex(
+            self.script, r"exit\s+1",
+            "build.nu must abort (exit 1) when the tag no longer resolves to "
+            "the pinned digest",
+        )
+
+    def test_local_and_harbor_coordinates_distinct_and_aligned(self):
+        image = self._const("IMAGE")
+        registry = self._env_default("REGISTRY")
+        registry_repository = self._const("REGISTRY_REPOSITORY")
+        self.assertEqual(image, "digiorg/fluentd")
+        self.assertIn("digiorg.local/library", registry)
+        self.assertEqual(registry_repository, "fluentd")
+        self.assertIn(
+            '$"($registry)/($REGISTRY_REPOSITORY):($TAG)"', self.script,
+            "Harbor push target must be digiorg.local/library/fluentd:<tag> "
+            "without duplicating the local digiorg namespace",
+        )
+        self.assertNotIn(
+            '$"($registry)/($IMAGE):($TAG)"', self.script,
+            "Harbor target must not become library/digiorg/fluentd",
+        )
+
+    def test_passes_provenance_build_args(self):
+        for arg in ("version", "base_digest"):
+            self.assertRegex(
+                self.script, r'--build-arg\s+\$?"?%s=' % arg,
+                "build should pass provenance build arg %s=" % arg,
+            )
+
+    def test_no_embedded_credentials(self):
+        for pat in (r"password\s*=", r"passwd\s*=", r"token\s*=",
+                    r"-p\s+\S+", r"DOCKER_PASSWORD="):
+            self.assertNotRegex(
+                self.script, re.compile(pat, re.I),
+                "build.nu must not embed credentials (matched %r)" % pat,
+            )
+
+    def test_kind_load_and_optional_push(self):
+        self.assertIn("kind load docker-image", self.script,
+                      "build.nu must kind-load the built image for local dev")
+        self.assertIn("docker push", self.script,
+                      "build.nu must support an optional Harbor push")
+
+
+class DockerfileContractTest(unittest.TestCase):
+    """Digest-pinned base + explicitly version-pinned plugin gems + OCI labels."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = read_text(DOCKERFILE)
+
+    def _from_lines(self):
+        return [ln for ln in self.text.splitlines()
+                if ln.strip().upper().startswith("FROM ")]
+
+    def test_base_is_digest_pinned(self):
+        self.assertIn(UPSTREAM_DIGEST, self.text,
+                      "the pinned base digest must appear in the Dockerfile")
+        for ln in self._from_lines():
+            self.assertRegex(
+                ln, r"@\$\{?UPSTREAM_DIGEST\}?|@%s" % re.escape(UPSTREAM_DIGEST),
+                "every FROM must pin the base by @sha256 digest: %r" % ln,
+            )
+
+    def test_plugins_are_explicitly_version_pinned(self):
+        for plugin in REQUIRED_PINNED_PLUGINS:
+            # `gem install <plugin> -v <exact-version>` (or --version) with a real
+            # semver — never an unpinned install.
+            m = re.search(
+                r"gem\s+install\s+%s\s+(?:-v|--version)\s+['\"]?"
+                r"(\d+\.\d+\.\d+)" % re.escape(plugin),
+                self.text,
+            )
+            self.assertIsNotNone(
+                m, "%s must be installed with an explicit pinned version" % plugin
+            )
+
+    def test_emits_oci_provenance_labels(self):
+        for label in (
+            "org.opencontainers.image.source",
+            "org.opencontainers.image.version",
+            "org.opencontainers.image.revision",
+        ):
+            self.assertIn(label, self.text,
+                          "Dockerfile must emit OCI label %s" % label)
+
+
+class DaemonsetWiringTest(unittest.TestCase):
+    """The daemonset must select the built image and keep everything else intact."""
+
+    @classmethod
+    def setUpClass(cls):
+        docs = load_yaml_docs(DAEMONSET)
+        cls.ds = next(d for d in docs if d.get("kind") == "DaemonSet")
+        cls.container = cls.ds["spec"]["template"]["spec"]["containers"][0]
+        cls.env = {e["name"]: e.get("value") for e in cls.container.get("env", [])}
+
+    def test_selects_exact_allowlisted_image(self):
+        self.assertEqual(self.container["image"], FULL_IMAGE)
+
+    def test_pull_policy_never(self):
+        self.assertEqual(self.container.get("imagePullPolicy"), "Never")
+
+    def test_preserves_opensearch_env(self):
+        self.assertEqual(
+            self.env.get("FLUENT_ELASTICSEARCH_HOST"),
+            "opensearch-cluster-master.platform-db.svc.cluster.local",
+        )
+        self.assertEqual(self.env.get("FLUENT_ELASTICSEARCH_PORT"), "9200")
+        self.assertEqual(self.env.get("FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX"), "digiorg-logs")
+        self.assertEqual(self.env.get("FLUENT_ELASTICSEARCH_INDEX_NAME"), "digiorg-logs")
+        self.assertEqual(self.env.get("KUBERNETES_URL"), "https://kubernetes.default.svc")
+
+    def test_preserves_prometheus_port(self):
+        ports = {p.get("name"): p["containerPort"] for p in self.container["ports"]}
+        self.assertEqual(ports.get("prometheus"), 24231)
+
+    def test_preserves_volumes(self):
+        mounts = {m["name"]: m["mountPath"] for m in self.container["volumeMounts"]}
+        self.assertEqual(mounts.get("varlog"), "/var/log")
+        self.assertEqual(mounts.get("varlibdockercontainers"), "/var/lib/docker/containers")
+        self.assertEqual(mounts.get("fluentd-config"), "/fluentd/etc/fluent.conf")
+
+    def test_preserves_resources(self):
+        res = self.container["resources"]
+        self.assertEqual(res["requests"]["cpu"], "100m")
+        self.assertEqual(res["requests"]["memory"], "200Mi")
+        self.assertEqual(res["limits"]["cpu"], "500m")
+        self.assertEqual(res["limits"]["memory"], "512Mi")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_gitea_migration.py
+++ b/platform/tests/test_gitea_migration.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Tests for the Gitea chart migration 10.6.0 -> 12.x (Issue #275).
+
+The 12.0 Helm chart carries a hard breaking change: the bundled in-memory cache
+provider changed from Redis to **Valkey**, and the default-enabled subchart is
+now ``valkey-cluster`` (``redis``/``redis-cluster`` keys no longer exist). The
+platform runs Gitea against the shared platform-db PostgreSQL with in-process
+session/cache/queue, so the bundled ``valkey-cluster``/``valkey`` AND
+``postgresql``/``postgresql-ha`` subcharts must all be explicitly disabled, and
+the old ``redis-cluster`` toggle (now a dead key) must be gone.
+
+Sources (revalidated 2026-07-18):
+  * chart index https://dl.gitea.com/charts/index.yaml — 12.6.0 (appVersion 1.26.1)
+  * chart values https://gitea.com/gitea/helm-gitea/raw/tag/v12.6.0/values.yaml —
+    postgresql-ha and valkey-cluster default to enabled:true.
+
+Pure python3 + PyYAML::
+
+    python3 platform/tests/test_gitea_migration.py
+"""
+
+import os
+import re
+import sys
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+APP = os.path.join(REPO_ROOT, "apps", "platform", "gitea.yaml")
+VALUES = os.path.join(REPO_ROOT, "platform", "base", "gitea", "values.yaml")
+
+
+def _docs(path):
+    with open(path, encoding="utf-8") as fh:
+        return [d for d in yaml.safe_load_all(fh) if d]
+
+
+def _load(path):
+    with open(path, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+class ChartPinTest(unittest.TestCase):
+    def setUp(self):
+        app = _docs(APP)[0]
+        self.src = next(s for s in app["spec"]["sources"] if s.get("chart") == "gitea")
+
+    def test_chart_pinned_to_12_x_exact(self):
+        rev = str(self.src["targetRevision"])
+        self.assertRegex(rev, r"^12\.\d+\.\d+$",
+                         "gitea chart must pin an exact 12.x SemVer, got %r" % rev)
+
+
+class ValuesMigrationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.values = _load(VALUES)
+
+    def test_bundled_valkey_cluster_disabled(self):
+        # valkey-cluster defaults to enabled:true in 12.x — must be turned off.
+        self.assertIn("valkey-cluster", self.values,
+                      "must explicitly disable the bundled valkey-cluster subchart")
+        self.assertFalse(self.values["valkey-cluster"].get("enabled", True))
+
+    def test_bundled_valkey_disabled(self):
+        self.assertIn("valkey", self.values)
+        self.assertFalse(self.values["valkey"].get("enabled", True))
+
+    def test_legacy_redis_cluster_key_removed(self):
+        # redis-cluster is not a valid key in 12.x; leaving it is misleading.
+        self.assertNotIn("redis-cluster", self.values,
+                         "the pre-12.x redis-cluster key must be removed")
+        self.assertNotIn("redis", self.values)
+
+    def test_bundled_postgres_disabled(self):
+        self.assertFalse(self.values["postgresql"].get("enabled", True))
+        self.assertFalse(self.values["postgresql-ha"].get("enabled", True))
+
+    def test_in_process_session_cache_queue_retained(self):
+        cfg = self.values["gitea"]["config"]
+        self.assertEqual(cfg["session"]["PROVIDER"], "memory")
+        self.assertEqual(cfg["cache"]["ADAPTER"], "memory")
+        self.assertEqual(cfg["queue"]["TYPE"], "level")
+
+    def test_shared_db_host_retained(self):
+        db = self.values["gitea"]["config"]["database"]
+        self.assertEqual(db["HOST"], "postgresql.platform-db.svc.cluster.local:5432")
+        self.assertEqual(db["USER"], "gitea")
+        self.assertEqual(db["NAME"], "gitea")
+
+    def test_image_matches_chart_12_registry_layout_and_is_digest_pinned(self):
+        # Chart 12 defaults to registry=docker.gitea.com and repository=gitea.
+        # Carrying the old docker.io-style `gitea/gitea` override renders the
+        # nonexistent docker.gitea.com/gitea/gitea:1.26.1 image.
+        image = self.values["image"]
+        self.assertEqual(image.get("registry"), "docker.gitea.com")
+        self.assertEqual(image.get("repository"), "gitea")
+        self.assertEqual(str(image.get("tag")), "1.26.1")
+        self.assertEqual(
+            image.get("digest"),
+            "sha256:d8667667b4ccbd1f67b86a376bffcc0a17b16cf71309ed04e3918231776d47dd",
+        )
+
+    def test_chart_test_hook_does_not_reintroduce_busybox_latest(self):
+        self.assertIn("test", self.values)
+        self.assertFalse(
+            self.values["test"].get("enabled", True),
+            "disable the optional chart test hook unless its image is digest-pinned",
+        )
+
+    def test_rootless_pinned_false(self):
+        # 12.x auto-transition can break SSH known_hosts; keep the prior behaviour.
+        self.assertFalse(self.values["image"].get("rootless", True))
+
+    def test_chart_12_probe_overrides_are_nested_under_gitea(self):
+        self.assertNotIn("livenessProbe", self.values)
+        self.assertNotIn("readinessProbe", self.values)
+        self.assertEqual(self.values["gitea"]["livenessProbe"]["timeoutSeconds"], 5)
+        self.assertEqual(self.values["gitea"]["readinessProbe"]["timeoutSeconds"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_harbor_monitoring_compat.py
+++ b/platform/tests/test_harbor_monitoring_compat.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Harbor chart 1.19 ServiceMonitor compatibility contract."""
+import os
+import unittest
+import yaml
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def load(path):
+    with open(os.path.join(ROOT, path), encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+class HarborServiceMonitorTest(unittest.TestCase):
+    def test_harbor_does_not_emit_duplicate_release_labels(self):
+        values = load("platform/base/harbor/values.yaml")
+        labels = values["metrics"]["serviceMonitor"].get("additionalLabels", {})
+        self.assertNotIn(
+            "release", labels,
+            "chart 1.19 already emits release: harbor; an override creates invalid duplicate YAML",
+        )
+
+    def test_prometheus_selects_both_platform_and_harbor_release_labels(self):
+        values = load("platform/base/grafana/values.yaml")
+        selector = values["prometheus"]["prometheusSpec"]["serviceMonitorSelector"]
+        expressions = selector.get("matchExpressions", [])
+        release = next((x for x in expressions if x.get("key") == "release"), None)
+        if release is None:
+            self.fail("serviceMonitorSelector must include a release expression")
+        self.assertEqual(release.get("operator"), "In")
+        self.assertGreaterEqual(set(release.get("values", [])), {"prometheus", "harbor"})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_harbor_proxy_cache.py
+++ b/platform/tests/test_harbor_proxy_cache.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Tests for the Harbor proxy-cache configuration (Issue #275, Tier 2).
+
+Tier 2 requires Harbor to pull upstream images through **proxy-cache projects**
+for Docker Hub, Quay, GHCR and registry.k8s.io. Harbor stores registries and
+projects in its database, so — exactly like the OIDC config (Issue #262) — they
+are provisioned by an ArgoCD PostSync Job that calls the Harbor REST API
+(``POST /api/v2.0/registries`` then ``POST /api/v2.0/projects`` with
+``registry_id``).
+
+Registry provider ``type`` strings are the exact Harbor constants
+(src/pkg/reg/model/registry.go): docker-hub, quay, github-ghcr, docker-registry.
+
+Pure python3 + PyYAML::
+
+    python3 platform/tests/test_harbor_proxy_cache.py
+"""
+
+import os
+import sys
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+HARBOR_DIR = os.path.join(REPO_ROOT, "platform", "base", "harbor")
+JOB = os.path.join(HARBOR_DIR, "harbor-proxy-cache-job.yaml")
+KUSTOMIZATION = os.path.join(HARBOR_DIR, "kustomization.yaml")
+
+# name -> (harbor registry type, upstream url) that MUST be configured.
+EXPECTED_REGISTRIES = {
+    "docker-hub": ("docker-hub", "https://hub.docker.com"),
+    "quay": ("quay", "https://quay.io"),
+    "ghcr": ("github-ghcr", "https://ghcr.io"),
+    "registry-k8s-io": ("docker-registry", "https://registry.k8s.io"),
+}
+
+
+def _docs(path):
+    with open(path, encoding="utf-8") as fh:
+        return [d for d in yaml.safe_load_all(fh) if d]
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+class JobShapeTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.job = next(d for d in _docs(JOB) if d.get("kind") == "Job")
+        cls.container = cls.job["spec"]["template"]["spec"]["containers"][0]
+
+    def test_is_postsync_hook_in_harbor_namespace(self):
+        ann = self.job["metadata"]["annotations"]
+        self.assertEqual(ann.get("argocd.argoproj.io/hook"), "PostSync")
+        self.assertEqual(self.job["metadata"]["namespace"], "harbor")
+
+    def test_uses_digest_pinned_curl_image(self):
+        self.assertRegex(self.container["image"], r"^curlimages/curl:.*@sha256:[0-9a-f]{64}$")
+
+    def test_admin_password_from_secret(self):
+        env = {e["name"]: e for e in self.container.get("env", [])}
+        self.assertIn("HARBOR_ADMIN_PASSWORD", env)
+        self.assertIn("secretKeyRef", env["HARBOR_ADMIN_PASSWORD"]["valueFrom"])
+
+
+class ProxyCacheContentTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.job = next(d for d in _docs(JOB) if d.get("kind") == "Job")
+        cls.script = cls.job["spec"]["template"]["spec"]["containers"][0]["command"][-1]
+
+    def test_calls_registries_and_projects_endpoints(self):
+        # The base path is composed from a HARBOR_API var (like the OIDC job).
+        self.assertIn("/api/v2.0", self.script)
+        self.assertIn("/registries", self.script)
+        self.assertIn("/projects", self.script)
+
+    def test_waits_for_harbor_ready(self):
+        self.assertIn("/ping", self.script)
+        self.assertIn("activeDeadlineSeconds", self.job["spec"])
+        self.assertIn("--connect-timeout", self.script)
+        self.assertIn("--max-time", self.script)
+        self.assertIn("readiness timeout", self.script)
+
+    def test_conflicts_are_verified_not_blindly_accepted(self):
+        self.assertIn("wrong type", self.script)
+        self.assertIn("wrong URL", self.script)
+        self.assertIn("not bound to registry", self.script)
+        self.assertIn("already exists and matches", self.script)
+
+    def test_every_registry_type_and_url_present(self):
+        for name, (rtype, url) in EXPECTED_REGISTRIES.items():
+            self.assertIn(rtype, self.script,
+                          f"registry type {rtype} ({name}) must be configured")
+            self.assertIn(url, self.script,
+                          f"upstream url {url} ({name}) must be configured")
+
+    def test_projects_reference_registry_id(self):
+        # A project only becomes a proxy cache when created with registry_id.
+        self.assertIn("registry_id", self.script,
+                      "proxy-cache projects must be created with a registry_id")
+
+    def test_idempotent_on_conflict(self):
+        # Re-running on an existing Harbor must not fail (409 already-exists).
+        self.assertIn("409", self.script,
+                      "the job must treat HTTP 409 (already exists) as success")
+
+
+class KustomizationTest(unittest.TestCase):
+    def test_job_is_included(self):
+        k = _docs(KUSTOMIZATION)[0]
+        self.assertIn("harbor-proxy-cache-job.yaml", k.get("resources", []))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_keycloak_image.py
+++ b/platform/tests/test_keycloak_image.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+# =============================================================================
+# Regression tests for the DigiOrg production-optimized Keycloak image — #275
+#
+# Architecture under test (Issue #275, Tier 1 — DigiOrg-owned Keycloak image):
+#
+#   * The stock deployment ran `start-dev` on the raw upstream image. Dev mode
+#     re-runs the augmentation/build step on every boot, disables production
+#     safeguards and is explicitly unsupported for real use.
+#
+#   * Tier 1 replaces it with a pinned, multi-stage image built by
+#     platform/images/keycloak/build.nu: stage 1 runs `kc.sh build` with the
+#     platform's build-time options (db=postgres, health, metrics) against the
+#     digest-pinned upstream base, stage 2 copies the optimized server from the
+#     SAME digest-pinned base, and the deployment starts it with
+#     `start --optimized`. Realm/user data is NEVER baked in — it stays in the
+#     mounted realm-import configMap volume.
+#
+# These tests parse/assert the REAL build definition and the REAL deployment
+# manifest (behaviour, not a single grepped string):
+#
+#   BuildContractTest      build.nu (Nushell, cross-platform) pins the upstream
+#                          tag + immutable base digest, verifies the tag still
+#                          resolves to that digest before building, bakes the
+#                          build-time options for `--optimized`, passes
+#                          version/base-digest provenance args, keeps local kind
+#                          and Harbor coordinates aligned, exposes REGISTRY/
+#                          KIND_CLUSTER/LOAD/PUSH overrides, and embeds no
+#                          credentials.
+#   DockerfileContractTest a multi-stage build FROM the digest-pinned base runs
+#                          `kc.sh build` with db=postgres/health/metrics, the
+#                          final stage copies the optimized build from the SAME
+#                          pinned base, emits OCI provenance labels, and bakes NO
+#                          realm/user JSON into the image.
+#   DeploymentWiringTest   keycloak-deployment.yaml selects the exact allow-listed
+#                          image with IfNotPresent, starts with `start
+#                          --optimized` (not start-dev), preserves every env var/
+#                          port/probe/relative-path/hostname setting, and keeps
+#                          the realm data in the mounted configMap volume.
+#
+# Runs with the standard library + PyYAML only (no pytest, cluster or network):
+#     python3 platform/tests/test_keycloak_image.py
+# =============================================================================
+import os
+import re
+import unittest
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+IMAGE_DIR = os.path.join(REPO_ROOT, "platform", "images", "keycloak")
+BUILD_NU = os.path.join(IMAGE_DIR, "build.nu")
+DOCKERFILE = os.path.join(IMAGE_DIR, "Dockerfile")
+DEPLOYMENT = os.path.join(
+    REPO_ROOT, "platform", "base", "keycloak", "keycloak-deployment.yaml"
+)
+
+# The exact coordinates fixed by the issue and the pin-policy allowlist.
+UPSTREAM_IMAGE = "quay.io/keycloak/keycloak"
+UPSTREAM_TAG = "26.7.0"
+UPSTREAM_DIGEST = "sha256:2eb3cd316835c990e69e26ade292ffa78f6fb0db7d5fc6377463c162e1979ac0"
+IMAGE = "digiorg/keycloak"
+TAG = "26.7.0-optimized"
+FULL_IMAGE = "%s:%s" % (IMAGE, TAG)
+
+
+def read_text(path):
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def load_yaml_docs(path):
+    with open(path, "r", encoding="utf-8") as fh:
+        return [d for d in yaml.safe_load_all(fh) if d is not None]
+
+
+# =========================================================================== #
+class BuildContractTest(unittest.TestCase):
+    """The build must be pinned, reproducible, credential-free, cross-platform."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.script = read_text(BUILD_NU)
+
+    def _const(self, name):
+        m = re.search(
+            r'^\s*const\s+%s\s*=\s*"([^"\n]+)"' % re.escape(name), self.script, re.M
+        )
+        self.assertIsNotNone(m, "build.nu must define const %s" % name)
+        return m.group(1).strip()
+
+    def _env_default(self, name):
+        m = re.search(
+            r'\$env\.%s\??\s*\|\s*default\s+"([^"\n]+)"' % re.escape(name), self.script
+        )
+        self.assertIsNotNone(
+            m, "build.nu must expose an $env.%s override with a default" % name
+        )
+        return m.group(1).strip()
+
+    def test_is_cross_platform_nushell_not_bash(self):
+        self.assertTrue(os.path.exists(BUILD_NU), "the builder must be build.nu (Nushell)")
+        self.assertRegex(
+            self.script.splitlines()[0], r"^#!.*\bnu\b",
+            "build.nu must carry a Nushell (`nu`) shebang",
+        )
+        for raw in self.script.splitlines():
+            line = raw.strip()
+            if line.startswith("#"):
+                continue
+            for tool in ("bash", "awk", "sed", "grep"):
+                self.assertNotRegex(
+                    line, r"(^|[\s|(])%s\b" % tool,
+                    "build.nu must not invoke the non-cross-platform tool "
+                    "%r: %r" % (tool, raw),
+                )
+
+    def test_supports_environment_overrides(self):
+        for name in ("REGISTRY", "KIND_CLUSTER", "LOAD", "PUSH"):
+            self._env_default(name)
+
+    def test_pins_upstream_image_tag_and_digest(self):
+        self.assertEqual(self._const("UPSTREAM_IMAGE"), UPSTREAM_IMAGE)
+        self.assertEqual(self._const("UPSTREAM_TAG"), UPSTREAM_TAG)
+        digest = self._const("UPSTREAM_DIGEST")
+        self.assertEqual(digest, UPSTREAM_DIGEST)
+        self.assertRegex(
+            digest, r"^sha256:[0-9a-f]{64}$",
+            "UPSTREAM_DIGEST must be a full immutable sha256 digest for provenance",
+        )
+
+    def test_image_coordinates(self):
+        self.assertEqual(self._const("IMAGE"), IMAGE)
+        self.assertEqual(self._const("TAG"), TAG)
+
+    def test_verifies_tag_resolves_to_pinned_digest_before_build(self):
+        # A re-tag upstream must not silently change the base: build.nu must
+        # resolve the tag and compare it to UPSTREAM_DIGEST before building.
+        self.assertIn(
+            "resolve_digest.py", self.script,
+            "build.nu must resolve the pinned tag (scripts/resolve_digest.py) "
+            "before building",
+        )
+        self.assertIn(
+            "UPSTREAM_DIGEST", self.script,
+            "the resolved digest must be compared against UPSTREAM_DIGEST",
+        )
+        # The comparison must be able to abort the build on mismatch.
+        self.assertRegex(
+            self.script, r"exit\s+1",
+            "build.nu must abort (exit 1) when the tag no longer resolves to "
+            "the pinned digest",
+        )
+
+    def test_local_and_harbor_coordinates_distinct_and_aligned(self):
+        image = self._const("IMAGE")
+        registry = self._env_default("REGISTRY")
+        registry_repository = self._const("REGISTRY_REPOSITORY")
+        self.assertEqual(image, "digiorg/keycloak")
+        self.assertIn("digiorg.local/library", registry)
+        self.assertEqual(registry_repository, "keycloak")
+        self.assertIn(
+            '$"($registry)/($REGISTRY_REPOSITORY):($TAG)"', self.script,
+            "Harbor push target must be digiorg.local/library/keycloak:<tag> "
+            "without duplicating the local digiorg namespace",
+        )
+        self.assertNotIn(
+            '$"($registry)/($IMAGE):($TAG)"', self.script,
+            "Harbor target must not become library/digiorg/keycloak",
+        )
+
+    def test_passes_provenance_build_args(self):
+        for arg in ("version", "base_digest"):
+            self.assertRegex(
+                self.script, r'--build-arg\s+\$?"?%s=' % arg,
+                "build should pass provenance build arg %s=" % arg,
+            )
+
+    def test_no_embedded_credentials(self):
+        for pat in (r"password\s*=", r"passwd\s*=", r"token\s*=",
+                    r"-p\s+\S+", r"DOCKER_PASSWORD="):
+            self.assertNotRegex(
+                self.script, re.compile(pat, re.I),
+                "build.nu must not embed credentials (matched %r)" % pat,
+            )
+
+    def test_kind_load_and_optional_push(self):
+        self.assertIn("kind load docker-image", self.script,
+                      "build.nu must kind-load the built image for local dev")
+        self.assertIn("docker push", self.script,
+                      "build.nu must support an optional Harbor push")
+
+
+class DockerfileContractTest(unittest.TestCase):
+    """Multi-stage, digest-pinned, production-optimized, realm-data-free."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = read_text(DOCKERFILE)
+
+    def _from_lines(self):
+        return [ln for ln in self.text.splitlines()
+                if ln.strip().upper().startswith("FROM ")]
+
+    def test_multi_stage_build_with_builder(self):
+        froms = self._from_lines()
+        self.assertGreaterEqual(len(froms), 2,
+                                "Dockerfile must be multi-stage (builder + final)")
+        self.assertRegex(
+            froms[0], r"(?i)\bAS\s+builder\b",
+            "the first stage must be named `builder`",
+        )
+
+    def test_both_stages_pin_the_same_base_digest(self):
+        # Every FROM must reference the immutable digest (directly or via an ARG
+        # that defaults to it) so the base can never float.
+        self.assertGreaterEqual(
+            self.text.count(UPSTREAM_DIGEST), 1,
+            "the pinned base digest must appear in the Dockerfile",
+        )
+        for ln in self._from_lines():
+            self.assertRegex(
+                ln, r"@\$\{?UPSTREAM_DIGEST\}?|@%s" % re.escape(UPSTREAM_DIGEST),
+                "every FROM must pin the base by @sha256 digest: %r" % ln,
+            )
+
+    def test_runs_optimized_kc_build_with_platform_options(self):
+        self.assertRegex(
+            self.text, r"kc\.sh\s+build",
+            "the builder stage must run `kc.sh build` to produce an optimized server",
+        )
+        # The build-time options that `start --optimized` then relies on.
+        self.assertRegex(self.text, r"KC_DB[= ]+postgres",
+                          "must fix KC_DB=postgres at build time for --optimized")
+        self.assertRegex(self.text, r"KC_HEALTH_ENABLED[= ]+true",
+                          "must enable health at build time")
+        self.assertRegex(self.text, r"KC_METRICS_ENABLED[= ]+true",
+                          "must enable metrics at build time")
+
+    def test_final_stage_copies_optimized_build(self):
+        self.assertRegex(
+            self.text, r"COPY\s+--from=builder\s+/opt/keycloak",
+            "the final stage must copy the optimized /opt/keycloak from the builder",
+        )
+
+    def test_emits_oci_provenance_labels(self):
+        for label in (
+            "org.opencontainers.image.source",
+            "org.opencontainers.image.version",
+            "org.opencontainers.image.revision",
+        ):
+            self.assertIn(label, self.text,
+                          "Dockerfile must emit OCI label %s" % label)
+
+    def test_no_realm_or_user_json_baked_in(self):
+        # Realm/user data must stay in the mounted configMap, never in the image.
+        # Inspect the actual COPY/ADD *instructions* (comments may reference the
+        # runtime mount path to explain why it is deliberately absent here).
+        copy_adds = [
+            ln for ln in self.text.splitlines()
+            if ln.strip().upper().startswith(("COPY ", "ADD "))
+        ]
+        for ln in copy_adds:
+            self.assertNotRegex(
+                ln, r"(?i)realm.*\.json",
+                "realm JSON must NOT be baked into the image: %r" % ln,
+            )
+            self.assertNotRegex(
+                ln, r"/opt/keycloak/data/import",
+                "the realm-import dir must stay a runtime mount, not a COPY "
+                "target: %r" % ln,
+            )
+
+
+class DeploymentWiringTest(unittest.TestCase):
+    """The deployment must select the built image and start --optimized."""
+
+    @classmethod
+    def setUpClass(cls):
+        docs = load_yaml_docs(DEPLOYMENT)
+        cls.deploy = next(d for d in docs if d.get("kind") == "Deployment")
+        cls.container = cls.deploy["spec"]["template"]["spec"]["containers"][0]
+        cls.env = {e["name"]: e for e in cls.container.get("env", [])}
+
+    def test_selects_exact_allowlisted_image(self):
+        self.assertEqual(self.container["image"], FULL_IMAGE)
+
+    def test_pull_policy_never(self):
+        self.assertEqual(self.container.get("imagePullPolicy"), "Never")
+
+    def test_starts_optimized_not_dev(self):
+        args = self.container.get("args", [])
+        self.assertIn("start", args, "must run production `start`")
+        self.assertIn("--optimized", args, "must pass --optimized")
+        self.assertNotIn("start-dev", args, "dev mode must be gone")
+
+    def test_realm_data_stays_a_mounted_configmap(self):
+        mounts = self.container.get("volumeMounts", [])
+        realm_mount = next(
+            (m for m in mounts if m.get("mountPath") == "/opt/keycloak/data/import"),
+            None,
+        )
+        self.assertIsNotNone(realm_mount, "realm-import volume mount must be preserved")
+        vols = {v["name"]: v for v in self.deploy["spec"]["template"]["spec"]["volumes"]}
+        vol = vols.get(realm_mount["name"])
+        self.assertIsNotNone(vol, "the realm mount must reference a declared volume")
+        self.assertIn("configMap", vol, "realm data must come from a configMap volume")
+
+    def test_preserves_relative_path_and_http_and_db(self):
+        self.assertEqual(self.env["KC_HTTP_RELATIVE_PATH"]["value"], "/keycloak")
+        self.assertEqual(self.env["KC_HTTP_ENABLED"]["value"], "true")
+        self.assertEqual(self.env["KC_DB"]["value"], "postgres")
+        self.assertEqual(self.env["KC_HEALTH_ENABLED"]["value"], "true")
+
+    def test_preserves_hostname_config(self):
+        self.assertEqual(
+            self.env["KC_HOSTNAME"]["value"], "https://digiorg.local/keycloak"
+        )
+        self.assertEqual(
+            self.env["KC_HOSTNAME_ADMIN"]["value"], "https://digiorg.local/keycloak"
+        )
+
+    def test_preserves_ports(self):
+        ports = {p.get("name"): p["containerPort"] for p in self.container["ports"]}
+        self.assertEqual(ports.get("http"), 8080)
+        self.assertEqual(ports.get("health"), 9000)
+
+    def test_preserves_probes(self):
+        for probe in ("startupProbe", "livenessProbe", "readinessProbe"):
+            self.assertIn(probe, self.container, "%s must be preserved" % probe)
+            self.assertEqual(self.container[probe]["httpGet"]["port"], 9000)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_local_setup_image_builds.py
+++ b/platform/tests/test_local_setup_image_builds.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""The bootstrap script must build+load the Tier-1 DigiOrg images (Issue #275).
+
+Keycloak and Fluentd now run locally built, kind-loaded images with
+``pullPolicy: Never`` (allow-listed in scripts/pin-policy-allowlist.yaml),
+so — exactly like the OpenCost UI image — ``scripts/local-setup.nu`` must build
+and load them during bootstrap, or their pods stay ``ErrImageNeverPull`` /
+pending on a clean kind cluster. Missing Docker or a failed build must abort
+bootstrap rather than falling back to an untrusted public image.
+
+Pure python3 (text assertions on the Nushell script)::
+
+    python3 platform/tests/test_local_setup_image_builds.py
+"""
+
+import os
+import re
+import unittest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SETUP = os.path.join(REPO_ROOT, "scripts", "local-setup.nu")
+
+
+class BuildWiringTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open(SETUP, encoding="utf-8") as fh:
+            cls.text = fh.read()
+
+    def test_invokes_keycloak_build(self):
+        self.assertIn("platform/images/keycloak/build.nu", self.text,
+                      "bootstrap must build the DigiOrg Keycloak image")
+
+    def test_invokes_fluentd_build(self):
+        self.assertIn("platform/images/fluentd/build.nu", self.text,
+                      "bootstrap must build the DigiOrg Fluentd image")
+
+    def test_opencost_ui_build_preserved(self):
+        # The OpenCost /opencost fix must not regress.
+        self.assertIn("platform/base/opencost/ui-image/build.nu", self.text)
+
+    def test_builds_are_docker_guarded(self):
+        # Fail with a clear bootstrap error before attempting builds when Docker
+        # is unavailable; never allow kubelet fallback to a public namespace.
+        self.assertGreaterEqual(
+            len(re.findall(r"which docker", self.text)), 2,
+            "Tier-1 image builds must guard on Docker availability",
+        )
+
+    def test_tier1_build_failures_are_fatal(self):
+        start = self.text.index("def build_tier1_images")
+        end = self.text.index("# -----------------------------------------------------------------------------\n# Phase 2", start)
+        self.assertIn("error make", self.text[start:end])
+
+    def test_prometheus_operator_upgrade_preinstalls_all_crds(self):
+        expected = (
+            "alertmanagerconfigs", "alertmanagers", "podmonitors", "probes",
+            "prometheusagents", "prometheuses", "prometheusrules",
+            "scrapeconfigs", "servicemonitors", "thanosrulers",
+        )
+        for crd in expected:
+            self.assertIn(f"monitoring.coreos.com_{crd}.yaml", self.text)
+
+    def test_tier1_builds_invoked_from_bootstrap(self):
+        # The build step must actually be called from the bootstrap flow (which
+        # `main up` runs), not just defined. Assert it appears in `main bootstrap`
+        # alongside the preserved opencost build.
+        m = re.search(r'def "main bootstrap" \[\][\s\S]*?(?=\ndef )', self.text)
+        self.assertIsNotNone(m, "could not locate the `main bootstrap` function body")
+        body = m.group(0)
+        self.assertIn("build_opencost_ui_image", body,
+                      "the opencost UI build must stay in bootstrap")
+        self.assertRegex(
+            body, r"build_(tier1_images|keycloak_image|fluentd_image|platform_images)",
+            "the Tier-1 image build step must be invoked from `main up`",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_major_upgrade_gates.py
+++ b/platform/tests/test_major_upgrade_gates.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Major platform upgrades must be promoted one at a time (Issue #275)."""
+import os
+import unittest
+import yaml
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+MAJOR_APPS = (
+    "external-secrets",
+    "nats",
+    "grafana",
+    "opencost",
+    "gitea",
+    "sonarqube",
+    "crossplane",
+    "crossplane-providers",
+    "crossplane-provider-configs",
+    "crossplane-xrds",
+    "core-catalog",
+)
+
+
+class MajorUpgradeGateTest(unittest.TestCase):
+    def test_major_upgrades_require_explicit_manual_sync(self):
+        for name in MAJOR_APPS:
+            with self.subTest(app=name):
+                path = os.path.join(ROOT, "apps", "platform", f"{name}.yaml")
+                with open(path, encoding="utf-8") as fh:
+                    app = yaml.safe_load(fh)
+                annotations = app["metadata"].get("annotations", {})
+                self.assertEqual(
+                    annotations.get("platform.digiorg.io/upgrade-gate"),
+                    "issue-275-manual",
+                )
+                policy = app["spec"].get("syncPolicy", {})
+                self.assertNotIn(
+                    "automated", policy,
+                    f"{name} is a major migration and must not auto-sync with the other upgrades",
+                )
+    def test_local_kind_bootstrap_explicitly_promotes_gates_in_order(self):
+        path = os.path.join(ROOT, "scripts", "local-setup.nu")
+        with open(path, encoding="utf-8") as fh:
+            setup = fh.read()
+        self.assertIn("sync_gated_apps_for_local_dev", setup)
+        self.assertIn("kubectl patch application $app", setup)
+        positions = [setup.index(f'\"{name}\"', setup.index("let gated_apps")) for name in MAJOR_APPS]
+        self.assertEqual(positions, sorted(positions))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_major_upgrade_gates.py
+++ b/platform/tests/test_major_upgrade_gates.py
@@ -43,6 +43,11 @@ class MajorUpgradeGateTest(unittest.TestCase):
             setup = fh.read()
         self.assertIn("sync_gated_apps_for_local_dev", setup)
         self.assertIn("kubectl patch application $app", setup)
+        self.assertIn("status.operationState.finishedAt", setup)
+        self.assertIn("status.operationState.phase", setup)
+        self.assertIn("status.sync.status", setup)
+        self.assertIn('phase in ["Failed" "Error"]', setup)
+        self.assertIn("Synced+Healthy", setup)
         positions = [setup.index(f'\"{name}\"', setup.index("let gated_apps")) for name in MAJOR_APPS]
         self.assertEqual(positions, sorted(positions))
 

--- a/platform/tests/test_opencost_ui_subpath.py
+++ b/platform/tests/test_opencost_ui_subpath.py
@@ -60,6 +60,7 @@ import yaml
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 OPENCOST_DIR = os.path.join(REPO_ROOT, "platform", "base", "opencost")
 INGRESS_DIR = os.path.join(REPO_ROOT, "platform", "base", "ingress")
+APPS_OPENCOST = os.path.join(REPO_ROOT, "apps", "platform", "opencost.yaml")
 
 VALUES = os.path.join(OPENCOST_DIR, "values.yaml")
 OAUTH2 = os.path.join(OPENCOST_DIR, "oauth2-proxy.yaml")
@@ -633,6 +634,50 @@ class RouterBasenameDomTest(unittest.TestCase):
                 "deep link %s must match its client-side route under the basename"
                 % pathname,
             )
+
+
+class ChartMajorUpgradeTest(unittest.TestCase):
+    """Issue #275: the OpenCost Helm chart is migrated 1.43.2 -> 2.x while the
+    pinned custom subpath UI image and the whole /opencost contract are preserved.
+
+    The 2.x chart ships appVersion 1.120.4 (exactly the release our custom UI is
+    built from) and defaults `opencost.ui.image` to the stock
+    ghcr.io/opencost/opencost-ui:1.120.4 — so these guards prove our subpath
+    override still wins after the upgrade and that the exact chart version is
+    pinned (no floating range)."""
+
+    @classmethod
+    def setUpClass(cls):
+        docs = load_yaml_docs(APPS_OPENCOST)
+        app = next(d for d in docs if d.get("kind") == "Application")
+        cls.chart_src = next(
+            s for s in app["spec"]["sources"] if s.get("chart") == "opencost"
+        )
+        cls.values = load_single(VALUES)
+
+    def test_chart_pinned_to_v2_exact_semver(self):
+        rev = str(self.chart_src["targetRevision"])
+        self.assertRegex(
+            rev, r"^2\.\d+\.\d+$",
+            "opencost chart must be pinned to an exact 2.x SemVer, got %r" % rev,
+        )
+
+    def test_custom_ui_image_preserved_after_upgrade(self):
+        img = self.values["opencost"]["ui"]["image"]
+        self.assertEqual(
+            img.get("repository"), "opencost-ui",
+            "the subpath-aware override must survive the chart 2.x upgrade",
+        )
+        self.assertIn("basename-opencost", str(img.get("tag", "")))
+        self.assertIn(img.get("pullPolicy"), ("IfNotPresent", "Never"))
+
+    def test_native_uipath_matches_subpath(self):
+        # 2.x exposes a first-class opencost.ui.uiPath; pin it to the subpath so
+        # the serving path is expressed through the supported chart value too.
+        self.assertEqual(
+            self.values["opencost"]["ui"].get("uiPath"), SUBPATH,
+            "opencost.ui.uiPath (native in chart 2.x) must equal %s" % SUBPATH,
+        )
 
 
 if __name__ == "__main__":

--- a/platform/tests/test_pin_policy.py
+++ b/platform/tests/test_pin_policy.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Regression tests for the platform image/chart pin policy (Issue #275).
+
+These tests guard the Tier-2 "Harbor mirror plus digest pinning" contract and
+the platform-wide "no floating references" validation requirement:
+
+  * every container `image:` in a rendered Kubernetes manifest is pinned to an
+    immutable ``@sha256:`` digest (or is an explicitly documented exception);
+  * every Argo CD Helm ``chart:`` source pins an exact SemVer (no ``latest``,
+    no branch, no range/wildcard);
+  * every non-first-party git source pins an immutable 40-hex commit.
+
+They exercise the *behaviour* of ``scripts/check_pins.py`` on synthetic inputs
+(so the rules themselves are proven, not just asserted to exist) and then run
+the real checker over the real tree, which must be clean.
+
+No cluster, pytest, or network access required::
+
+    python3 platform/tests/test_pin_policy.py
+"""
+
+import os
+import sys
+import unittest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, os.path.join(REPO_ROOT, "scripts"))
+
+import check_pins  # noqa: E402  (path injected above)
+
+
+def _images_from(text):
+    """Violations for image refs written to a temp manifest with the given body."""
+    return check_pins.scan_text("m.yaml", text)
+
+
+class ImageDigestRuleTest(unittest.TestCase):
+    def test_latest_tag_is_rejected(self):
+        v = _images_from("spec:\n  containers:\n  - image: natsio/nats-surveyor:latest\n")
+        self.assertTrue(any(x.kind == "image" for x in v))
+        self.assertTrue(any("latest" in x.message or "digest" in x.message for x in v))
+
+    def test_branch_tag_is_rejected(self):
+        v = _images_from("    image: ghcr.io/digiorg/core-landingpage:main\n")
+        self.assertTrue(any(x.kind == "image" for x in v))
+
+    def test_bare_tag_without_digest_is_rejected(self):
+        v = _images_from("    image: postgres:16-alpine\n")
+        self.assertEqual([x.kind for x in v], ["image"])
+
+    def test_digest_pinned_image_is_accepted(self):
+        ref = "postgres:16-alpine@sha256:" + "0" * 64
+        v = _images_from(f"    image: {ref}\n")
+        self.assertEqual(v, [])
+
+    def test_allowlisted_local_image_is_accepted(self):
+        # The kind-loaded, locally built images are documented exceptions.
+        allow = {"opencost-ui:v1.120.4-basename-opencost"}
+        v = check_pins.scan_text(
+            "m.yaml", "    image: opencost-ui:v1.120.4-basename-opencost\n", allow=allow
+        )
+        self.assertEqual(v, [])
+
+
+class ChartVersionRuleTest(unittest.TestCase):
+    def _chart(self, rev):
+        return (
+            "spec:\n  sources:\n"
+            "  - repoURL: https://charts.example.com\n"
+            "    chart: thing\n"
+            f'    targetRevision: "{rev}"\n'
+        )
+
+    def test_exact_semver_chart_is_accepted(self):
+        self.assertEqual(_images_from(self._chart("1.43.2")), [])
+
+    def test_range_chart_is_rejected(self):
+        v = _images_from(self._chart("^1.43.0"))
+        self.assertTrue(any(x.kind == "chart" for x in v))
+
+    def test_wildcard_chart_is_rejected(self):
+        v = _images_from(self._chart("1.43.x"))
+        self.assertTrue(any(x.kind == "chart" for x in v))
+
+    def test_missing_chart_pin_is_rejected(self):
+        text = (
+            "spec:\n  source:\n"
+            "    repoURL: https://charts.crossplane.io/stable\n"
+            "    chart: crossplane\n"
+        )
+        v = _images_from(text)
+        self.assertTrue(any(x.kind == "chart" for x in v))
+
+
+class GitSourceRuleTest(unittest.TestCase):
+    def test_first_party_main_is_accepted(self):
+        text = (
+            "spec:\n  source:\n"
+            "    repoURL: https://github.com/digiorg/core.git\n"
+            "    targetRevision: main\n"
+            "    path: platform/base/keycloak\n"
+        )
+        self.assertEqual(_images_from(text), [])
+
+    def test_third_party_branch_is_rejected(self):
+        text = (
+            "spec:\n  source:\n"
+            "    repoURL: https://github.com/digiorg/core-catalog.git\n"
+            "    targetRevision: main\n"
+            "    path: compositions/local\n"
+        )
+        v = _images_from(text)
+        self.assertTrue(any(x.kind == "git" for x in v))
+
+    def test_third_party_commit_sha_is_accepted(self):
+        text = (
+            "spec:\n  source:\n"
+            "    repoURL: https://github.com/digiorg/core-catalog.git\n"
+            "    targetRevision: 0ced57eb40a50ec170352ce4a59bffedd4a16a6c\n"
+            "    path: compositions/local\n"
+        )
+        self.assertEqual(_images_from(text), [])
+
+
+class RealTreeIsCleanTest(unittest.TestCase):
+    """The committed manifests must satisfy the pin policy end-to-end."""
+
+    def test_repo_has_no_pin_violations(self):
+        violations = check_pins.scan_repo(REPO_ROOT)
+        detail = "\n".join(f"  {v.file}:{v.line} [{v.kind}] {v.ref} — {v.message}" for v in violations)
+        self.assertEqual(violations, [], f"\nPin-policy violations:\n{detail}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_platform_versions_doc.py
+++ b/platform/tests/test_platform_versions_doc.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""The platform version/upgrade documentation must exist and stay in sync (Issue #275).
+
+Several manifests point operators at ``docs/guides/platform-versions.md`` for the
+upgrade/rollback/CRD-ordering notes (crossplane, sonarqube, the Harbor
+proxy-cache Job). This guards those references from going dead and asserts the
+doc actually covers the pinned versions, the major migrations, rollback, and the
+Harbor proxy-cache bootstrap exception.
+
+Pure python3::
+
+    python3 platform/tests/test_platform_versions_doc.py
+"""
+
+import os
+import unittest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+DOC = os.path.join(REPO_ROOT, "docs", "guides", "platform-versions.md")
+REFERRERS = [
+    os.path.join(REPO_ROOT, "apps", "platform", "crossplane.yaml"),
+    os.path.join(REPO_ROOT, "apps", "platform", "sonarqube.yaml"),
+    os.path.join(REPO_ROOT, "platform", "base", "harbor", "harbor-proxy-cache-job.yaml"),
+]
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+class DocPresenceTest(unittest.TestCase):
+    def test_doc_exists(self):
+        self.assertTrue(os.path.exists(DOC), "docs/guides/platform-versions.md must exist")
+
+    def test_referenced_by_manifests_and_reference_is_valid(self):
+        for path in REFERRERS:
+            self.assertIn("docs/guides/platform-versions.md", _read(path),
+                          f"{os.path.relpath(path, REPO_ROOT)} should reference the versions guide")
+
+
+class DocContentTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = _read(DOC)
+        cls.lower = cls.text.lower()
+
+    def test_covers_pinned_migration_versions(self):
+        # The exact pins that must appear so the doc can't silently drift.
+        for token in ("12.6.0", "2026.3.1", "2.3.3", "2.7.0", "0.29.0", "87.17.0"):
+            self.assertIn(token, self.text, f"versions doc must list pin {token}")
+
+    def test_covers_upgrade_and_rollback(self):
+        self.assertIn("rollback", self.lower)
+        self.assertIn("upgrade", self.lower)
+
+    def test_covers_pin_policy_and_ci(self):
+        self.assertIn("check_pins.py", self.text)
+
+    def test_covers_harbor_proxy_cache_bootstrap_exception(self):
+        self.assertIn("proxy-cache", self.lower)
+        self.assertIn("bootstrap exception", self.lower)
+
+    def test_links_cnpg_runbook(self):
+        self.assertIn("postgres-cnpg-migration.md", self.text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_sonarqube_migration.py
+++ b/platform/tests/test_sonarqube_migration.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Tests for the SonarQube chart migration 10.8.1 -> 2026.x (Issue #275).
+
+SonarSource moved to calendar versioning; the chart is now ``2026.x`` and the
+platform deploys the **Community Build** via ``community.enabled: true`` +
+``community.buildNumber``. The 2026.3.1 chart keeps every value key this repo
+relies on (``jdbcOverwrite``, ``monitoringPasscodeSecretName``,
+``sonarWebContext``, ``deploymentType``, ``initSysctl``, ``sonarProperties`` …),
+so the migration is a version bump plus a Community-Build number aligned with the
+chart default.
+
+Sources (revalidated 2026-07-18):
+  * chart index https://SonarSource.github.io/helm-chart-sonarqube/index.yaml —
+    2026.3.1 (appVersion 2026.3.1) is newest.
+  * chart values (tag sonarqube-2026.3.1-…) — community.buildNumber default
+    "26.5.0.122743"; jdbcOverwrite/monitoringPasscodeSecretName/sonarWebContext
+    all present.
+
+Pure python3 + PyYAML::
+
+    python3 platform/tests/test_sonarqube_migration.py
+"""
+
+import os
+import re
+import sys
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+APP = os.path.join(REPO_ROOT, "apps", "platform", "sonarqube.yaml")
+VALUES = os.path.join(REPO_ROOT, "platform", "base", "sonarqube", "values.yaml")
+
+# The Community Build number shipped as the 2026.3.1 chart default.
+EXPECTED_BUILD = "26.5.0.122743"
+
+
+def _docs(path):
+    with open(path, encoding="utf-8") as fh:
+        return [d for d in yaml.safe_load_all(fh) if d]
+
+
+def _load(path):
+    with open(path, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+class ChartPinTest(unittest.TestCase):
+    def setUp(self):
+        app = _docs(APP)[0]
+        self.src = next(s for s in app["spec"]["sources"] if s.get("chart") == "sonarqube")
+
+    def test_chart_pinned_to_calendar_2026_exact(self):
+        rev = str(self.src["targetRevision"])
+        self.assertRegex(rev, r"^2026\.\d+\.\d+$",
+                         "sonarqube chart must pin an exact 2026.x SemVer, got %r" % rev)
+
+
+class ValuesMigrationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.values = _load(VALUES)
+
+    def test_community_build_enabled_and_pinned(self):
+        self.assertTrue(self.values["community"]["enabled"],
+                        "Community Build must stay enabled")
+        # buildNumber must be pinned and aligned with the migrated chart default.
+        self.assertEqual(self.values["community"]["buildNumber"], EXPECTED_BUILD,
+                         "community.buildNumber must align with the 2026.x chart")
+
+    def test_community_image_is_digest_pinned(self):
+        image = self.values["image"]
+        self.assertEqual(image.get("repository"), "sonarqube")
+        self.assertEqual(
+            image.get("tag"),
+            "26.5.0.122743-community@sha256:223d0090322edce6211a5328298b6f646920f1535025ef8dd880cab6647bb1fa",
+        )
+
+    def test_shared_db_retained(self):
+        jo = self.values["jdbcOverwrite"]
+        self.assertTrue(jo["enabled"])
+        self.assertIn("postgresql.platform-db.svc.cluster.local:5432", jo["jdbcUrl"])
+        self.assertEqual(jo["jdbcUsername"], "sonarqube")
+        self.assertEqual(jo["jdbcSecretName"], "sonarqube-db-secret")
+        self.assertFalse(self.values["postgresql"].get("enabled", True),
+                         "bundled postgresql subchart must stay disabled")
+
+    def test_monitoring_passcode_secret_retained(self):
+        self.assertEqual(self.values["monitoringPasscodeSecretName"],
+                         "sonarqube-monitoring-secret")
+
+    def test_web_context_subpath_retained(self):
+        self.assertEqual(self.values["sonarWebContext"], "/sonarqube")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/check_pins.py
+++ b/scripts/check_pins.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Pin-policy checker for the DigiOrg Core Platform (Issue #275).
+
+Rejects floating / non-reproducible references so a clean bootstrap installs the
+same versions every time:
+
+  * container ``image:`` refs must be pinned to an immutable ``@sha256:`` digest
+    (Tier-2 "record a human tag plus an immutable digest"), unless the exact ref
+    is listed in ``scripts/pin-policy-allowlist.yaml`` with a rationale (e.g.
+    locally built, kind-loaded images with ``pullPolicy: Never``);
+  * Argo CD Helm ``chart:`` sources must pin an exact SemVer — no ``latest``,
+    branch, empty, range (``^`` ``~`` ``>=`` ``*``) or ``x`` wildcard;
+  * git sources for repositories other than first-party ``digiorg/core`` must
+    pin an immutable 40-hex commit (first-party ``main`` is the GitOps norm and
+    is allowed).
+
+Pure standard library + PyYAML; no cluster or network access. Run directly for
+CI (exit non-zero on any violation) or import ``scan_repo`` / ``scan_text``::
+
+    python3 scripts/check_pins.py            # scan the repo, print violations
+    python3 scripts/check_pins.py --list     # also print every checked ref
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from dataclasses import dataclass
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment guard
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+ALLOWLIST_PATH = os.path.join(SCRIPT_DIR, "pin-policy-allowlist.yaml")
+
+# Directories scanned for manifests (repo-relative).
+SCAN_DIRS = ("apps", "platform/base")
+
+# First-party repositories: GitOps self-references may track ``main``.
+FIRST_PARTY_REPOS = ("https://github.com/digiorg/core.git", "https://github.com/digiorg/core")
+
+DIGEST_RE = re.compile(r"@sha256:[0-9a-f]{64}$")
+EXACT_SEMVER_RE = re.compile(r"^v?\d+\.\d+\.\d+([-.][0-9A-Za-z.-]+)?$")
+COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+RANGE_CHARS_RE = re.compile(r"[\^~*]|>=|<=|>|<|\bx\b|\.x")
+# A scalar that looks like an OCI image reference (has a repo path + tag/digest)
+# and is not a Helm template expression.
+IMAGE_LIKE_RE = re.compile(r"^[a-z0-9]([a-z0-9._/-]*[a-z0-9])?(:[\w][\w.-]*)?(@sha256:[0-9a-f]{64})?$")
+
+
+@dataclass(frozen=True)
+class Violation:
+    file: str
+    line: int
+    kind: str  # "image" | "chart" | "git"
+    ref: str
+    message: str
+
+
+def load_allowlist(path: str = ALLOWLIST_PATH) -> set[str]:
+    if not os.path.exists(path):
+        return set()
+    with open(path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return {entry["ref"] for entry in (data.get("images") or []) if entry.get("ref")}
+
+
+def _line_of(text: str, needle: str, start: int = 0) -> int:
+    idx = text.find(needle, start)
+    if idx < 0:
+        return 1
+    return text.count("\n", 0, idx) + 1
+
+
+def _is_image_ref(value) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    if "{{" in value or "$(" in value or " " in value:
+        return False
+    # Must have a tag or digest, and at least one dot/slash/colon distinguishing
+    # it from an arbitrary word.
+    if ":" not in value and "@" not in value:
+        return False
+    return bool(IMAGE_LIKE_RE.match(value))
+
+
+def _check_image(value: str, allow: set[str]) -> str | None:
+    """Return a violation message for an image ref, or None if it is compliant."""
+    if value in allow:
+        return None
+    if not DIGEST_RE.search(value):
+        tag = value.split("@")[0].split(":")[-1] if (":" in value or "@" in value) else ""
+        if tag in ("latest", "main", "master", "stable", "edge", "") and ":" in value:
+            return f"floating tag ':{tag}' — pin an immutable @sha256 digest"
+        return "image is not pinned to an immutable @sha256 digest"
+    return None
+
+
+def _check_chart_rev(rev) -> str | None:
+    if rev is None or rev == "":
+        return "chart targetRevision is missing/empty — pin an exact SemVer"
+    rev = str(rev)
+    if rev in ("latest", "main", "master", "stable"):
+        return f"chart targetRevision '{rev}' is floating — pin an exact SemVer"
+    if RANGE_CHARS_RE.search(rev):
+        return f"chart targetRevision '{rev}' is a range/wildcard — pin an exact SemVer"
+    if not EXACT_SEMVER_RE.match(rev):
+        return f"chart targetRevision '{rev}' is not an exact SemVer"
+    return None
+
+
+def _normalize_repo(url: str) -> str:
+    return url.rstrip("/").removesuffix(".git")
+
+
+def _check_git_rev(repo_url: str, rev) -> str | None:
+    rev = "" if rev is None else str(rev)
+    first_party = {_normalize_repo(fp) for fp in FIRST_PARTY_REPOS}
+    if _normalize_repo(repo_url) in first_party:
+        return None  # first-party GitOps self-reference may track a branch
+    if COMMIT_SHA_RE.match(rev):
+        return None
+    # Allow an exact tag pin for third-party repos too.
+    if EXACT_SEMVER_RE.match(rev):
+        return None
+    return f"git source '{repo_url}' targetRevision '{rev}' is not an immutable 40-hex commit"
+
+
+def _walk_images(node, out: list):
+    """Yield every value under an 'image' key anywhere in the structure."""
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k == "image" and _is_image_ref(v):
+                out.append(v)
+            _walk_images(v, out)
+    elif isinstance(node, list):
+        for item in node:
+            _walk_images(item, out)
+
+
+def _walk_sources(node, out: list):
+    """Yield Argo CD source mappings (dicts that have a repoURL)."""
+    if isinstance(node, dict):
+        if "repoURL" in node and isinstance(node.get("repoURL"), str):
+            out.append(node)
+        for v in node.values():
+            _walk_sources(v, out)
+    elif isinstance(node, list):
+        for item in node:
+            _walk_sources(item, out)
+
+
+def scan_text(path: str, text: str, allow: set[str] | None = None) -> list[Violation]:
+    """Scan a single manifest body. ``allow`` overrides the on-disk allowlist."""
+    allow = load_allowlist() if allow is None else allow
+    violations: list[Violation] = []
+    try:
+        docs = list(yaml.safe_load_all(text))
+    except yaml.YAMLError as exc:  # surface unparseable YAML as a violation
+        return [Violation(path, 1, "yaml", path, f"YAML parse error: {exc}")]
+
+    for doc in docs:
+        if doc is None:
+            continue
+        images: list = []
+        _walk_images(doc, images)
+        for ref in images:
+            msg = _check_image(ref, allow)
+            if msg:
+                violations.append(Violation(path, _line_of(text, ref), "image", ref, msg))
+
+        sources: list = []
+        _walk_sources(doc, sources)
+        for src in sources:
+            repo = src["repoURL"]
+            rev = src.get("targetRevision")
+            if "chart" in src:  # Helm chart source
+                msg = _check_chart_rev(rev)
+                if msg:
+                    violations.append(
+                        Violation(path, _line_of(text, str(rev)) if rev else 1, "chart", f"{src['chart']}@{rev}", msg)
+                    )
+            else:  # git source
+                msg = _check_git_rev(repo, rev)
+                if msg:
+                    violations.append(Violation(path, _line_of(text, repo), "git", f"{repo}@{rev}", msg))
+    return violations
+
+
+def scan_repo(root: str) -> list[Violation]:
+    allow = load_allowlist()
+    violations: list[Violation] = []
+    for scan_dir in SCAN_DIRS:
+        base = os.path.join(root, scan_dir)
+        for dirpath, _dirs, files in os.walk(base):
+            for name in sorted(files):
+                if not name.endswith((".yaml", ".yml")):
+                    continue
+                full = os.path.join(dirpath, name)
+                rel = os.path.relpath(full, root)
+                with open(full, encoding="utf-8") as fh:
+                    text = fh.read()
+                violations.extend(
+                    Violation(rel, v.line, v.kind, v.ref, v.message)
+                    for v in scan_text(rel, text, allow=allow)
+                )
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    root = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
+    violations = scan_repo(root)
+    if violations:
+        print(f"✗ {len(violations)} pin-policy violation(s):\n")
+        for v in violations:
+            print(f"  {v.file}:{v.line}  [{v.kind}]  {v.ref}\n      {v.message}")
+        print("\nPin an immutable digest/version, or add a documented exception to")
+        print("  scripts/pin-policy-allowlist.yaml")
+        return 1
+    print("✓ source pin policy: direct image/chart/git references are pinned")
+    print("  (rendered Helm defaults are checked separately by render_platform_charts.py)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -692,6 +692,8 @@ def sync_gated_apps_for_local_dev [] {
             error make {msg: $"ArgoCD Application ($app) was not created by the root app"}
         }
 
+        let previous_state = (kubectl get application $app -n argocd -o json | from json)
+        let previous_finished = ($previous_state | get -o status.operationState.finishedAt | default "")
         print $"  Syncing gated Application: ($app)"
         let sync_result = (do {
             kubectl patch application $app -n argocd --type merge -p $sync_payload
@@ -700,21 +702,35 @@ def sync_gated_apps_for_local_dev [] {
             error make {msg: $"Could not start sync for ($app): ($sync_result.stderr | str trim)"}
         }
 
-        mut healthy = false
+        mut completed = false
+        mut saw_new_operation = false
         for attempt in 1..90 {
-            let health_result = (do {
-                kubectl get application $app -n argocd -o jsonpath='{.status.health.status}'
+            let state_result = (do {
+                kubectl get application $app -n argocd -o json
             } | complete)
-            if $health_result.exit_code == 0 and ($health_result.stdout | str trim) == "Healthy" {
-                $healthy = true
-                break
+            if $state_result.exit_code == 0 {
+                let state = ($state_result.stdout | from json)
+                let phase = ($state | get -o status.operationState.phase | default "")
+                let finished = ($state | get -o status.operationState.finishedAt | default "")
+                let sync = ($state | get -o status.sync.status | default "")
+                let health = ($state | get -o status.health.status | default "")
+                if $phase == "Running" or $finished != $previous_finished {
+                    $saw_new_operation = true
+                }
+                if $saw_new_operation and $phase in ["Failed" "Error"] {
+                    error make {msg: $"Gated Application ($app) sync failed with phase ($phase)"}
+                }
+                if $saw_new_operation and $phase == "Succeeded" and $sync == "Synced" and $health == "Healthy" {
+                    $completed = true
+                    break
+                }
             }
             sleep 10sec
         }
-        if not $healthy {
-            error make {msg: $"Gated Application ($app) did not become Healthy within 15 minutes"}
+        if not $completed {
+            error make {msg: $"Gated Application ($app) did not complete a new successful Synced+Healthy operation within 15 minutes"}
         }
-        print $"(ansi green)  ✓ ($app) Healthy(ansi reset)"
+        print $"(ansi green)  ✓ ($app) sync Succeeded, Synced and Healthy(ansi reset)"
     }
 }
 
@@ -754,25 +770,28 @@ def wait_for_argocd_apps [] {
     loop {
         $attempts = $attempts + 1
         if $attempts > $max_attempts {
-            print $"(ansi yellow)Warning: Timeout waiting for all apps. Check ArgoCD UI for status.(ansi reset)"
-            break
+            error make {msg: "Timeout waiting for every required ArgoCD Application to become Synced and Healthy"}
         }
         
-        mut healthy_count = 0
+        mut ready_count = 0
         
         for app in $apps {
-            let status = (do { 
-                kubectl get application $app -n argocd -o jsonpath='{.status.health.status}' 
+            let status = (do {
+                kubectl get application $app -n argocd -o json
             } | complete)
-            
-            if $status.exit_code == 0 and ($status.stdout | str trim) == "Healthy" {
-                $healthy_count = $healthy_count + 1
+            if $status.exit_code == 0 {
+                let state = ($status.stdout | from json)
+                let health = ($state | get -o status.health.status | default "")
+                let sync = ($state | get -o status.sync.status | default "")
+                if $health == "Healthy" and $sync == "Synced" {
+                    $ready_count = $ready_count + 1
+                }
             }
         }
-        
-        print $"  Apps healthy: ($healthy_count)/($apps | length) [attempt ($attempts)/($max_attempts)]"
-        
-        if $healthy_count == ($apps | length) {
+
+        print $"  Apps Synced+Healthy: ($ready_count)/($apps | length) [attempt ($attempts)/($max_attempts)]"
+
+        if $ready_count == ($apps | length) {
             $all_healthy = true
             break
         }

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -156,6 +156,10 @@ def "main bootstrap" [] {
     print "1.9 Building custom OpenCost UI image..."
     build_opencost_ui_image
 
+    # 10. Build & load the Tier-1 DigiOrg images (Keycloak, Fluentd) — Issue #275
+    print "1.10 Building Tier-1 DigiOrg images (Keycloak, Fluentd)..."
+    build_tier1_images
+
     print ""
     print $"(ansi green_bold)✓ Phase 1 Bootstrap complete(ansi reset)"
 }
@@ -248,13 +252,20 @@ def install_gateway_api [] {
 # Required before ArgoCD deploys any ServiceMonitor resources.
 # kube-prometheus-stack (grafana, Wave 2) will later adopt and manage these CRDs.
 def install_prometheus_crds [] {
-    let prom_op_version = "v0.82.2"
+    let prom_op_version = "v0.92.1"  # Issue #275: aligned with kube-prometheus-stack 87.17.0 (prometheus-operator v0.92.1)
     let base_url = $"https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/($prom_op_version)/example/prometheus-operator-crd"
 
     let crds = [
-        "monitoring.coreos.com_servicemonitors.yaml"
+        "monitoring.coreos.com_alertmanagerconfigs.yaml"
+        "monitoring.coreos.com_alertmanagers.yaml"
         "monitoring.coreos.com_podmonitors.yaml"
+        "monitoring.coreos.com_probes.yaml"
+        "monitoring.coreos.com_prometheusagents.yaml"
+        "monitoring.coreos.com_prometheuses.yaml"
         "monitoring.coreos.com_prometheusrules.yaml"
+        "monitoring.coreos.com_scrapeconfigs.yaml"
+        "monitoring.coreos.com_servicemonitors.yaml"
+        "monitoring.coreos.com_thanosrulers.yaml"
     ]
 
     for crd in $crds {
@@ -264,7 +275,7 @@ def install_prometheus_crds [] {
         if $result.exit_code == 0 {
             print $"(ansi green)✓ ($crd) installed(ansi reset)"
         } else {
-            print $"(ansi yellow)⚠ ($crd): ($result.stderr | str trim)(ansi reset)"
+            error make {msg: $"Failed to install Prometheus Operator CRD ($crd): ($result.stderr | str trim)"}
         }
     }
 }
@@ -399,6 +410,18 @@ def create_platform_namespaces_secrets [] {
         --from-literal=GITEA_DB_PASSWORD=($gitea_db_password)
         --from-literal=SONARQUBE_DB_PASSWORD=($sonarqube_db_password)
         --from-literal=HARBOR_DB_PASSWORD=($harbor_db_password)
+        --dry-run=client -o yaml | kubectl apply -f -)
+
+    # CNPG superuser secret (Issue #275, Tier-3 migration). CloudNativePG requires
+    # its superuserSecret to be a kubernetes.io/basic-auth Secret with
+    # username=postgres + password (the Opaque postgresql-secrets above cannot be
+    # reused: a Secret's type is immutable). Reuse the SAME postgres_password so
+    # the init Job (auths with POSTGRES_PASSWORD) connects. Used by the CNPG
+    # Cluster in platform/base/cnpg/cluster.yaml.
+    (kubectl create secret generic postgresql-cnpg-superuser -n platform-db
+        --type=kubernetes.io/basic-auth
+        --from-literal=username=postgres
+        --from-literal=password=($postgres_password)
         --dry-run=client -o yaml | kubectl apply -f -)
     
     # Keycloak namespace and DB credentials secret
@@ -548,7 +571,12 @@ def install_argocd [] {
     helm repo add argo https://argoproj.github.io/argo-helm
     helm repo update
 
+    # Issue #275: pin the bootstrap chart explicitly so a clean install is
+    # reproducible. argo-cd 10.1.4 ships Argo CD app v3.4.5. Keep in sync with
+    # the ARGOCD_CHART_VERSION comment in docs/guides/platform-versions.md and
+    # the second (OIDC CA) helm upgrade below.
     (helm upgrade --install argocd argo/argo-cd
+        --version 10.1.4
         --namespace argocd
         --create-namespace
         --values platform/base/argocd/values.yaml
@@ -561,25 +589,40 @@ def install_argocd [] {
 
 # Build the custom subpath-aware OpenCost UI image and load it into the kind
 # cluster (Issue #272 Option B). The opencost ArgoCD app (wave 2) selects this
-# image via platform/base/opencost/values.yaml with pullPolicy IfNotPresent, so
-# it must exist in the node before the opencost pod schedules. build.nu is the
-# single source of truth for how the image is built (pinned upstream v1.120.4 +
-# vite_basename=/opencost) and is a cross-platform Nushell script. Non-fatal on
-# failure so the rest of bootstrap can proceed — the opencost UI pod simply
-# stays pending until the image is loaded.
+# image via platform/base/opencost/values.yaml with pullPolicy Never, so it must
+# exist in the node before the opencost pod schedules. build.nu is the single
+# source of truth for how the image is built (pinned upstream v1.120.4 +
+# vite_basename=/opencost). Missing Docker or a failed build aborts bootstrap.
 def build_opencost_ui_image [] {
     if (which docker | length) == 0 {
-        print $"(ansi yellow)○ docker not found — skipping OpenCost UI image build.(ansi reset)"
-        print "  Build & load manually once docker is available:"
-        print "    nu platform/base/opencost/ui-image/build.nu"
-        return
+        error make {msg: "Docker is required to build the local OpenCost UI image"}
     }
     try {
         nu platform/base/opencost/ui-image/build.nu
         print $"(ansi green)✓ Custom OpenCost UI image built and loaded.(ansi reset)"
-    } catch {
-        print $"(ansi yellow)Warning: OpenCost UI image build failed — the opencost UI pod(ansi reset)"
-        print $"(ansi yellow)will stay pending until you run build.nu manually.(ansi reset)"
+    } catch {|err|
+        error make {msg: $"OpenCost UI image build failed: ($err.msg)"}
+    }
+}
+
+# Build & kind-load the Tier-1 DigiOrg images (Issue #275): the pinned,
+# production-optimized Keycloak image and the pinned Fluentd log-forwarder image.
+# Both use pullPolicy Never and must exist in the kind node before their pods
+# schedule. Fail closed: never fall back to an untrusted public namespace.
+def build_tier1_images [] {
+    if (which docker | length) == 0 {
+        error make {msg: "Docker is required to build the local Keycloak and Fluentd images"}
+    }
+    for spec in [
+        {name: "Keycloak", path: "platform/images/keycloak/build.nu"}
+        {name: "Fluentd",  path: "platform/images/fluentd/build.nu"}
+    ] {
+        try {
+            nu $spec.path
+            print $"(ansi green)✓ ($spec.name) image built and loaded.(ansi reset)"
+        } catch {|err|
+            error make {msg: $"($spec.name) image build failed: ($err.msg)"}
+        }
     }
 }
 
@@ -599,7 +642,7 @@ def deploy_root_app [] {
     print "ArgoCD Sync Waves:"
     print "  Wave -1: root-app (just deployed)"
     print "  Wave  0: cert-manager, cnpg, external-secrets, nats, postgresql"
-    print "  Wave  1: keycloak, argocd (self-managed)"
+    print "  Wave  1: cnpg-cluster, keycloak, argocd (self-managed)"
     print "  Wave  2: backstage, gitea, grafana, harbor, jaeger, landingpage, opencost, sonarqube"
     print "  Wave  3: crossplane, kyverno, opensearch"
     print "  Wave  4: crossplane-providers, fluentd, kyverno-policies"
@@ -608,11 +651,71 @@ def deploy_root_app [] {
     print "  Wave  7: crossplane-xrds"
     print "  Wave  8: core-catalog"
 
+    # The repository keeps major upgrades manual so a Git merge cannot trigger
+    # them concurrently in a shared cluster. This script targets only the named
+    # local KinD environment; invoking `main up` is the explicit approval to sync
+    # its gated apps sequentially.
+    sync_gated_apps_for_local_dev
+
     # Wait for apps to sync
     print ""
     print $"(ansi cyan_bold)Phase 3: Waiting for ArgoCD Apps(ansi reset)"
     print "────────────────────────────────────"
     wait_for_argocd_apps
+}
+
+# Explicitly promote gated major upgrades on the disposable local KinD cluster.
+# Shared/production clusters must follow docs/guides/platform-versions.md instead.
+def sync_gated_apps_for_local_dev [] {
+    let gated_apps = [
+        "external-secrets", "nats", "grafana", "opencost", "gitea",
+        "sonarqube", "crossplane", "crossplane-providers",
+        "crossplane-provider-configs", "crossplane-xrds", "core-catalog"
+    ]
+    let sync_payload = '{"operation":{"sync":{"prune":true,"syncOptions":["CreateNamespace=true","ServerSideApply=true"]}}}'
+
+    print ""
+    print $"(ansi cyan_bold)Promoting gated upgrades sequentially on local KinD(ansi reset)"
+    for app in $gated_apps {
+        mut exists = false
+        for attempt in 1..60 {
+            let get_result = (do {
+                kubectl get application $app -n argocd -o name
+            } | complete)
+            if $get_result.exit_code == 0 {
+                $exists = true
+                break
+            }
+            sleep 2sec
+        }
+        if not $exists {
+            error make {msg: $"ArgoCD Application ($app) was not created by the root app"}
+        }
+
+        print $"  Syncing gated Application: ($app)"
+        let sync_result = (do {
+            kubectl patch application $app -n argocd --type merge -p $sync_payload
+        } | complete)
+        if $sync_result.exit_code != 0 {
+            error make {msg: $"Could not start sync for ($app): ($sync_result.stderr | str trim)"}
+        }
+
+        mut healthy = false
+        for attempt in 1..90 {
+            let health_result = (do {
+                kubectl get application $app -n argocd -o jsonpath='{.status.health.status}'
+            } | complete)
+            if $health_result.exit_code == 0 and ($health_result.stdout | str trim) == "Healthy" {
+                $healthy = true
+                break
+            }
+            sleep 10sec
+        }
+        if not $healthy {
+            error make {msg: $"Gated Application ($app) did not become Healthy within 15 minutes"}
+        }
+        print $"(ansi green)  ✓ ($app) Healthy(ansi reset)"
+    }
 }
 
 # Wait for ArgoCD apps to become healthy
@@ -627,7 +730,7 @@ def wait_for_argocd_apps [] {
         # Wave 0
         "cert-manager", "cnpg", "external-secrets", "nats", "postgresql",
         # Wave 1
-        "keycloak", "argocd",
+        "cnpg-cluster", "keycloak", "argocd",
         # Wave 2
         "backstage", "gitea", "grafana", "harbor", "jaeger", "landingpage", "opencost", "sonarqube",
         # Wave 3
@@ -1121,6 +1224,7 @@ rootCA: |\n($indented_cert)
     # so ArgoCD self-sync will not overwrite it
     print "  Running helm upgrade to embed CA cert in ArgoCD release..."
     (helm upgrade argocd argo/argo-cd
+        --version 10.1.4
         --namespace argocd
         --reuse-values
         --values platform/base/argocd/values.yaml

--- a/scripts/pin-policy-allowlist.yaml
+++ b/scripts/pin-policy-allowlist.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Pin-policy allowlist — documented exceptions to scripts/check_pins.py
+# =============================================================================
+# Every entry MUST carry a rationale. Exceptions are limited to images that are
+# built locally and loaded into the kind cluster (pullPolicy Never/IfNotPresent)
+# and are therefore never pulled from a registry, so a registry digest is neither
+# available nor meaningful. Their reproducibility is guaranteed instead by the
+# build definition under platform/images/<name>/ (pinned upstream release +
+# immutable base-image digest + OCI provenance labels).
+#
+# Third-party registry images must NOT appear here — they are pinned by digest
+# directly in the manifest.
+images:
+  - ref: "opencost-ui:v1.120.4-basename-opencost"
+    reason: >-
+      DigiOrg Tier-1 image built by platform/base/opencost/ui-image/build.nu from
+      upstream opencost-ui v1.120.4 (commit 6384abbf) and kind-loaded with
+      pullPolicy Never. Not pulled from a registry (Issue #272 / #275).
+
+  - ref: "digiorg/keycloak:26.7.0-optimized"
+    reason: >-
+      DigiOrg Tier-1 image built by platform/images/keycloak/build.nu from
+      upstream quay.io/keycloak/keycloak:26.7.0 (digest-pinned base) with
+      `kc.sh build --optimized`. Kind-loaded with pullPolicy Never; realm data
+      stays outside the image (Issue #275).
+
+  - ref: "digiorg/fluentd:v1.19.2-debian-opensearch-1.0"
+    reason: >-
+      DigiOrg Tier-1 image built by platform/images/fluentd/build.nu from upstream
+      fluent/fluentd-kubernetes-daemonset:v1.19.2-debian-opensearch-1.0
+      (digest-pinned base) with pinned fluent-plugin gem versions. Kind-loaded,
+      pullPolicy Never (Issue #275).

--- a/scripts/render_platform_charts.py
+++ b/scripts/render_platform_charts.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Render every Argo CD Helm source and reject floating rendered images.
+
+This complements check_pins.py: chart defaults are invisible in source manifests.
+Exact chart packages may still emit exact tag-only transitive images; those are
+reported so digest migration remains visible, while floating tags fail CI.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+IMAGE_RE = re.compile(r"^\s*image:\s*[\"']?([^\"'\s]+)", re.MULTILINE)
+FLOATING_RE = re.compile(r"(?i)(?::|^)(latest|main|master|head)$")
+
+
+def sources(app: dict) -> list[dict]:
+    spec = app.get("spec", {})
+    return spec.get("sources") or ([spec["source"]] if "source" in spec else [])
+
+
+def values_files(app: dict, source: dict, tmp: Path) -> list[Path]:
+    helm = source.get("helm", {})
+    result: list[Path] = []
+    inline = helm.get("values")
+    if inline:
+        path = tmp / f"{app['metadata']['name']}-inline-values.yaml"
+        path.write_text(inline, encoding="utf-8")
+        result.append(path)
+    for value_file in helm.get("valueFiles", []):
+        if value_file.startswith("$values/"):
+            result.append(ROOT / value_file.removeprefix("$values/"))
+        elif not value_file.startswith("$"):
+            result.append(ROOT / value_file)
+    return result
+
+
+def image_is_floating(ref: str) -> bool:
+    base = ref.split("@", 1)[0]
+    last = base.rsplit("/", 1)[-1]
+    if ":" not in last:
+        return True
+    return bool(FLOATING_RE.search(last.rsplit(":", 1)[1]))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", default="/tmp/platform-helm-renders")
+    args = parser.parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rendered = 0
+    floating: list[str] = []
+    tag_only: set[str] = set()
+
+    with tempfile.TemporaryDirectory(prefix="platform-chart-values-") as td:
+        tmp = Path(td)
+        for app_path in sorted((ROOT / "apps/platform").glob("*.yaml")):
+            app = yaml.safe_load(app_path.read_text(encoding="utf-8"))
+            for source in sources(app):
+                if "chart" not in source:
+                    continue
+                name = app["metadata"]["name"]
+                out = output_dir / f"{name}.yaml"
+                cmd = [
+                    "helm", "template", name, source["chart"],
+                    "--repo", source["repoURL"],
+                    "--version", str(source["targetRevision"]),
+                    "--namespace", app["spec"]["destination"]["namespace"],
+                    "--include-crds",
+                ]
+                for path in values_files(app, source, tmp):
+                    if not path.is_file():
+                        raise FileNotFoundError(f"{app_path}: values file not found: {path}")
+                    cmd.extend(["-f", str(path)])
+                proc = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True)
+                if proc.returncode:
+                    sys.stderr.write(proc.stderr)
+                    return proc.returncode
+                out.write_text(proc.stdout, encoding="utf-8")
+                rendered += 1
+                for ref in IMAGE_RE.findall(proc.stdout):
+                    # CRD OpenAPI schemas contain `image: description:` prose;
+                    # only OCI-like scalar references participate in the policy.
+                    if ref.endswith(":"):
+                        continue
+                    if image_is_floating(ref):
+                        floating.append(f"{name}: {ref}")
+                    elif "@sha256:" not in ref:
+                        tag_only.add(f"{name}: {ref}")
+
+    if tag_only:
+        print("Rendered exact tag-only images (remaining digest work):")
+        for item in sorted(tag_only):
+            print(f"  WARN {item}")
+    if floating:
+        print("Floating rendered images:", file=sys.stderr)
+        for item in floating:
+            print(f"  ERROR {item}", file=sys.stderr)
+        return 1
+    print(f"HELM_RENDER_PASS={rendered}; no floating rendered image tags")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/resolve_digest.py
+++ b/scripts/resolve_digest.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Resolve an immutable ``@sha256:`` digest for a container image tag.
+
+Companion to ``scripts/check_pins.py``: the pin policy requires a human-readable
+tag *plus* an immutable digest, and this tool produces the digest without Docker
+by talking to the registry v2 API directly (anonymous pull tokens). It backs the
+"record a human-readable version tag plus an immutable digest" workflow for
+Docker Hub, Quay, GHCR and ``registry.k8s.io``.
+
+Usage::
+
+    python3 scripts/resolve_digest.py quay.io/keycloak/keycloak:26.7.0
+    python3 scripts/resolve_digest.py ghcr.io/cloudnative-pg/postgresql:16.9
+    python3 scripts/resolve_digest.py postgres:16-alpine     # Docker Hub library
+
+Prints ``<registry>/<repo>:<tag>@sha256:<digest>`` on success. Network access to
+the registry is required; on failure it exits non-zero with a clear message so a
+human can pin the digest by hand from a documented source.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+
+_UA = {"User-Agent": "digiorg-resolve-digest"}
+_ACCEPT = ",".join(
+    (
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    )
+)
+
+
+def _get(url: str, headers: dict):
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.headers, resp.read()
+
+
+def parse_ref(ref: str):
+    """Split an image reference into (registry, repository, tag)."""
+    if "@" in ref:
+        ref = ref.split("@", 1)[0]
+    tag = "latest"
+    # Only treat the last ':' as a tag separator if it is not part of a host:port.
+    if ":" in ref.rsplit("/", 1)[-1]:
+        ref, tag = ref.rsplit(":", 1)
+    if "/" not in ref:  # Docker Hub official image, e.g. "postgres"
+        registry, repo = "registry-1.docker.io", f"library/{ref}"
+    else:
+        head, rest = ref.split("/", 1)
+        if "." in head or ":" in head or head == "localhost":
+            registry, repo = head, rest
+        else:  # Docker Hub namespaced, e.g. "fluent/fluentd-..."
+            registry, repo = "registry-1.docker.io", ref
+    if registry == "docker.io":
+        registry = "registry-1.docker.io"
+    return registry, repo, tag
+
+
+def _token(registry: str, repo: str):
+    if registry == "registry-1.docker.io":
+        url = f"https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repo}:pull"
+    elif registry == "ghcr.io":
+        url = f"https://ghcr.io/token?scope=repository:{repo}:pull"
+    else:
+        return None  # quay.io and registry.k8s.io allow anonymous manifest reads
+    return json.loads(_get(url, _UA)[1]).get("token")
+
+
+def resolve(ref: str) -> str:
+    registry, repo, tag = parse_ref(ref)
+    headers = dict(_UA)
+    headers["Accept"] = _ACCEPT
+    token = _token(registry, repo)
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    hdr, _ = _get(f"https://{registry}/v2/{repo}/manifests/{tag}", headers)
+    digest = hdr.get("Docker-Content-Digest")
+    if not digest:
+        raise RuntimeError(f"registry did not return a digest for {ref}")
+    display_repo = repo[len("library/"):] if repo.startswith("library/") and registry == "registry-1.docker.io" else repo
+    prefix = "" if registry == "registry-1.docker.io" and "/" not in display_repo else f"{registry}/"
+    if registry != "registry-1.docker.io":
+        prefix = f"{registry}/"
+    return f"{prefix}{display_repo}:{tag}@{digest}"
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        sys.stderr.write(__doc__ or "")
+        return 2
+    rc = 0
+    for ref in argv:
+        try:
+            print(resolve(ref))
+        except Exception as exc:  # noqa: BLE001 - CLI boundary
+            sys.stderr.write(f"ERROR resolving {ref}: {exc}\n")
+            rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Stages the code-side implementation of #275: exact chart/application pins, immutable direct-image references, CI guardrails, DigiOrg Keycloak/Fluentd images, Harbor proxy-cache provisioning, safe major-upgrade gates, and a coexistence-first CloudNativePG migration.

This PR intentionally **does not close #275**. The repository changes and static/render validation are complete, but the issue also requires real-cluster migration, backup/restore, smoke-test, Harbor pull-through, and final CNPG cutover evidence that cannot be produced without a Kubernetes/container runtime.

## Changes

### Pinning and CI

- Adds `scripts/check_pins.py`, a documented allowlist, a registry digest resolver, full Helm-source rendering, Make targets, and a GitHub Actions validation workflow.
- Rejects floating direct image references, non-exact chart versions, and mutable third-party Git revisions.
- Pins direct runtime images by human-readable tag plus OCI digest; fixes mutable chart defaults for Gitea, SonarQube, NATS, OpenSearch, and Kyverno hooks.
- Pins GitHub Actions to commit SHAs and CI tooling (`helm` 4.2.3, `kustomize` 5.8.1, Nushell 0.114.1, PyYAML 6.0.3) with archive/wheel checksums.

### Component versions

| Component | Pinned target |
| --- | --- |
| Argo CD | chart 10.1.4 |
| kube-prometheus-stack | 87.17.0 |
| CloudNativePG operator | 0.29.0 |
| External Secrets | 2.7.0 |
| Kyverno | 3.8.1 |
| OpenSearch | 3.7.0 |
| NATS | 2.14.2 |
| OpenCost | 2.5.27 |
| Gitea | 12.6.0 / app 1.26.1 |
| SonarQube | 2026.3.1 / Community Build 26.5.0.122743 |
| Crossplane | 2.3.3 |
| cert-manager | v1.20.1 |
| oauth2-proxy | v7.15.3 |

Harbor 1.19.1 and Jaeger 4.11.1 remain pinned after compatibility validation. Crossplane providers are pinned to provider-kubernetes v1.2.1, provider-helm v1.3.0, and provider-http v1.0.14.

### Major-upgrade safety

- Major migrations omit `syncPolicy.automated` and carry `platform.digiorg.io/upgrade-gate: issue-275-manual` so a merge cannot launch all CRD/database/operator migrations concurrently.
- Shared clusters promote ESO, NATS, monitoring, OpenCost, Gitea, SonarQube, then the five Crossplane/provider/XRD/catalog Applications one at a time.
- The disposable local KinD bootstrap explicitly starts those gated Argo syncs sequentially and requires a new operation to finish `Succeeded`, `Synced`, and `Healthy`; stale health cannot advance the sequence.
- Preserves the OpenCost `/opencost/`, `/opencost`, and `/opencost/model` contract from #274.

### Images and Harbor

- Adds Nushell builds, pinned base digests, OCI provenance labels, `imagePullPolicy: Never`, fail-closed local bootstrap, and regression tests for optimized Keycloak and Fluentd images.
- Adds bounded Harbor proxy-cache project/registry provisioning for Docker Hub, Quay, GHCR, and registry.k8s.io; conflicts are read back and verified rather than blindly accepted.
- Fixes the Harbor 1.19 ServiceMonitor duplicate-label render error and updates Prometheus discovery accordingly.

### CloudNativePG

- Adds the CNPG Cluster, isolated database/bootstrap workload, dedicated `kubernetes.io/basic-auth` superuser Secret provisioning, and a non-conflicting cutover Service artifact.
- Keeps the legacy PostgreSQL StatefulSet during coexistence; the alias is deliberately excluded from the synced Kustomization until cutover.
- Binds database passwords as quoted `psql` variables rather than interpolating Secret values into SQL.
- Adds private, verified, atomic logical backup snapshots with retention and documents ownership-preserving restore, a mandatory final frozen full restore, an observed two-Application service handoff, stateful reverse-restore/RPO requirements, and deferred legacy cleanup.

## Verification performed

- `make test` — **185 tests passed**.
- `python3 scripts/check_pins.py` — passed.
- YAML parse — **119 files**, no errors.
- Helm 4.2.3 — **12 Argo CD Helm sources rendered** with their real inline/repository values; no floating rendered image tags.
- kubeconform 0.8.0 strict mode — all 12 Helm renders passed (`-ignore-missing-schemas` for CRDs).
- Kustomize — **20 bases rendered** and passed the same kubeconform validation.
- Nushell 0.114.1 — **4 scripts parsed** with no diagnostics.
- `python3 -m py_compile` — new Python scripts/tests passed.
- `git diff --check` — passed.
- Direct image digests were resolved again against their registries.
- Current Crossplane provider and supporting upstream Git tags were verified through the GitHub API.

### Not executable in this environment

- Docker builds / kind image loading (no Docker daemon).
- Empty-cluster bootstrap and Kubernetes API-server dry run (no Kubernetes runtime/kubectl/kind).
- Stateful database migrations, backup/restore evidence, Argo `Synced`/`Healthy`, workload readiness, ingress/OAuth/persistence integrations, and security scanning of running images.
- Harbor pull-through/offline-repeat validation.
- Final PostgreSQL Service cutover and legacy StatefulSet removal.

## Remaining #275 acceptance work

- Run the gated promotions one at a time on a disposable cluster and record component-level smoke/rollback evidence.
- Verify Harbor pull-through and scanning, then decide the bootstrap-safe rewrite for chart-managed/transitive images. Exact chart packages still select some sidecars/operators that do not expose digest fields directly.
- Replace the remaining rendered exact tag-only chart images with digest overrides as their charts expose supported values; CI now lists these references instead of falsely claiming they are digest-pinned.
- Lock or vendor/checksum Fluentd's transitive Ruby dependencies; the base and direct plugin versions are pinned, but the documentation now explicitly avoids claiming full build reproducibility.
- Execute and verify the CNPG data migration, enable the alias Service, then remove the legacy workload only after consumer validation.
- Confirm the clean local bootstrap and the complete platform smoke matrix.

## Review notes

The implementation was produced with Claude Code as the requested coding subagent and then independently exercised and corrected before commit. Please review the migration gates and residual runtime evidence carefully; do not merge this PR as if the operational acceptance criteria were already complete.

Refs #275
