### PR TITLE
fix(keycloak): persist optimized HTTP paths

### DIFF
--- a/.github/workflows/platform-validation.yml
+++ b/.github/workflows/platform-validation.yml
@@ -42,6 +42,15 @@ jobs:
       - name: Pin policy (reject floating / unpinned references)
         run: python3 scripts/check_pins.py
 
+      - name: Install Nushell for behavioral tests
+        run: |
+          set -euo pipefail
+          NU_VERSION=0.114.1
+          curl -fsSL "https://github.com/nushell/nushell/releases/download/${NU_VERSION}/nu-${NU_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o /tmp/nu.tgz
+          echo '8802b26edcdf1a64477567b5ce909fbae3d72d731c8f0847892ea16c6fa73c53  /tmp/nu.tgz' | sha256sum -c -
+          mkdir -p /tmp/nu && tar xzf /tmp/nu.tgz -C /tmp/nu --strip-components=1
+          sudo install -m 0755 /tmp/nu/nu /usr/local/bin/nu
+
       - name: Platform regression tests
         run: python3 -m unittest discover -s platform/tests -p 'test_*.py' -v
 

--- a/platform/images/keycloak/Dockerfile
+++ b/platform/images/keycloak/Dockerfile
@@ -27,6 +27,8 @@ FROM ${UPSTREAM_IMAGE}:${UPSTREAM_TAG}@${UPSTREAM_DIGEST} AS builder
 ENV KC_DB=postgres
 ENV KC_HEALTH_ENABLED=true
 ENV KC_METRICS_ENABLED=true
+ENV KC_HTTP_RELATIVE_PATH=/keycloak
+ENV KC_HTTP_MANAGEMENT_RELATIVE_PATH=/
 
 # Produce the augmented/optimized distribution under /opt/keycloak.
 RUN /opt/keycloak/bin/kc.sh build

--- a/platform/images/keycloak/build.nu
+++ b/platform/images/keycloak/build.nu
@@ -44,6 +44,43 @@ const IMAGE = "digiorg/keycloak"
 const TAG = "26.7.0-optimized"
 const REGISTRY_REPOSITORY = "keycloak"
 
+def validate_persisted_result [result: record] {
+    if $result.exit_code != 0 {
+        error make {msg: $"persisted Keycloak configuration check exited with code ($result.exit_code)"}
+    }
+
+    let persisted_config = (
+        $result.stdout
+        | lines
+        | each {|line| $line | str replace -ar '\s+' ' ' | str trim }
+    )
+    let expected = [
+        { name: "db", value: "postgres" }
+        { name: "health-enabled", value: "true" }
+        { name: "metrics-enabled", value: "true" }
+        { name: "http-relative-path", value: "/keycloak" }
+        { name: "http-management-relative-path", value: "/" }
+    ]
+    for option in $expected {
+        let persisted_line = ($"kc.($option.name) = ($option.value) " + "(Persisted)")
+        if not ($persisted_config | any {|line| $line == $persisted_line }) {
+            error make {msg: $"built image does not persist kc.($option.name)=($option.value)"}
+        }
+    }
+}
+
+def validate_persisted_config [image: string] {
+    let result = (
+        ^docker run
+            --rm
+            --entrypoint /opt/keycloak/bin/kc.sh
+            $image
+            show-config
+        | complete
+    )
+    validate_persisted_result $result
+}
+
 def main [] {
     # --- Behaviour toggles / registry (overridable via environment) --------- #
     let registry = ($env.REGISTRY? | default "digiorg.local/library")
@@ -89,6 +126,8 @@ def main [] {
     )
 
     print $">> Built ($IMAGE):($TAG)"
+    validate_persisted_config $"($IMAGE):($TAG)"
+    print "   verified: optimized Keycloak configuration is persisted"
 
     if $load == "1" {
         print $">> Loading ($IMAGE):($TAG) into kind cluster '($kind_cluster)'"

--- a/platform/tests/test_ci_pin_policy.py
+++ b/platform/tests/test_ci_pin_policy.py
@@ -103,6 +103,18 @@ class CiWorkflowTest(unittest.TestCase):
         self.assertIn("KUSTOMIZE_VERSION=v5.8.1", workflow)
         self.assertNotIn("kustomize/master/hack/install_kustomize.sh", workflow)
 
+    def test_nushell_is_installed_before_platform_regression_tests(self):
+        workflow = next(
+            text for text in self.texts.values() if "scripts/check_pins.py" in text
+        )
+        marker = "Install Nushell for behavioral tests"
+        self.assertIn(marker, workflow)
+        self.assertLess(
+            workflow.index(marker),
+            workflow.index("Platform regression tests"),
+            "behavioral .nu tests require the pinned Nushell binary before Python tests run",
+        )
+
     def test_workflows_are_valid_yaml(self):
         for path, text in self.texts.items():
             try:

--- a/platform/tests/test_keycloak_image.py
+++ b/platform/tests/test_keycloak_image.py
@@ -38,11 +38,13 @@
 #                          port/probe/relative-path/hostname setting, and keeps
 #                          the realm data in the mounted configMap volume.
 #
-# Runs with the standard library + PyYAML only (no pytest, cluster or network):
+# Runs with the standard library + PyYAML + the repository-pinned Nushell
+# binary (no pytest, cluster, Docker daemon or network):
 #     python3 platform/tests/test_keycloak_image.py
 # =============================================================================
 import os
 import re
+import subprocess
 import unittest
 
 import yaml
@@ -81,6 +83,25 @@ class BuildContractTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.script = read_text(BUILD_NU)
+
+    def _validate_persisted_result(self, output, exit_code=0):
+        env = os.environ.copy()
+        env["KEYCLOAK_TEST_OUTPUT"] = output
+        env["KEYCLOAK_TEST_EXIT_CODE"] = str(exit_code)
+        source_path = BUILD_NU.replace("\\", "/")
+        command = (
+            'source "%s"; '
+            'validate_persisted_result {'
+            'exit_code: ($env.KEYCLOAK_TEST_EXIT_CODE | into int), '
+            'stdout: $env.KEYCLOAK_TEST_OUTPUT}'
+        ) % source_path
+        return subprocess.run(
+            ["nu", "-c", command],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
 
     def _const(self, name):
         m = re.search(
@@ -190,6 +211,101 @@ class BuildContractTest(unittest.TestCase):
         self.assertIn("docker push", self.script,
                       "build.nu must support an optional Harbor push")
 
+    def test_validates_finished_image_persisted_configuration(self):
+        validator = re.search(
+            r"def validate_persisted_config \[image: string\] \{(?P<body>.*?)\n\}",
+            self.script,
+            re.S,
+        )
+        self.assertIsNotNone(
+            validator,
+            "build.nu must define a post-build persisted-config validator",
+        )
+        body = validator.group("body")
+        self.assertIn("docker run", body)
+        self.assertIn("--rm", body)
+        self.assertIn("--entrypoint /opt/keycloak/bin/kc.sh", body)
+        self.assertIn("show-config", body)
+        self.assertIn("| complete", body, "show-config failures must be captured")
+        self.assertIn("validate_persisted_result $result", body)
+
+        result_validator = re.search(
+            r"def validate_persisted_result \[result: record\] \{(?P<body>.*?)\n\}",
+            self.script,
+            re.S,
+        )
+        self.assertIsNotNone(
+            result_validator,
+            "build.nu must expose the result validation as testable Nushell behavior",
+        )
+        result_body = result_validator.group("body")
+        for name, value in (
+            ("db", "postgres"),
+            ("health-enabled", "true"),
+            ("metrics-enabled", "true"),
+            ("http-relative-path", "/keycloak"),
+            ("http-management-relative-path", "/"),
+        ):
+            self.assertRegex(
+                result_body,
+                r'name:\s*"%s"\s*,?\s*value:\s*"%s"'
+                % (re.escape(name), re.escape(value)),
+                "validator must require kc.%s = %s" % (name, value),
+            )
+        self.assertIn("(Persisted)", result_body)
+        self.assertIn("error make", result_body)
+
+        validation_call = 'validate_persisted_config $"($IMAGE):($TAG)"'
+        self.assertIn(validation_call, self.script)
+        self.assertLess(self.script.index("docker build"), self.script.index(validation_call))
+        self.assertLess(
+            self.script.index(validation_call),
+            self.script.index("kind load docker-image"),
+            "the finished image must be validated before it is loaded or pushed",
+        )
+        self.assertLess(
+            self.script.index(validation_call),
+            self.script.index("docker push"),
+            "the finished image must be validated before it is pushed",
+        )
+
+    def test_persisted_config_validator_accepts_real_variable_whitespace(self):
+        output = """
+            kc.health-enabled =  true (Persisted)
+        kc.metrics-enabled    = true   (Persisted)
+        kc.db =  postgres (Persisted)
+        kc.http-relative-path =   /keycloak (Persisted)
+        kc.http-management-relative-path = / (Persisted)
+        """
+        result = self._validate_persisted_result(output)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_persisted_config_validator_rejects_wrong_value(self):
+        output = """
+        kc.db = postgres (Persisted)
+        kc.health-enabled = true (Persisted)
+        kc.metrics-enabled = true (Persisted)
+        kc.http-relative-path = / (Persisted)
+        kc.http-management-relative-path = / (Persisted)
+        """
+        result = self._validate_persisted_result(output)
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_persisted_config_validator_requires_persisted_marker(self):
+        output = """
+        kc.db = postgres (Persisted)
+        kc.health-enabled = true (Persisted)
+        kc.metrics-enabled = true (Persisted)
+        kc.http-relative-path = /keycloak
+        kc.http-management-relative-path = / (Persisted)
+        """
+        result = self._validate_persisted_result(output)
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_persisted_config_validator_rejects_show_config_failure(self):
+        result = self._validate_persisted_result("", exit_code=2)
+        self.assertNotEqual(result.returncode, 0)
+
 
 class DockerfileContractTest(unittest.TestCase):
     """Multi-stage, digest-pinned, production-optimized, realm-data-free."""
@@ -236,6 +352,41 @@ class DockerfileContractTest(unittest.TestCase):
                           "must enable health at build time")
         self.assertRegex(self.text, r"KC_METRICS_ENABLED[= ]+true",
                           "must enable metrics at build time")
+
+    def test_builder_persists_complete_deployment_build_time_contract(self):
+        docs = load_yaml_docs(DEPLOYMENT)
+        deploy = next(d for d in docs if d.get("kind") == "Deployment")
+        container = deploy["spec"]["template"]["spec"]["containers"][0]
+        deployment_env = {
+            entry["name"]: str(entry["value"])
+            for entry in container.get("env", [])
+            if "value" in entry
+        }
+        expected_build_time = {
+            "KC_DB": "postgres",
+            "KC_HEALTH_ENABLED": "true",
+            "KC_METRICS_ENABLED": "true",
+            "KC_HTTP_RELATIVE_PATH": "/keycloak",
+            "KC_HTTP_MANAGEMENT_RELATIVE_PATH": "/",
+        }
+
+        builder_before_build = self.text.split("RUN /opt/keycloak/bin/kc.sh build", 1)[0]
+        builder_env = dict(
+            re.findall(r"^ENV\s+(KC_[A-Z_]+)[= ]([^\s]+)\s*$", builder_before_build, re.M)
+        )
+
+        for name, expected in expected_build_time.items():
+            if name in deployment_env:
+                self.assertEqual(
+                    deployment_env[name], expected,
+                    "%s must retain the image's persisted value at runtime" % name,
+                )
+            self.assertEqual(
+                builder_env.get(name),
+                expected,
+                "%s must be persisted before kc.sh build with the platform value"
+                % name,
+            )
 
     def test_final_stage_copies_optimized_build(self):
         self.assertRegex(


### PR DESCRIPTION
## Summary

- persist Keycloak's `/keycloak` application path and `/` management path before `kc.sh build`
- keep the optimized image's build-time settings aligned with the Deployment contract
- validate the finished image with `kc.sh show-config` before it can be loaded into KinD or pushed
- normalize `show-config` whitespace so the validator matches real Keycloak 26.7 output on Windows
- behaviorally reject wrong values, missing persisted markers, and failed `show-config` executions
- add regression coverage for both persisted path settings and the post-build validation gate
- install the pinned Nushell binary before CI's Python regression suite so behavioral `.nu` tests execute in CI

## Root cause

The optimized image persisted the database, health, and metrics options but not `KC_HTTP_RELATIVE_PATH` or `KC_HTTP_MANAGEMENT_RELATIVE_PATH`. Both path options are build-time settings in Keycloak 26.7. The Deployment supplied them only at runtime while invoking `start --optimized`, causing Keycloak to reject the mismatch and exit with code 2.

## Test evidence

TDD evidence from the implementation:

- RED: the builder contract test reported `KC_HTTP_RELATIVE_PATH: None != '/keycloak'`
- RED: the post-build validator test failed because `validate_persisted_config` did not exist
- RED during independent review: the first source-only validator test did not exercise real Nushell behavior
- RED: behavioral execution exposed invalid interpolation of the literal `(Persisted)` marker
- GREEN: four behavioral Nushell validator cases passed, including the exact variable-whitespace format observed on Windows
- GREEN: all 29 Keycloak image/deployment tests passed
- GREEN: `make test` — 192 tests passed
- GREEN: `python3 scripts/check_pins.py`
- GREEN: Nushell parser sweep — 4 files passed
- GREEN: Python compile check and `git diff --check`
- GREEN: added-line static security scan

## Runtime verification

This execution environment has no Docker daemon or KinD runtime, so it could not rebuild and boot the image here. The build script now performs the image-level `show-config` check automatically before load/push. Final clean Windows Docker Desktop/KinD validation remains part of the issue acceptance test after this branch is checked out.

Closes #277
