### PR TITLE
fix(platform): stabilize fresh KinD bootstrap and gated sync

### DIFF
--- a/apps/platform/core-catalog.yaml
+++ b/apps/platform/core-catalog.yaml
@@ -14,9 +14,9 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core-catalog.git
-    # Pinned to specific commit to prevent silent breaking changes from HEAD.
-    # Update this SHA deliberately after validating compatibility with the core wave 0-7 stack.
-    targetRevision: 0ced57eb40a50ec170352ce4a59bffedd4a16a6c
+    # Crossplane v2 removed native `spec.resources` Compositions. This commit
+    # migrates the local catalog to function-patch-and-transform Pipeline mode.
+    targetRevision: 4c30d9c3fa5c3c401c19f26b66a025854c65ee02
     path: compositions/local
 
   destination:

--- a/apps/platform/grafana.yaml
+++ b/apps/platform/grafana.yaml
@@ -28,11 +28,27 @@ spec:
     server: https://kubernetes.default.svc
     namespace: monitoring
 
+  # kube-prometheus-stack generates Grafana's initial admin password on every
+  # render when no explicit password is supplied. Preserve only that generated
+  # key and its rollout checksum; all other Secret data remains drift-managed.
+  ignoreDifferences:
+    - group: ""
+      kind: Secret
+      name: prometheus-grafana
+      jsonPointers:
+        - /data/admin-password
+    - group: apps
+      kind: Deployment
+      name: prometheus-grafana
+      jsonPointers:
+        - /spec/template/metadata/annotations/checksum~1secret
+
   syncPolicy:
     # Major Prometheus Operator/CRD migration: promote and validate manually.
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      - RespectIgnoreDifferences=true
     retry:
       limit: 5
       backoff:

--- a/apps/platform/harbor.yaml
+++ b/apps/platform/harbor.yaml
@@ -27,29 +27,32 @@ spec:
     server: https://kubernetes.default.svc
     namespace: harbor
   # The chart generates these internal values with randAlphaNum on every Helm
-  # render. Ignore only their data and the corresponding rollout checksums;
+  # render. Ignore only those generated keys and corresponding rollout checksums;
   # all other Secret metadata and Deployment fields remain drift-managed.
   ignoreDifferences:
     - group: ""
       kind: Secret
       name: harbor-core
       jsonPointers:
-        - /data
+        - /data/CSRF_KEY
+        - /data/secret
+        - /data/tls.crt
+        - /data/tls.key
     - group: ""
       kind: Secret
       name: harbor-jobservice
       jsonPointers:
-        - /data
+        - /data/JOBSERVICE_SECRET
     - group: ""
       kind: Secret
       name: harbor-registry
       jsonPointers:
-        - /data
+        - /data/REGISTRY_HTTP_SECRET
     - group: ""
       kind: Secret
       name: harbor-registry-htpasswd
       jsonPointers:
-        - /data
+        - /data/REGISTRY_HTPASSWD
     - group: apps
       kind: Deployment
       name: harbor-core

--- a/apps/platform/harbor.yaml
+++ b/apps/platform/harbor.yaml
@@ -26,6 +26,49 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: harbor
+  # The chart generates these internal values with randAlphaNum on every Helm
+  # render. Ignore only their data and the corresponding rollout checksums;
+  # all other Secret metadata and Deployment fields remain drift-managed.
+  ignoreDifferences:
+    - group: ""
+      kind: Secret
+      name: harbor-core
+      jsonPointers:
+        - /data
+    - group: ""
+      kind: Secret
+      name: harbor-jobservice
+      jsonPointers:
+        - /data
+    - group: ""
+      kind: Secret
+      name: harbor-registry
+      jsonPointers:
+        - /data
+    - group: ""
+      kind: Secret
+      name: harbor-registry-htpasswd
+      jsonPointers:
+        - /data
+    - group: apps
+      kind: Deployment
+      name: harbor-core
+      jsonPointers:
+        - /spec/template/metadata/annotations/checksum~1secret
+        - /spec/template/metadata/annotations/checksum~1secret-jobservice
+    - group: apps
+      kind: Deployment
+      name: harbor-jobservice
+      jsonPointers:
+        - /spec/template/metadata/annotations/checksum~1secret
+        - /spec/template/metadata/annotations/checksum~1secret-core
+    - group: apps
+      kind: Deployment
+      name: harbor-registry
+      jsonPointers:
+        - /spec/template/metadata/annotations/checksum~1secret
+        - /spec/template/metadata/annotations/checksum~1secret-core
+        - /spec/template/metadata/annotations/checksum~1secret-jobservice
   syncPolicy:
     automated:
       selfHeal: true
@@ -33,6 +76,7 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      - RespectIgnoreDifferences=true
     retry:
       limit: 5
       backoff:

--- a/apps/platform/kyverno.yaml
+++ b/apps/platform/kyverno.yaml
@@ -98,7 +98,52 @@ spec:
       kind: CustomResourceDefinition
       jqPathExpressions:
         - '.spec.conversion | select(.strategy == "None")'
-        - '.metadata.labels | select(length == 0)'
+    # Chart 3.8.1 renders an empty labels map on only these policy-v2 CRDs;
+    # kube-apiserver drops it. Scope the normalization exception by exact name.
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: deletingpolicies.policies.kyverno.io
+      jsonPointers: [/metadata/labels]
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: generatingpolicies.policies.kyverno.io
+      jsonPointers: [/metadata/labels]
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: imagevalidatingpolicies.policies.kyverno.io
+      jsonPointers: [/metadata/labels]
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: mutatingpolicies.policies.kyverno.io
+      jsonPointers: [/metadata/labels]
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: namespaceddeletingpolicies.policies.kyverno.io
+      jsonPointers: [/metadata/labels]
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: namespacedgeneratingpolicies.policies.kyverno.io
+      jsonPointers: [/metadata/labels]
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: namespacedimagevalidatingpolicies.policies.kyverno.io
+      jsonPointers: [/metadata/labels]
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: namespacedmutatingpolicies.policies.kyverno.io
+      jsonPointers: [/metadata/labels]
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: namespacedvalidatingpolicies.policies.kyverno.io
+      jsonPointers: [/metadata/labels]
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: policyexceptions.policies.kyverno.io
+      jsonPointers: [/metadata/labels]
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: validatingpolicies.policies.kyverno.io
+      jsonPointers: [/metadata/labels]
 
   syncPolicy:
     automated:

--- a/apps/platform/kyverno.yaml
+++ b/apps/platform/kyverno.yaml
@@ -20,11 +20,20 @@ spec:
       values: |
         # Kyverno Helm values for local development
         # Reduced resource requests for KinD
-        # Keep the chart's v1.18 CRD migration hook explicit for this upgrade.
         # The removed policyReportsCleanup value is intentionally not used.
+        #
+        # Issue #279: crds.migration.enabled renders a Helm post-upgrade hook
+        # (kyverno-migrate-resources). Helm itself only runs post-upgrade hooks
+        # on `helm upgrade`, never on a fresh `helm install` — but Argo CD
+        # renders via `helm template` and maps post-upgrade/post-install hooks
+        # onto PostSync for every sync, with no install-vs-upgrade distinction.
+        # On a brand-new disposable cluster there is no prior Kyverno CRD state
+        # to migrate, so the hook was pure churn. Disabled for this clean-install
+        # baseline; see docs/guides/platform-versions.md for how to re-enable it
+        # for a real upgrade with prior Kyverno state.
         crds:
           migration:
-            enabled: true
+            enabled: false
         admissionController:
           replicas: 1
           container:

--- a/apps/platform/kyverno.yaml
+++ b/apps/platform/kyverno.yaml
@@ -91,6 +91,14 @@ spec:
     server: https://kubernetes.default.svc
     namespace: kyverno
 
+  # Kubernetes defaults absent CRD conversion blocks to strategy=None. Ignore
+  # only that API-added object; any declared webhook conversion remains managed.
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jqPathExpressions:
+        - '.spec.conversion | select(.strategy == "None")'
+
   syncPolicy:
     automated:
       selfHeal: true

--- a/apps/platform/kyverno.yaml
+++ b/apps/platform/kyverno.yaml
@@ -98,6 +98,7 @@ spec:
       kind: CustomResourceDefinition
       jqPathExpressions:
         - '.spec.conversion | select(.strategy == "None")'
+        - '.metadata.labels | select(length == 0)'
 
   syncPolicy:
     automated:

--- a/apps/platform/kyverno.yaml
+++ b/apps/platform/kyverno.yaml
@@ -34,6 +34,12 @@ spec:
         crds:
           migration:
             enabled: false
+        # The kyverno-api subchart otherwise emits labels: {} on policy-v2
+        # CRDs, which kube-apiserver normalizes away and Argo CD reports as
+        # perpetual drift. Render one stable label instead of ignoring metadata.
+        kyverno-api:
+          labels:
+            app.kubernetes.io/managed-by: kyverno
         admissionController:
           replicas: 1
           container:
@@ -98,52 +104,6 @@ spec:
       kind: CustomResourceDefinition
       jqPathExpressions:
         - '.spec.conversion | select(.strategy == "None")'
-    # Chart 3.8.1 renders an empty labels map on only these policy-v2 CRDs;
-    # kube-apiserver drops it. Scope the normalization exception by exact name.
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: deletingpolicies.policies.kyverno.io
-      jsonPointers: [/metadata/labels]
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: generatingpolicies.policies.kyverno.io
-      jsonPointers: [/metadata/labels]
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: imagevalidatingpolicies.policies.kyverno.io
-      jsonPointers: [/metadata/labels]
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: mutatingpolicies.policies.kyverno.io
-      jsonPointers: [/metadata/labels]
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: namespaceddeletingpolicies.policies.kyverno.io
-      jsonPointers: [/metadata/labels]
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: namespacedgeneratingpolicies.policies.kyverno.io
-      jsonPointers: [/metadata/labels]
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: namespacedimagevalidatingpolicies.policies.kyverno.io
-      jsonPointers: [/metadata/labels]
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: namespacedmutatingpolicies.policies.kyverno.io
-      jsonPointers: [/metadata/labels]
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: namespacedvalidatingpolicies.policies.kyverno.io
-      jsonPointers: [/metadata/labels]
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: policyexceptions.policies.kyverno.io
-      jsonPointers: [/metadata/labels]
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: validatingpolicies.policies.kyverno.io
-      jsonPointers: [/metadata/labels]
 
   syncPolicy:
     automated:

--- a/apps/platform/nats.yaml
+++ b/apps/platform/nats.yaml
@@ -28,7 +28,8 @@ spec:
       targetRevision: main
       ref: values
 
-    # Surveyor, oauth2-proxy, namespace via Kustomize
+    # Surveyor and its Service via Kustomize. The messaging Namespace is owned
+    # centrally by the namespaces Application.
     - repoURL: https://github.com/digiorg/core.git
       targetRevision: main
       path: platform/base/nats
@@ -36,6 +37,18 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: messaging
+
+  # Kubernetes persists a status field inside each StatefulSet PVC template.
+  # Argo CD 3.4.5 does not normalize that nested status, which otherwise leaves
+  # the healthy NATS StatefulSet permanently OutOfSync after every successful
+  # server-side apply. Ignore only this API-populated status field.
+  ignoreDifferences:
+    - group: apps
+      kind: StatefulSet
+      name: nats
+      namespace: messaging
+      jqPathExpressions:
+        - .spec.volumeClaimTemplates[]?.status
 
   syncPolicy:
     # Major chart migration with JetStream persistence: promote manually.

--- a/apps/platform/opensearch.yaml
+++ b/apps/platform/opensearch.yaml
@@ -35,6 +35,18 @@ spec:
     server: https://kubernetes.default.svc
     namespace: platform-db
 
+  # The chart omits immutable PVC-template type/default fields that Kubernetes
+  # stores on the StatefulSet. Ignore only those API defaults and status.
+  ignoreDifferences:
+    - group: apps
+      kind: StatefulSet
+      name: opensearch-cluster-master
+      jqPathExpressions:
+        - '.spec.volumeClaimTemplates[]?.apiVersion'
+        - '.spec.volumeClaimTemplates[]?.kind'
+        - '.spec.volumeClaimTemplates[]?.spec.volumeMode'
+        - '.spec.volumeClaimTemplates[]?.status'
+
   syncPolicy:
     automated:
       selfHeal: true

--- a/apps/platform/postgresql.yaml
+++ b/apps/platform/postgresql.yaml
@@ -20,6 +20,14 @@ spec:
     server: https://kubernetes.default.svc
     namespace: platform-db
 
+  # Kubernetes maintains PVC-template status internally on StatefulSets.
+  ignoreDifferences:
+    - group: apps
+      kind: StatefulSet
+      name: postgresql
+      jqPathExpressions:
+        - '.spec.volumeClaimTemplates[]?.status'
+
   syncPolicy:
     automated:
       selfHeal: true

--- a/crossplane/providers/packages/function-patch-and-transform.yaml
+++ b/crossplane/providers/packages/function-patch-and-transform.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-patch-and-transform
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.10.7

--- a/crossplane/providers/packages/kustomization.yaml
+++ b/crossplane/providers/packages/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - provider-kubernetes.yaml
   - provider-helm.yaml
   - provider-http.yaml
+  - function-patch-and-transform.yaml

--- a/docs/guides/platform-versions.md
+++ b/docs/guides/platform-versions.md
@@ -83,7 +83,7 @@ Third-party images record a human-readable tag **plus** an immutable digest:
 | `docker.gitea.com/gitea` | 1.26.1 | Gitea chart primary/init image |
 | `sonarqube` | 26.5.0.122743-community | SonarQube Community Build |
 | `ghcr.io/kyverno/readiness-checker` | v1.18.1 | Kyverno chart test/cleanup hooks |
-| `ghcr.io/digiorg/core-portal` | 48d262e | Backstage (release tag + digest, was `latest`) |
+| `ghcr.io/digiorg/core-portal` | b77e94a | Backstage — core-portal `main` HEAD (Issue #279; was initial-scaffold commit `48d262e`) |
 | `ghcr.io/digiorg/core-landingpage` | 32a6777 | Landing page (release tag + digest, was `main`) |
 
 ### Tier-1 DigiOrg-built images (allow-listed, kind-loaded)
@@ -174,6 +174,28 @@ where noted (this environment has no cluster — see section 7).
   compatible for the fake-provider dev store). Verify every `SecretStore`/
   `ExternalSecret` in downstream repos is on `v1` before upgrading.
 - **Rollback:** revert the chart pin; v1 CRs are also accepted by 0.14.x.
+
+### Kyverno 3.8.1 CRD migration hook — clean install vs. upgrade (Issue #279)
+- `crds.migration.enabled` (chart default `true`) renders a Helm
+  **post-upgrade** hook Job (`kyverno-migrate-resources`) that migrates CRD
+  contents from a prior Kyverno release. Helm only runs `post-upgrade` hooks on
+  `helm upgrade`, never on a fresh `helm install` — but Argo CD renders every
+  chart with `helm template` and maps `post-upgrade`/`post-install` hooks onto
+  `PostSync` for **every** sync, with no install-vs-upgrade distinction. On a
+  brand-new disposable cluster there is no prior Kyverno CRD state, so the hook
+  fired as pure churn on every sync of a clean bootstrap (confirmed in issue
+  #279).
+- `apps/platform/kyverno.yaml` therefore pins `crds.migration.enabled: false`
+  as the clean-install baseline used by `nu scripts/local-setup.nu up` and by
+  default on any freshly-provisioned cluster.
+- **To perform a real upgrade** of an existing cluster that has prior Kyverno
+  CRD data (e.g. hopping across a Kyverno release that changes CRD storage):
+  1. In a dedicated commit, set `crds.migration.enabled: true` in
+     `apps/platform/kyverno.yaml`.
+  2. Sync only the `kyverno` Application and confirm the
+     `kyverno-migrate-resources` Job completes successfully.
+  3. Revert `crds.migration.enabled` back to `false` in a follow-up commit so
+     the next clean bootstrap does not re-run the migration hook.
 
 ### kube-prometheus-stack 72.6.2 → 87.17.0
 - CRDs are pre-installed at prometheus-operator **v0.92.1** by `local-setup.nu`

--- a/platform/base/argocd/values.yaml
+++ b/platform/base/argocd/values.yaml
@@ -167,14 +167,30 @@ applicationSet:
       memory: 256Mi
 
 # -- Repo server
+# Issue #279: the app-of-apps root Application triggers many concurrent
+# Git/Helm/Kustomize comparisons at once. Under the original 50m/64Mi request
+# (500m/256Mi limit) with the chart's default 1s probe timeout, repo-server
+# missed its /healthz?full=true liveness deadline during that initial burst,
+# kubelet restarted it mid-render, and the severed gRPC stream surfaced as
+# `ComparisonError ... rpc error: code = Unavailable desc = error reading from
+# server: EOF` on whichever Application was rendering at that moment
+# (confirmed on both Windows and Linux KinD). Raised requests/limits and probe
+# timeouts so repo-server survives the initial render burst instead of
+# flapping.
 repoServer:
   resources:
     requests:
-      cpu: 50m
-      memory: 64Mi
-    limits:
-      cpu: 500m
+      cpu: 200m
       memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  readinessProbe:
+    timeoutSeconds: 5
+    failureThreshold: 5
+  livenessProbe:
+    timeoutSeconds: 5
+    failureThreshold: 5
 
 # -- Redis
 redis:

--- a/platform/base/backstage/deployment.yaml
+++ b/platform/base/backstage/deployment.yaml
@@ -32,7 +32,7 @@ spec:
               echo "PostgreSQL is ready!"
       containers:
         - name: backstage
-          image: ghcr.io/digiorg/core-portal:48d262e@sha256:8736f4195b06ab8fe0dbe3b806cd538771f61e7f53dedd4f11dc6ad7e2ff644f
+          image: ghcr.io/digiorg/core-portal:b77e94a@sha256:44d00aba125e1e66d712222ec7f64cbc7cce02f05e5f05146af5af996bfe19dd
           imagePullPolicy: Always
           ports:
             - containerPort: 7007

--- a/platform/base/backstage/kustomization.yaml
+++ b/platform/base/backstage/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 namespace: backstage
 
 resources:
-  - namespace.yaml
   - rbac.yaml
   - deployment.yaml
   - service.yaml

--- a/platform/base/backstage/namespace.yaml
+++ b/platform/base/backstage/namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: backstage
-  labels:
-    app.kubernetes.io/name: backstage
-    app.kubernetes.io/part-of: digiorg-platform

--- a/platform/base/cert-manager/kustomization.yaml
+++ b/platform/base/cert-manager/kustomization.yaml
@@ -7,3 +7,17 @@ resources:
   # Issuers and certificates (applied after cert-manager CRDs are ready)
   - cluster-issuers.yaml
   - certificate-dev.yaml
+
+# The upstream bundle includes Namespace/cert-manager, but namespace ownership is
+# centralized in platform/base/namespaces. Remove the duplicate resource.
+patches:
+  - target:
+      version: v1
+      kind: Namespace
+      name: cert-manager
+    patch: |-
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: cert-manager
+      $patch: delete

--- a/platform/base/cnpg/init-databases.yaml
+++ b/platform/base/cnpg/init-databases.yaml
@@ -154,6 +154,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: postgresql-cnpg-backups
   namespace: platform-db
+  annotations:
+    # local-path binds on first consumer; this PVC is intentionally idle until
+    # the scheduled backup runs and must not block Argo CD application health.
+    argocd.argoproj.io/ignore-healthcheck: "true"
 spec:
   accessModes:
     - ReadWriteOnce

--- a/platform/base/fluentd/kustomization.yaml
+++ b/platform/base/fluentd/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 namespace: logging
 
 resources:
-  - namespace.yaml
   - rbac.yaml
   - configmap.yaml
   - daemonset.yaml

--- a/platform/base/fluentd/namespace.yaml
+++ b/platform/base/fluentd/namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: logging
-  labels:
-    app.kubernetes.io/part-of: digiorg-core-platform
-    app.kubernetes.io/component: logging

--- a/platform/base/gitea/kustomization.yaml
+++ b/platform/base/gitea/kustomization.yaml
@@ -3,9 +3,11 @@ kind: Kustomization
 
 namespace: gitea
 
-resources:
-  - namespace.yaml
+resources: []
 
+# Namespace 'gitea' is owned centrally by platform/base/namespaces (issue #279)
+# — do not re-add namespace.yaml here.
+#
 # Note: The main Gitea deployment is handled via Helm chart
 # referenced in the ArgoCD Application (apps/platform/gitea.yaml).
 # This Kustomization provides supporting resources.

--- a/platform/base/gitea/namespace.yaml
+++ b/platform/base/gitea/namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: gitea
-  labels:
-    app.kubernetes.io/name: gitea
-    app.kubernetes.io/part-of: digiorg-platform

--- a/platform/base/harbor/harbor-proxy-cache-job.yaml
+++ b/platform/base/harbor/harbor-proxy-cache-job.yaml
@@ -125,7 +125,9 @@ spec:
                   echo "ERROR: could not resolve registry ${registry_name} id (HTTP ${code})" >&2; return 1
                 fi
                 tr -d '[:space:]' < "${body}" \
-                  | tr ',' '\n' | grep -o '"id":[0-9]*' | head -1 | grep -o '[0-9]*'
+                  | tr '}' '\n' \
+                  | grep -F "\"name\":\"${registry_name}\"" \
+                  | grep -o '"id":[0-9]*' | head -1 | grep -o '[0-9]*'
               }
 
               # Create or verify a proxy-cache project bound to the registry.

--- a/platform/base/harbor/harbor-proxy-cache-job.yaml
+++ b/platform/base/harbor/harbor-proxy-cache-job.yaml
@@ -59,6 +59,17 @@ spec:
 
               CURL="curl --connect-timeout 5 --max-time 30 --retry 2"
 
+              # Harbor error responses contain only API error code/message for
+              # these non-secret payloads. Bound output to keep hook logs safe
+              # and useful without printing auth headers or environment values.
+              print_api_error() {
+                body="$1"
+                if [ -s "${body}" ]; then
+                  summary=$(tr '\n' ' ' < "${body}" | cut -c1-500)
+                  echo "    Harbor API response: ${summary}" >&2
+                fi
+              }
+
               echo "Waiting for Harbor API to be ready..."
               ready=false
               for attempt in $(seq 1 60); do
@@ -98,14 +109,20 @@ spec:
                       echo "ERROR: registry ${name} readback transport failure (curl exit ${curl_exit})" >&2; exit 1
                     fi
                     if [ "${readback_code}" != "200" ]; then
-                      echo "ERROR: could not read back registry ${name} (HTTP ${readback_code})"; exit 1
+                      echo "ERROR: could not read back registry ${name} (HTTP ${readback_code})" >&2
+                      print_api_error "${readback_body}"
+                      exit 1
                     fi
                     existing=$(tr -d '[:space:]' < "${readback_body}")
                     echo "$existing" | grep -Fq "\"type\":\"${rtype}\"" || { echo "ERROR: registry ${name} has wrong type"; exit 1; }
                     echo "$existing" | grep -Fq "\"url\":\"${url}\"" || { echo "ERROR: registry ${name} has wrong URL"; exit 1; }
                     echo "  registry ${name} already exists and matches"
                     ;;
-                  *) echo "ERROR: registry ${name} -> HTTP ${code}"; exit 1 ;;
+                  *)
+                    echo "ERROR: registry ${name} -> HTTP ${code}" >&2
+                    print_api_error "${create_body}"
+                    exit 1
+                    ;;
                 esac
               }
 
@@ -160,13 +177,19 @@ spec:
                       echo "ERROR: project ${project} readback transport failure (curl exit ${curl_exit})" >&2; exit 1
                     fi
                     if [ "${readback_code}" != "200" ]; then
-                      echo "ERROR: could not read back project ${project} (HTTP ${readback_code})"; exit 1
+                      echo "ERROR: could not read back project ${project} (HTTP ${readback_code})" >&2
+                      print_api_error "${readback_body}"
+                      exit 1
                     fi
                     existing=$(tr -d '[:space:]' < "${readback_body}")
                     echo "$existing" | grep -Fq "\"registry_id\":${regid}" || { echo "ERROR: project ${project} is not bound to registry ${regid}"; exit 1; }
                     echo "  proxy project ${project} already exists and matches"
                     ;;
-                  *) echo "ERROR: project ${project} -> HTTP ${code}"; exit 1 ;;
+                  *)
+                    echo "ERROR: project ${project} -> HTTP ${code}" >&2
+                    print_api_error "${create_body}"
+                    exit 1
+                    ;;
                 esac
               }
 

--- a/platform/base/harbor/harbor-proxy-cache-job.yaml
+++ b/platform/base/harbor/harbor-proxy-cache-job.yaml
@@ -74,16 +74,29 @@ spec:
               # Create or verify an upstream registry endpoint.
               create_registry() {
                 name="$1"; rtype="$2"; url="$3"
-                code=$(${CURL} -s -o /dev/null -w "%{http_code}" -X POST \
+                create_body="/tmp/harbor-registry-create-${name}.json"
+                set +e
+                code=$(${CURL} -s -o "${create_body}" -w "%{http_code}" -X POST \
                   -u "${AUTH}" -H "Content-Type: application/json" \
                   -d "{\"name\":\"${name}\",\"type\":\"${rtype}\",\"url\":\"${url}\",\"insecure\":false}" \
                   "${HARBOR_API}/registries")
+                curl_exit=$?
+                set -e
+                if [ "${curl_exit}" -ne 0 ]; then
+                  echo "ERROR: registry ${name} create transport failure (curl exit ${curl_exit})" >&2; exit 1
+                fi
                 case "$code" in
                   201) echo "  registry ${name} created" ;;
                   409)
                     readback_body="/tmp/harbor-registry-${name}.json"
+                    set +e
                     readback_code=$(${CURL} -s -o "${readback_body}" -w "%{http_code}" \
                       -u "${AUTH}" "${HARBOR_API}/registries?q=name%3D${name}")
+                    curl_exit=$?
+                    set -e
+                    if [ "${curl_exit}" -ne 0 ]; then
+                      echo "ERROR: registry ${name} readback transport failure (curl exit ${curl_exit})" >&2; exit 1
+                    fi
                     if [ "${readback_code}" != "200" ]; then
                       echo "ERROR: could not read back registry ${name} (HTTP ${readback_code})"; exit 1
                     fi
@@ -98,7 +111,20 @@ spec:
 
               # Resolve a registry's numeric id by name (curl-only, no jq).
               registry_id() {
-                ${CURL} -sf -u "${AUTH}" "${HARBOR_API}/registries?q=name%3D$1" \
+                registry_name="$1"
+                body="/tmp/harbor-registry-id-${registry_name}.json"
+                set +e
+                code=$(${CURL} -s -o "${body}" -w "%{http_code}" \
+                  -u "${AUTH}" "${HARBOR_API}/registries?q=name%3D${registry_name}")
+                curl_exit=$?
+                set -e
+                if [ "${curl_exit}" -ne 0 ]; then
+                  echo "ERROR: registry ${registry_name} id lookup transport failure (curl exit ${curl_exit})" >&2; return 1
+                fi
+                if [ "${code}" != "200" ]; then
+                  echo "ERROR: could not resolve registry ${registry_name} id (HTTP ${code})" >&2; return 1
+                fi
+                tr -d '[:space:]' < "${body}" \
                   | tr ',' '\n' | grep -o '"id":[0-9]*' | head -1 | grep -o '[0-9]*'
               }
 
@@ -108,16 +134,29 @@ spec:
                 if [ -z "${regid}" ]; then
                   echo "ERROR: could not resolve registry id for project ${project}"; exit 1
                 fi
-                code=$(${CURL} -s -o /dev/null -w "%{http_code}" -X POST \
+                create_body="/tmp/harbor-project-create-${project}.json"
+                set +e
+                code=$(${CURL} -s -o "${create_body}" -w "%{http_code}" -X POST \
                   -u "${AUTH}" -H "Content-Type: application/json" \
                   -d "{\"project_name\":\"${project}\",\"registry_id\":${regid},\"public\":true,\"metadata\":{\"public\":\"true\"},\"storage_limit\":-1}" \
                   "${HARBOR_API}/projects")
+                curl_exit=$?
+                set -e
+                if [ "${curl_exit}" -ne 0 ]; then
+                  echo "ERROR: project ${project} create transport failure (curl exit ${curl_exit})" >&2; exit 1
+                fi
                 case "$code" in
                   201) echo "  proxy project ${project} created" ;;
                   409)
                     readback_body="/tmp/harbor-project-${project}.json"
+                    set +e
                     readback_code=$(${CURL} -s -o "${readback_body}" -w "%{http_code}" \
                       -u "${AUTH}" "${HARBOR_API}/projects/${project}")
+                    curl_exit=$?
+                    set -e
+                    if [ "${curl_exit}" -ne 0 ]; then
+                      echo "ERROR: project ${project} readback transport failure (curl exit ${curl_exit})" >&2; exit 1
+                    fi
                     if [ "${readback_code}" != "200" ]; then
                       echo "ERROR: could not read back project ${project} (HTTP ${readback_code})"; exit 1
                     fi

--- a/platform/base/harbor/harbor-proxy-cache-job.yaml
+++ b/platform/base/harbor/harbor-proxy-cache-job.yaml
@@ -81,7 +81,13 @@ spec:
                 case "$code" in
                   201) echo "  registry ${name} created" ;;
                   409)
-                    existing=$(${CURL} -sf -u "${AUTH}" "${HARBOR_API}/registries?q=name%3D${name}" | tr -d '[:space:]')
+                    readback_body="/tmp/harbor-registry-${name}.json"
+                    readback_code=$(${CURL} -s -o "${readback_body}" -w "%{http_code}" \
+                      -u "${AUTH}" "${HARBOR_API}/registries?q=name%3D${name}")
+                    if [ "${readback_code}" != "200" ]; then
+                      echo "ERROR: could not read back registry ${name} (HTTP ${readback_code})"; exit 1
+                    fi
+                    existing=$(tr -d '[:space:]' < "${readback_body}")
                     echo "$existing" | grep -Fq "\"type\":\"${rtype}\"" || { echo "ERROR: registry ${name} has wrong type"; exit 1; }
                     echo "$existing" | grep -Fq "\"url\":\"${url}\"" || { echo "ERROR: registry ${name} has wrong URL"; exit 1; }
                     echo "  registry ${name} already exists and matches"
@@ -109,7 +115,13 @@ spec:
                 case "$code" in
                   201) echo "  proxy project ${project} created" ;;
                   409)
-                    existing=$(${CURL} -sf -u "${AUTH}" "${HARBOR_API}/projects/${project}" | tr -d '[:space:]')
+                    readback_body="/tmp/harbor-project-${project}.json"
+                    readback_code=$(${CURL} -s -o "${readback_body}" -w "%{http_code}" \
+                      -u "${AUTH}" "${HARBOR_API}/projects/${project}")
+                    if [ "${readback_code}" != "200" ]; then
+                      echo "ERROR: could not read back project ${project} (HTTP ${readback_code})"; exit 1
+                    fi
+                    existing=$(tr -d '[:space:]' < "${readback_body}")
                     echo "$existing" | grep -Fq "\"registry_id\":${regid}" || { echo "ERROR: project ${project} is not bound to registry ${regid}"; exit 1; }
                     echo "  proxy project ${project} already exists and matches"
                     ;;

--- a/platform/base/harbor/values.yaml
+++ b/platform/base/harbor/values.yaml
@@ -16,6 +16,14 @@ existingSecretAdminPassword: harbor-admin-secret
 existingSecretAdminPasswordKey: HARBOR_ADMIN_PASSWORD
 existingSecretSecretKey: harbor-secret-key
 
+# Chart 1.19.1 omits `quay` from Harbor's proxy-cache provider allowlist even
+# though Harbor 2.15 supports it. An explicit container env value overrides the
+# generated ConfigMap value and keeps every provider used by the GitOps hook.
+core:
+  extraEnvVars:
+    - name: PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE
+      value: "docker-hub,harbor,azure-acr,ali-acr,aws-ecr,google-gcr,quay,docker-registry,github-ghcr,jfrog-artifactory"
+
 # External PostgreSQL — reuse platform shared instance (platform-db namespace)
 # Harbor's built-in PostgreSQL disabled to reduce resource usage
 database:

--- a/platform/base/ingress/digiorg-ingress.yaml
+++ b/platform/base/ingress/digiorg-ingress.yaml
@@ -30,7 +30,6 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
     # TLS: cert-manager provisions and renews the certificate automatically
     # Switch issuer for staging/prod: letsencrypt-staging or letsencrypt-prod
-    cert-manager.io/cluster-issuer: "digiorg-local-ca-issuer"
     # Redirect all HTTP traffic to HTTPS
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
@@ -105,7 +104,6 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
-    cert-manager.io/cluster-issuer: "digiorg-local-ca-issuer"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
@@ -139,7 +137,6 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/proxy-body-size: "512m"  # Large Git pushes
-    cert-manager.io/cluster-issuer: "digiorg-local-ca-issuer"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:

--- a/platform/base/ingress/harbor-ingress.yaml
+++ b/platform/base/ingress/harbor-ingress.yaml
@@ -22,7 +22,6 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
-    cert-manager.io/cluster-issuer: "digiorg-local-ca-issuer"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:

--- a/platform/base/ingress/opencost-portal-ingress.yaml
+++ b/platform/base/ingress/opencost-portal-ingress.yaml
@@ -20,7 +20,6 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    cert-manager.io/cluster-issuer: "digiorg-local-ca-issuer"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:

--- a/platform/base/jaeger/kustomization.yaml
+++ b/platform/base/jaeger/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: tracing
 resources:
-  - namespace.yaml
   - oauth2-proxy.yaml

--- a/platform/base/jaeger/namespace.yaml
+++ b/platform/base/jaeger/namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: tracing
-  labels:
-    app.kubernetes.io/managed-by: argocd
-    platform.digiorg.io/component: observability

--- a/platform/base/namespaces/namespaces.yaml
+++ b/platform/base/namespaces/namespaces.yaml
@@ -1,4 +1,7 @@
 # Pre-created platform namespaces (Wave -1)
+# Namespace deletion is never an acceptable prune operation. Every object is
+# marked Prune=false, which also protects the one-time ownership transfer from
+# legacy component Applications that previously rendered their own Namespace.
 # Purpose: Eliminate 409 Conflict races when multiple Wave 2+ apps
 #          try to CreateNamespace=true for the same namespace simultaneously.
 #
@@ -13,6 +16,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: argocd
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -21,6 +26,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: monitoring
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -29,6 +36,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: tracing
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -37,6 +46,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: cost-monitoring
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -45,6 +56,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: harbor
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -53,6 +66,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: code-quality
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -61,6 +76,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: messaging
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -69,6 +86,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: cert-manager
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -77,6 +96,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: external-secrets
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -85,6 +106,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: keycloak
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -93,6 +116,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: platform-db
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -101,6 +126,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: cnpg
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -109,6 +136,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: crossplane-system
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -117,6 +146,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: kyverno
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -125,6 +156,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: gitea
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -133,6 +166,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: backstage
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -141,6 +176,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: landingpage
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -149,6 +186,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: opensearch
   labels:
     app.kubernetes.io/managed-by: argocd
@@ -157,6 +196,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   name: logging
   labels:
     app.kubernetes.io/managed-by: argocd

--- a/platform/base/nats/kustomization.yaml
+++ b/platform/base/nats/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 namespace: messaging
 
 resources:
-  - namespace.yaml
   - surveyor.yaml
   - grafana-dashboards.yaml
 

--- a/platform/base/nats/namespace.yaml
+++ b/platform/base/nats/namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: messaging
-  labels:
-    app.kubernetes.io/part-of: digiorg-core-platform
-    app.kubernetes.io/component: messaging

--- a/platform/base/nats/surveyor.yaml
+++ b/platform/base/nats/surveyor.yaml
@@ -23,6 +23,24 @@ spec:
         app.kubernetes.io/name: nats-surveyor
         app.kubernetes.io/component: observability
     spec:
+      initContainers:
+        - name: wait-for-nats
+          image: busybox:1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for NATS to be reachable..."
+              for attempt in $(seq 1 60); do
+                if nc -z nats.messaging.svc.cluster.local 4222; then
+                  echo "NATS is reachable."
+                  exit 0
+                fi
+                echo "  NATS not reachable yet (${attempt}/60), retrying in 5s..."
+                sleep 5
+              done
+              echo "ERROR: NATS did not become reachable within the timeout"
+              exit 1
       containers:
         - name: nats-surveyor
           image: natsio/nats-surveyor:0.9.10@sha256:3ba1d0e1f9e29a9f7481451097e39246d322cfd2e085aadefaec3b5141691746

--- a/platform/base/nats/values.yaml
+++ b/platform/base/nats/values.yaml
@@ -38,6 +38,15 @@ config:
 natsBox:
   enabled: false
 
+# Keep pod-template annotations non-null. Chart 2.14.2 otherwise renders
+# `metadata.annotations: null`; Kubernetes drops that null map and Argo CD 3.4.5
+# reports the StatefulSet OutOfSync after every successful apply (issue #279).
+podTemplate:
+  merge:
+    metadata:
+      annotations:
+        platform.digiorg.io/component: nats
+
 # Resource limits for the NATS container
 # Use container.merge (not podTemplate.merge.spec.containers) to avoid
 # generating a container entry without an image field (causes StatefulSet validation failure)

--- a/platform/base/nats/values.yaml
+++ b/platform/base/nats/values.yaml
@@ -12,6 +12,13 @@ config:
       pvc:
         enabled: true
         size: 1Gi
+        # Match API-defaulted fields persisted inside StatefulSet
+        # volumeClaimTemplates so Argo CD does not report false drift.
+        merge:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          spec:
+            volumeMode: Filesystem
 
   # Single-node for local dev (no clustering needed)
   cluster:

--- a/platform/base/opencost/values.yaml
+++ b/platform/base/opencost/values.yaml
@@ -16,7 +16,7 @@ opencost:
       enabled: false
     external:
       enabled: true
-      url: "http://prometheus-server.monitoring.svc.cluster.local:80"
+      url: "http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090"
 
   exporter:
     defaultClusterId: digiorg-core-dev

--- a/platform/base/postgresql/kustomization.yaml
+++ b/platform/base/postgresql/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 namespace: platform-db
 
 resources:
-  - namespace.yaml
   - statefulset.yaml
   - service.yaml
 

--- a/platform/base/postgresql/namespace.yaml
+++ b/platform/base/postgresql/namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: platform-db
-  labels:
-    app.kubernetes.io/name: postgresql
-    app.kubernetes.io/part-of: digiorg-platform

--- a/platform/base/postgresql/statefulset.yaml
+++ b/platform/base/postgresql/statefulset.yaml
@@ -151,11 +151,14 @@ spec:
             name: postgresql-init-scripts
             defaultMode: 0755
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: postgres-data
       spec:
         accessModes:
           - ReadWriteOnce
+        volumeMode: Filesystem
         resources:
           requests:
             storage: 5Gi

--- a/platform/base/sonarqube/kustomization.yaml
+++ b/platform/base/sonarqube/kustomization.yaml
@@ -3,9 +3,11 @@ kind: Kustomization
 
 namespace: code-quality
 
-resources:
-  - namespace.yaml
+resources: []
 
+# Namespace 'code-quality' is owned centrally by platform/base/namespaces
+# (issue #279) — do not re-add namespace.yaml here.
+#
 # SonarQube itself is deployed via Helm by the ArgoCD Application (apps/platform/sonarqube.yaml).
 # The following secrets must be created manually by local-setup.nu before ArgoCD sync:
 #   - sonarqube-db-secret          (SONAR_JDBC_PASSWORD)

--- a/platform/base/sonarqube/namespace.yaml
+++ b/platform/base/sonarqube/namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: code-quality
-  labels:
-    app.kubernetes.io/managed-by: argocd
-    platform.digiorg.io/component: code-quality

--- a/platform/base/sonarqube/values.yaml
+++ b/platform/base/sonarqube/values.yaml
@@ -12,12 +12,21 @@ community:
   # Aligned with the chart 2026.3.1 default Community Build (Issue #275).
   buildNumber: "26.5.0.122743"
 
-# Explicitly pin the Community Build OCI index; the chart otherwise derives a
-# mutable tag from community.buildNumber.
+# Chart 2026.3.1 copies image.tag into app.kubernetes.io/version, where OCI
+# digest syntax (`@sha256:`) is invalid. Keep a label-safe tag in image.tag and
+# use the chart's explicit full image coordinates to retain the immutable digest.
 image:
   repository: sonarqube
-  tag: "26.5.0.122743-community@sha256:223d0090322edce6211a5328298b6f646920f1535025ef8dd880cab6647bb1fa"
+  tag: "26.5.0.122743-community"
   pullPolicy: IfNotPresent
+
+global:
+  azure:
+    images:
+      sonarqube:
+        registry: docker.io
+        image: sonarqube
+        tag: "26.5.0.122743-community@sha256:223d0090322edce6211a5328298b6f646920f1535025ef8dd880cab6647bb1fa"
 
 # ── Deployment ─────────────────────────────────────────────────────────────────
 replicaCount: 1

--- a/platform/tests/test_api_default_drift.py
+++ b/platform/tests/test_api_default_drift.py
@@ -40,6 +40,21 @@ class StatefulSetDriftTest(unittest.TestCase):
         )
 
 
+    def test_grafana_ignores_only_generated_admin_password(self):
+        app = load("apps/platform/grafana.yaml")
+        self.assertIn("RespectIgnoreDifferences=true", app["spec"]["syncPolicy"]["syncOptions"])
+        rules = app["spec"]["ignoreDifferences"]
+        self.assertEqual(
+            {(rule["kind"], rule["name"]): rule["jsonPointers"] for rule in rules},
+            {
+                ("Secret", "prometheus-grafana"): ["/data/admin-password"],
+                ("Deployment", "prometheus-grafana"): [
+                    "/spec/template/metadata/annotations/checksum~1secret"
+                ],
+            },
+        )
+
+
 class CertificateOwnershipTest(unittest.TestCase):
     def test_upstream_cert_manager_namespace_is_removed(self):
         kustomization = load("platform/base/cert-manager/kustomization.yaml")

--- a/platform/tests/test_api_default_drift.py
+++ b/platform/tests/test_api_default_drift.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Regression contracts for API-defaulted resources found by clean bootstrap #279."""
+import os
+import unittest
+
+import yaml
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def load(path):
+    with open(os.path.join(ROOT, path), encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+class StatefulSetDriftTest(unittest.TestCase):
+    def test_postgresql_declares_pvc_api_defaults_and_ignores_only_status(self):
+        docs = []
+        with open(os.path.join(ROOT, "platform/base/postgresql/statefulset.yaml"), encoding="utf-8") as fh:
+            docs = [doc for doc in yaml.safe_load_all(fh) if doc]
+        sts = next(doc for doc in docs if doc.get("kind") == "StatefulSet")
+        pvc = sts["spec"]["volumeClaimTemplates"][0]
+        self.assertEqual(pvc["apiVersion"], "v1")
+        self.assertEqual(pvc["kind"], "PersistentVolumeClaim")
+        self.assertEqual(pvc["spec"]["volumeMode"], "Filesystem")
+        rules = load("apps/platform/postgresql.yaml")["spec"]["ignoreDifferences"]
+        self.assertEqual(rules[0]["jqPathExpressions"], [".spec.volumeClaimTemplates[]?.status"])
+
+    def test_opensearch_ignores_only_chart_omitted_pvc_defaults(self):
+        rules = load("apps/platform/opensearch.yaml")["spec"]["ignoreDifferences"]
+        self.assertEqual(rules[0]["name"], "opensearch-cluster-master")
+        self.assertEqual(
+            set(rules[0]["jqPathExpressions"]),
+            {
+                ".spec.volumeClaimTemplates[]?.apiVersion",
+                ".spec.volumeClaimTemplates[]?.kind",
+                ".spec.volumeClaimTemplates[]?.spec.volumeMode",
+                ".spec.volumeClaimTemplates[]?.status",
+            },
+        )
+
+
+class CertificateOwnershipTest(unittest.TestCase):
+    def test_upstream_cert_manager_namespace_is_removed(self):
+        kustomization = load("platform/base/cert-manager/kustomization.yaml")
+        patches = kustomization.get("patches", [])
+        self.assertTrue(
+            any(
+                patch.get("target", {}).get("kind") == "Namespace"
+                and patch.get("target", {}).get("name") == "cert-manager"
+                and "$patch: delete" in patch.get("patch", "")
+                for patch in patches
+            )
+        )
+
+    def test_ingresses_do_not_compete_with_declared_certificate(self):
+        ingress_dir = os.path.join(ROOT, "platform", "base", "ingress")
+        for name in os.listdir(ingress_dir):
+            if not name.endswith(".yaml"):
+                continue
+            with open(os.path.join(ingress_dir, name), encoding="utf-8") as fh:
+                for doc in yaml.safe_load_all(fh):
+                    if not doc or doc.get("kind") != "Ingress":
+                        continue
+                    annotations = doc.get("metadata", {}).get("annotations", {})
+                    self.assertNotIn("cert-manager.io/cluster-issuer", annotations, name)
+                    self.assertNotIn("cert-manager.io/issuer", annotations, name)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_argocd_repo_server_hardening.py
+++ b/platform/tests/test_argocd_repo_server_hardening.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""argocd-repo-server must survive the initial app-of-apps render burst (#279).
+
+Confirmed runtime evidence (issue #279, reproduced on Windows and Linux):
+``argocd-repo-server`` ships with
+
+    requests: {cpu: 50m, memory: 64Mi}
+    limits:   {cpu: 500m, memory: 256Mi}
+
+and the argo-cd 10.1.4 chart's repo-server liveness/readiness probes default to
+``timeoutSeconds: 1``. During the very first root-app reconciliation, Argo CD
+concurrently renders every chart/Kustomize source in the app-of-apps set; under
+that burst the ``/healthz?full=true`` liveness check missed its 1s deadline,
+kubelet restarted repo-server mid-render, and severed the gRPC manifest-
+generation stream (observed as ``ComparisonError ... rpc error: code =
+Unavailable desc = error reading from server: EOF`` on External Secrets).
+
+The fix raises repo-server's resource ceiling for the burst and gives its
+probes a realistic timeout, without touching any other component's resources.
+
+Pure python3 + PyYAML::
+
+    python3 platform/tests/test_argocd_repo_server_hardening.py
+"""
+import os
+import re
+import unittest
+
+import yaml
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+VALUES = os.path.join(REPO_ROOT, "platform", "base", "argocd", "values.yaml")
+
+# The exact under-provisioned baseline confirmed to cause liveness restarts.
+CONFIRMED_INSUFFICIENT = {
+    "requests": {"cpu": "50m", "memory": "64Mi"},
+    "limits": {"cpu": "500m", "memory": "256Mi"},
+}
+
+
+def _cpu_millis(v: str) -> int:
+    v = str(v)
+    return int(v[:-1]) if v.endswith("m") else int(v) * 1000
+
+
+def _mem_mi(v: str) -> int:
+    v = str(v)
+    if v.endswith("Gi"):
+        return int(float(v[:-2]) * 1024)
+    if v.endswith("Mi"):
+        return int(v[:-2])
+    raise ValueError(f"unsupported memory unit: {v}")
+
+
+def _values():
+    with open(VALUES, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+class RepoServerResourceTest(unittest.TestCase):
+    def test_requests_raised_above_confirmed_insufficient_baseline(self):
+        repo_server = _values()["repoServer"]
+        requests = repo_server["resources"]["requests"]
+        self.assertGreater(
+            _cpu_millis(requests["cpu"]), _cpu_millis(CONFIRMED_INSUFFICIENT["requests"]["cpu"]),
+            "repoServer CPU request must be raised above the 50m baseline that restarted under load",
+        )
+        self.assertGreater(
+            _mem_mi(requests["memory"]), _mem_mi(CONFIRMED_INSUFFICIENT["requests"]["memory"]),
+            "repoServer memory request must be raised above the 64Mi baseline",
+        )
+
+    def test_limits_raised_above_confirmed_insufficient_baseline(self):
+        repo_server = _values()["repoServer"]
+        limits = repo_server["resources"]["limits"]
+        self.assertGreaterEqual(_cpu_millis(limits["cpu"]), 1000)
+        self.assertGreaterEqual(_mem_mi(limits["memory"]), 512)
+
+    def test_probe_timeouts_survive_render_burst(self):
+        repo_server = _values()["repoServer"]
+        for probe_name in ("readinessProbe", "livenessProbe"):
+            probe = repo_server.get(probe_name)
+            self.assertIsNotNone(probe, f"repoServer.{probe_name} must be overridden (chart default timeoutSeconds: 1)")
+            self.assertGreaterEqual(
+                probe["timeoutSeconds"], 5,
+                f"repoServer.{probe_name}.timeoutSeconds must exceed the 1s chart default",
+            )
+
+    def test_other_components_untouched(self):
+        values = _values()
+        # Only repoServer should move — controller/server/redis stay as-is.
+        self.assertEqual(values["controller"]["resources"]["requests"]["cpu"], "250m")
+        self.assertEqual(values["server"]["resources"]["requests"]["cpu"], "50m")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_backstage_image.py
+++ b/platform/tests/test_backstage_image.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Backstage must run the customized core-portal image, not the scaffold (#279).
+
+``ghcr.io/digiorg/core-portal:48d262e`` is core-portal's **initial commit**
+(2026-04-18) — the stock Backstage scaffold, before the DigiOrg theme
+(commit ``9077fa3``) and the TeraSky Crossplane plugins (commits ``42bc40e``/
+``c74fe7c``/``b77e94a``) were added. Pinning it explained why the deployed UI
+looked unstyled/uncustomized.
+
+``b77e94a1a0e50a834f1844918c4e7287b0764c0b`` is core-portal's current `main`
+HEAD (confirmed via ``gh api repos/digiorg/core-portal/commits``) and CI built
+and pushed it successfully (workflow run 26395858961, conclusion "success").
+The digest below was resolved independently from the GHCR anonymous registry
+API (``scripts/resolve_digest.py ghcr.io/digiorg/core-portal:b77e94a``), not
+invented.
+
+Pure python3 + PyYAML, no cluster/network access::
+
+    python3 platform/tests/test_backstage_image.py
+"""
+import os
+import re
+import unittest
+
+import yaml
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+DEPLOYMENT = os.path.join(REPO_ROOT, "platform", "base", "backstage", "deployment.yaml")
+VERSIONS_DOC = os.path.join(REPO_ROOT, "docs", "guides", "platform-versions.md")
+
+# Resolved 2026-07-18 via scripts/resolve_digest.py against the live GHCR API,
+# and independently cross-checked against core-portal's commit history/Actions
+# run for that exact commit.
+EXPECTED_IMAGE = (
+    "ghcr.io/digiorg/core-portal:b77e94a"
+    "@sha256:44d00aba125e1e66d712222ec7f64cbc7cce02f05e5f05146af5af996bfe19dd"
+)
+INITIAL_SCAFFOLD_COMMIT = "48d262e"
+
+
+def _backstage_container():
+    with open(DEPLOYMENT, encoding="utf-8") as fh:
+        deployment = yaml.safe_load(fh)
+    containers = deployment["spec"]["template"]["spec"]["containers"]
+    return next(c for c in containers if c["name"] == "backstage")
+
+
+class BackstageImageProvenanceTest(unittest.TestCase):
+    def test_pinned_to_current_customized_release_with_digest(self):
+        image = _backstage_container()["image"]
+        self.assertEqual(image, EXPECTED_IMAGE)
+
+    def test_not_pinned_to_initial_scaffold_commit(self):
+        image = _backstage_container()["image"]
+        self.assertNotIn(INITIAL_SCAFFOLD_COMMIT, image)
+
+    def test_not_floating(self):
+        image = _backstage_container()["image"]
+        tag = image.split("@")[0].split(":")[-1]
+        self.assertNotIn(tag, ("latest", "main", "master"))
+        self.assertRegex(image, r"@sha256:[0-9a-f]{64}$")
+
+    def test_versions_doc_updated(self):
+        with open(VERSIONS_DOC, encoding="utf-8") as fh:
+            doc = fh.read()
+        self.assertIn("core-portal", doc)
+        self.assertNotIn("core-portal` | 48d262e", doc)
+        self.assertIn("b77e94a", doc)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_chart_image_overrides.py
+++ b/platform/tests/test_chart_image_overrides.py
@@ -68,7 +68,14 @@ class KyvernoHookImagePinsTest(unittest.TestCase):
         self.assertRegex(self.values["webhooksCleanup"]["image"]["tag"], DIGEST_TAG)
 
     def test_current_crd_migration_key_is_explicit(self):
-        self.assertTrue(self.values["crds"]["migration"]["enabled"])
+        # Issue #279 supersedes #275's blanket "keep it explicit and on": a
+        # clean-install cluster has no prior Kyverno CRD state to migrate, and
+        # Argo CD's helm-template rendering runs this post-upgrade hook on
+        # every sync (no install-vs-upgrade distinction), so it churned on a
+        # fresh bootstrap. The key must still be explicit — just off by
+        # default. See test_kyverno_migration.py and
+        # docs/guides/platform-versions.md for the upgrade-path override.
+        self.assertIs(self.values["crds"]["migration"]["enabled"], False)
         self.assertNotIn("replicaCount", self.values)
         self.assertNotIn("policyReportsCleanup", self.values)
 

--- a/platform/tests/test_cnpg_migration.py
+++ b/platform/tests/test_cnpg_migration.py
@@ -351,6 +351,15 @@ class CoexistenceSafetyTest(unittest.TestCase):
         self.assertIn("backup_dir=./pgbackup-final", text)
         self.assertIn("rpo", text)
 
+    def test_idle_backup_pvc_does_not_block_argocd_health(self):
+        pvc = _find(_docs(INIT_YAML), "PersistentVolumeClaim", "postgresql-cnpg-backups")
+        if pvc is None:
+            self.fail("CNPG backup PVC is missing")
+        self.assertEqual(
+            pvc["metadata"].get("annotations", {}).get("argocd.argoproj.io/ignore-healthcheck"),
+            "true",
+        )
+
     def test_logical_backups_are_private_verified_atomic_and_retained(self):
         cron = _find(_docs(INIT_YAML), "CronJob")
         if cron is None:

--- a/platform/tests/test_crossplane_migration.py
+++ b/platform/tests/test_crossplane_migration.py
@@ -38,6 +38,8 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 APP = os.path.join(REPO_ROOT, "apps", "platform", "crossplane.yaml")
 PKG_DIR = os.path.join(REPO_ROOT, "crossplane", "providers", "packages")
 XRD = os.path.join(REPO_ROOT, "crossplane", "xrds", "application.yaml")
+FUNCTION = os.path.join(PKG_DIR, "function-patch-and-transform.yaml")
+PROVIDER_KUSTOMIZATION = os.path.join(PKG_DIR, "kustomization.yaml")
 
 # Revalidated compatible provider package versions (exact pins).
 EXPECTED_PROVIDERS = {
@@ -91,6 +93,19 @@ class ProviderVersionTest(unittest.TestCase):
                              "%s must not use a floating package tag" % name)
             self.assertRegex(tag, r"^v\d+\.\d+\.\d+",
                              "%s package tag must be an exact version" % name)
+
+
+class CompositionFunctionTest(unittest.TestCase):
+    def test_patch_and_transform_function_is_exactly_pinned_and_installed(self):
+        function = _docs(FUNCTION)[0]
+        self.assertEqual(function["kind"], "Function")
+        self.assertEqual(function["metadata"]["name"], "function-patch-and-transform")
+        self.assertEqual(
+            function["spec"]["package"],
+            "xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.10.7",
+        )
+        kustomization = _docs(PROVIDER_KUSTOMIZATION)[0]
+        self.assertIn("function-patch-and-transform.yaml", kustomization["resources"])
 
 
 class XrdLegacyClusterCompatTest(unittest.TestCase):

--- a/platform/tests/test_gated_sync_retry_classification.py
+++ b/platform/tests/test_gated_sync_retry_classification.py
@@ -32,7 +32,9 @@ Requires the `nu` binary (Nushell 0.114.1, matches docs/guides/platform-versions
     python3 platform/tests/test_gated_sync_retry_classification.py
 """
 import os
+import shutil
 import subprocess
+import tempfile
 import unittest
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -197,6 +199,63 @@ class RetryWiringStructureTest(unittest.TestCase):
         self.assertIn("status.sync.status", self.text)
         self.assertIn('phase in ["Failed" "Error"]', self.text)
         self.assertIn("Synced+Healthy", self.text)
+
+    def test_stale_status_fallback_remains_fail_closed(self):
+        start = self.text.index("def argocd_app_has_no_material_diff")
+        end = self.text.index("\n# Wait for ArgoCD apps", start)
+        body = self.text[start:end]
+        self.assertIn("argocd app diff $app --core --refresh", body)
+        self.assertIn("$diff.exit_code == 0", body)
+        self.assertNotIn("$diff.stdout", body)
+        self.assertNotIn("$diff.stderr", body)
+
+        wait_start = self.text.index("def wait_for_argocd_apps")
+        wait_end = self.text.index("\n# -----------------------------------------------------------------------------", wait_start)
+        wait_body = self.text[wait_start:wait_end]
+        self.assertIn('$health == "Healthy" and $sync == "OutOfSync"', wait_body)
+        self.assertIn("argocd_app_has_no_material_diff $app", wait_body)
+
+
+class MaterialDiffFallbackRuntimeTest(unittest.TestCase):
+    def _run_with_fake_argocd(self, exit_code: int) -> str:
+        nu = shutil.which("nu")
+        assert nu is not None
+        with tempfile.TemporaryDirectory() as tmp:
+            with open(os.path.join(tmp, "kubeconfig-local.yaml"), "w", encoding="utf-8") as fh:
+                fh.write("apiVersion: v1\nkind: Config\n")
+            for name, script in {
+                "kubectl": "#!/bin/sh\nexit 0\n",
+                "mktemp": "#!/bin/sh\nexec /usr/bin/mktemp \"$@\"\n",
+                "argocd": (
+                    "#!/bin/sh\n"
+                    "echo 'Authorization: Bearer should-not-leak'\n"
+                    "echo 'password=should-not-leak' >&2\n"
+                    f"exit {exit_code}\n"
+                ),
+            }.items():
+                path = os.path.join(tmp, name)
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write(script)
+                os.chmod(path, 0o755)
+
+            result = subprocess.run(
+                [nu, "-c", f"source {SETUP}; argocd_app_has_no_material_diff kyverno"],
+                cwd=tmp,
+                env={**os.environ, "PATH": f"{tmp}:/usr/bin:/bin"},
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertNotIn("should-not-leak", result.stdout + result.stderr)
+            return result.stdout.strip()
+
+    def test_zero_diff_is_accepted(self):
+        self.assertEqual(self._run_with_fake_argocd(0), "true")
+
+    def test_diff_or_cli_error_is_rejected(self):
+        self.assertEqual(self._run_with_fake_argocd(1), "false")
+        self.assertEqual(self._run_with_fake_argocd(2), "false")
 
 
 if __name__ == "__main__":

--- a/platform/tests/test_gated_sync_retry_classification.py
+++ b/platform/tests/test_gated_sync_retry_classification.py
@@ -50,8 +50,14 @@ CASES = [
     ("rpc error: code = Unavailable desc = transport is closing", True),
     ("failed to list refs: EOF", True),
     ("lookup github.com on 10.96.0.10:53: server misbehaving", True),
-    ("dial tcp: connect: connection refused", True),
-    ("context deadline exceeded", True),
+    ("repository checkout dial tcp: connect: connection refused", True),
+    ("repo-server manifest generation context deadline exceeded", True),
+    (
+        "one or more synchronization tasks completed unsuccessfully\n"
+        "Prometheus/prometheus: shard 0: pod prometheus-0: containers with "
+        "incomplete status: [init-config-reloader]",
+        True,
+    ),
     (
         "rpc error: code = Internal desc = error reading from server: EOF",
         True,
@@ -59,6 +65,15 @@ CASES = [
     (
         "rpc error: code = InvalidArgument desc = failed to unmarshal manifest: "
         "yaml: line 7: mapping values are not allowed here",
+        False,
+    ),
+    ("rpc error: code = PermissionDenied desc = access denied", False),
+    ("rpc error: code = Unauthenticated desc = missing credentials", False),
+    ("rpc error: code = Unknown desc = failed to unmarshal manifest", False),
+    ("helm template: YAML parse error: unexpected EOF", False),
+    (
+        "failed to apply: admission webhook validate.example.svc: dial tcp: "
+        "connect: connection refused",
         False,
     ),
     (
@@ -97,6 +112,25 @@ class RetryClassificationTest(unittest.TestCase):
                                   f"message classified as {out}, expected {expected}")
 
 
+class DiagnosticRedactionTest(unittest.TestCase):
+    CASES = [
+        ("password=super-secret-value", "super-secret-value"),
+        ("token: token-value-123", "token-value-123"),
+        ("api_key=key-123456", "key-123456"),
+        ("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload", "eyJhbGciOiJIUzI1NiJ9.payload"),
+        ("request to https://admin:hunter2@harbor.example/api failed", "admin:hunter2"),
+        ("Secret data: c2Vuc2l0aXZl", "c2Vuc2l0aXZl"),
+    ]
+
+    def test_sensitive_values_are_redacted_by_real_nushell(self):
+        for message, sensitive in self.CASES:
+            with self.subTest(message=message):
+                escaped = message.replace("\\", "\\\\").replace('"', '\\"')
+                out = _run_nu(f'redact_sync_diagnostic "{escaped}"')
+                self.assertNotIn(sensitive, out)
+                self.assertIn("[REDACTED]", out)
+
+
 class RetryWiringStructureTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -127,6 +161,22 @@ class RetryWiringStructureTest(unittest.TestCase):
     def test_prints_operation_state_message_and_resource_diagnostics(self):
         self.assertIn("operationState.message", self.text)
         self.assertIn("syncResult.resources", self.text)
+
+    def test_classification_includes_resource_messages(self):
+        start = self.text.index("def sync_gated_apps_for_local_dev")
+        end = self.text.index("\ndef ", start + 10)
+        body = self.text[start:end]
+        self.assertIn("classification_text", body)
+        self.assertIn("syncResult.resources", body)
+        self.assertIn("is_retryable_sync_error $classification_text", body)
+
+    def test_uses_started_at_as_fresh_operation_identity(self):
+        start = self.text.index("def sync_gated_apps_for_local_dev")
+        end = self.text.index("\ndef ", start + 10)
+        body = self.text[start:end]
+        self.assertIn("previous_started", body)
+        self.assertIn("status.operationState.startedAt", body)
+        self.assertIn("started != $previous_started", body)
 
     def test_preserves_major_upgrade_gate_contract(self):
         # Must not regress the existing gated-sync contract (test_major_upgrade_gates.py)

--- a/platform/tests/test_gated_sync_retry_classification.py
+++ b/platform/tests/test_gated_sync_retry_classification.py
@@ -88,6 +88,14 @@ CASES = [
     ),
     ("admission webhook \"validate.kyverno.svc\" denied the request", False),
     ("failed to sync: failed to run hook: BackoffLimitExceeded", False),
+    (
+        "containers with incomplete status: [init] hook failed: BackoffLimitExceeded",
+        False,
+    ),
+    (
+        "containers with incomplete status: [init] helm template failed with unexpected EOF",
+        False,
+    ),
     ("", False),
 ]
 
@@ -118,6 +126,10 @@ class DiagnosticRedactionTest(unittest.TestCase):
         ("token: token-value-123", "token-value-123"),
         ("api_key=key-123456", "key-123456"),
         ("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload", "eyJhbGciOiJIUzI1NiJ9.payload"),
+        ("Authorization: Basic YWRtaW46cGFzcw==", "YWRtaW46cGFzcw=="),
+        ('{"token":"sentinel-json-value"}', "sentinel-json-value"),
+        ("secret=sentinel-secret-value", "sentinel-secret-value"),
+        ('password: "quoted value with spaces"', "quoted value with spaces"),
         ("request to https://admin:hunter2@harbor.example/api failed", "admin:hunter2"),
         ("Secret data: c2Vuc2l0aXZl", "c2Vuc2l0aXZl"),
     ]

--- a/platform/tests/test_gated_sync_retry_classification.py
+++ b/platform/tests/test_gated_sync_retry_classification.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Gated Argo sync must retry only transient errors, and say why (#279).
+
+Confirmed runtime evidence: the first gated Application (external-secrets)
+failed with
+
+    ComparisonError: Failed to load target state: failed to generate manifest
+    for source 1 of 2:
+    rpc error: code = Unavailable desc = error reading from server: EOF
+
+caused by argocd-repo-server's liveness restart severing the in-flight gRPC
+manifest-generation call — not a real ESO/chart problem (the same source
+rendered successfully moments later). ``scripts/local-setup.nu`` must:
+
+  * classify this class of error (gRPC Unavailable/EOF, connection resets,
+    transient DNS/network failures) as retryable, with bounded exponential
+    backoff and a genuinely *fresh* sync operation (not re-reading the same
+    stale ``Error`` operation forever);
+  * classify deterministic manifest/resource/hook/policy errors as fatal —
+    fail immediately, no retry;
+  * print ``operationState.message`` and failed resource/hook messages either
+    way.
+
+This test drives the real ``is_retryable_sync_error`` function lifted straight
+out of ``scripts/local-setup.nu`` via the actual Nushell interpreter (no mocks
+of the classification logic itself), plus static structural checks for the
+retry/backoff/diagnostics wiring since the rest of the function talks to a
+real cluster.
+
+Requires the `nu` binary (Nushell 0.114.1, matches docs/guides/platform-versions.md)::
+
+    python3 platform/tests/test_gated_sync_retry_classification.py
+"""
+import os
+import subprocess
+import unittest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SETUP = os.path.join(REPO_ROOT, "scripts", "local-setup.nu")
+
+# (operationState.message, expected classification) confirmed from issue #279
+# diagnostics plus representative deterministic failures that must NOT retry.
+CASES = [
+    (
+        "ComparisonError: Failed to load target state: failed to generate "
+        "manifest for source 1 of 2:\nrpc error: code = Unavailable desc = "
+        "error reading from server: EOF",
+        True,
+    ),
+    ("rpc error: code = Unavailable desc = transport is closing", True),
+    ("failed to list refs: EOF", True),
+    ("lookup github.com on 10.96.0.10:53: server misbehaving", True),
+    ("dial tcp: connect: connection refused", True),
+    ("context deadline exceeded", True),
+    (
+        "rpc error: code = Internal desc = error reading from server: EOF",
+        True,
+    ),
+    (
+        "rpc error: code = InvalidArgument desc = failed to unmarshal manifest: "
+        "yaml: line 7: mapping values are not allowed here",
+        False,
+    ),
+    (
+        "rpc error: code = Internal desc = Manifest generation error (cached): "
+        "helm template failed with exit status 1",
+        False,
+    ),
+    (
+        "one or more objects failed to apply, reason: Deployment.apps \"foo\" "
+        "is invalid: spec.template.spec.containers: Required value",
+        False,
+    ),
+    ("admission webhook \"validate.kyverno.svc\" denied the request", False),
+    ("failed to sync: failed to run hook: BackoffLimitExceeded", False),
+    ("", False),
+]
+
+
+def _run_nu(expr: str) -> str:
+    result = subprocess.run(
+        ["nu", "-c", f"source {SETUP}; {expr}"],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"nu failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+class RetryClassificationTest(unittest.TestCase):
+    def test_classifier_matches_confirmed_cases(self):
+        for message, expected in CASES:
+            with self.subTest(message=message[:60]):
+                escaped = message.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+                out = _run_nu(f'is_retryable_sync_error "{escaped}"')
+                self.assertEqual(out, str(expected).lower(),
+                                  f"message classified as {out}, expected {expected}")
+
+
+class RetryWiringStructureTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open(SETUP, encoding="utf-8") as fh:
+            cls.text = fh.read()
+
+    def test_bounded_retry_with_backoff(self):
+        self.assertIn("max_operation_retries", self.text)
+        self.assertRegex(self.text, r"1sec\s*\*|\*\s*1sec|2\s*\*\*\s*\$retry_count")
+
+    def test_reissues_a_fresh_operation_on_retry(self):
+        # The sync patch must live inside the same enclosing retry loop as the
+        # backoff/retry-count bookkeeping, so a retry loops back and reissues
+        # a brand-new `kubectl patch` (fresh operation) rather than re-polling
+        # the same stale terminal operation.
+        start = self.text.index("def sync_gated_apps_for_local_dev")
+        end = self.text.index("\ndef ", start + 10)
+        body = self.text[start:end]
+        loop_start = body.index("loop {")
+        patch_pos = body.index("kubectl patch application $app", loop_start)
+        retry_incr_pos = body.index("$retry_count = $retry_count + 1", loop_start)
+        self.assertLess(
+            patch_pos, retry_incr_pos,
+            "the sync patch must be inside the same retry `loop {}` as the "
+            "backoff/retry increment so a retry reissues a fresh operation",
+        )
+
+    def test_prints_operation_state_message_and_resource_diagnostics(self):
+        self.assertIn("operationState.message", self.text)
+        self.assertIn("syncResult.resources", self.text)
+
+    def test_preserves_major_upgrade_gate_contract(self):
+        # Must not regress the existing gated-sync contract (test_major_upgrade_gates.py)
+        self.assertIn("status.operationState.finishedAt", self.text)
+        self.assertIn("status.operationState.phase", self.text)
+        self.assertIn("status.sync.status", self.text)
+        self.assertIn('phase in ["Failed" "Error"]', self.text)
+        self.assertIn("Synced+Healthy", self.text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_harbor_proxy_cache.py
+++ b/platform/tests/test_harbor_proxy_cache.py
@@ -133,15 +133,22 @@ class GeneratedSecretDriftTest(unittest.TestCase):
         app = _docs(APP)[0]
         rules = app["spec"].get("ignoreDifferences", [])
         self.assertIn("RespectIgnoreDifferences=true", app["spec"]["syncPolicy"]["syncOptions"])
-        secret_names = {
-            rule.get("name")
+        secret_rules = {
+            rule.get("name"): set(rule.get("jsonPointers", []))
             for rule in rules
-            if rule.get("kind") == "Secret" and rule.get("jsonPointers") == ["/data"]
+            if rule.get("kind") == "Secret"
         }
         self.assertEqual(
-            secret_names,
-            {"harbor-core", "harbor-jobservice", "harbor-registry", "harbor-registry-htpasswd"},
+            secret_rules,
+            {
+                "harbor-core": {"/data/CSRF_KEY", "/data/secret", "/data/tls.crt", "/data/tls.key"},
+                "harbor-jobservice": {"/data/JOBSERVICE_SECRET"},
+                "harbor-registry": {"/data/REGISTRY_HTTP_SECRET"},
+                "harbor-registry-htpasswd": {"/data/REGISTRY_HTPASSWD"},
+            },
         )
+        self.assertNotIn("/data/REGISTRY_CREDENTIAL_PASSWORD", set().union(*secret_rules.values()))
+        self.assertNotIn("/data/REGISTRY_REDIS_PASSWORD", set().union(*secret_rules.values()))
 
         deployment_rules = {
             rule.get("name"): set(rule.get("jsonPointers", []))

--- a/platform/tests/test_harbor_proxy_cache.py
+++ b/platform/tests/test_harbor_proxy_cache.py
@@ -29,6 +29,7 @@ except ImportError:  # pragma: no cover
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 HARBOR_DIR = os.path.join(REPO_ROOT, "platform", "base", "harbor")
 JOB = os.path.join(HARBOR_DIR, "harbor-proxy-cache-job.yaml")
+VALUES = os.path.join(HARBOR_DIR, "values.yaml")
 KUSTOMIZATION = os.path.join(HARBOR_DIR, "kustomization.yaml")
 
 # name -> (harbor registry type, upstream url) that MUST be configured.
@@ -94,6 +95,13 @@ class ProxyCacheContentTest(unittest.TestCase):
         self.assertIn("wrong URL", self.script)
         self.assertIn("not bound to registry", self.script)
         self.assertIn("already exists and matches", self.script)
+
+    def test_harbor_core_permits_every_configured_proxy_provider(self):
+        values = _docs(VALUES)[0]
+        env = {item["name"]: item["value"] for item in values.get("core", {}).get("extraEnvVars", [])}
+        permitted = set(env.get("PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE", "").split(","))
+        expected = {rtype for rtype, _ in EXPECTED_REGISTRIES.values()}
+        self.assertTrue(expected.issubset(permitted), expected - permitted)
 
     def test_every_registry_type_and_url_present(self):
         for name, (rtype, url) in EXPECTED_REGISTRIES.items():

--- a/platform/tests/test_harbor_proxy_cache.py
+++ b/platform/tests/test_harbor_proxy_cache.py
@@ -30,6 +30,7 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 HARBOR_DIR = os.path.join(REPO_ROOT, "platform", "base", "harbor")
 JOB = os.path.join(HARBOR_DIR, "harbor-proxy-cache-job.yaml")
 VALUES = os.path.join(HARBOR_DIR, "values.yaml")
+APP = os.path.join(REPO_ROOT, "apps", "platform", "harbor.yaml")
 KUSTOMIZATION = os.path.join(HARBOR_DIR, "kustomization.yaml")
 
 # name -> (harbor registry type, upstream url) that MUST be configured.
@@ -125,6 +126,32 @@ class KustomizationTest(unittest.TestCase):
     def test_job_is_included(self):
         k = _docs(KUSTOMIZATION)[0]
         self.assertIn("harbor-proxy-cache-job.yaml", k.get("resources", []))
+
+
+class GeneratedSecretDriftTest(unittest.TestCase):
+    def test_argocd_ignores_only_chart_generated_secret_material(self):
+        app = _docs(APP)[0]
+        rules = app["spec"].get("ignoreDifferences", [])
+        self.assertIn("RespectIgnoreDifferences=true", app["spec"]["syncPolicy"]["syncOptions"])
+        secret_names = {
+            rule.get("name")
+            for rule in rules
+            if rule.get("kind") == "Secret" and rule.get("jsonPointers") == ["/data"]
+        }
+        self.assertEqual(
+            secret_names,
+            {"harbor-core", "harbor-jobservice", "harbor-registry", "harbor-registry-htpasswd"},
+        )
+
+        deployment_rules = {
+            rule.get("name"): set(rule.get("jsonPointers", []))
+            for rule in rules
+            if rule.get("kind") == "Deployment"
+        }
+        self.assertEqual(set(deployment_rules), {"harbor-core", "harbor-jobservice", "harbor-registry"})
+        for pointers in deployment_rules.values():
+            self.assertTrue(pointers)
+            self.assertTrue(all("/checksum~1secret" in pointer for pointer in pointers))
 
 
 if __name__ == "__main__":

--- a/platform/tests/test_harbor_proxy_cache_diagnostics.py
+++ b/platform/tests/test_harbor_proxy_cache_diagnostics.py
@@ -30,6 +30,10 @@ Pure python3 + PyYAML::
 """
 import os
 import re
+import stat
+import subprocess
+import tempfile
+import textwrap
 import unittest
 
 import yaml
@@ -43,6 +47,24 @@ def _script():
         docs = [d for d in yaml.safe_load_all(fh) if d]
     job = next(d for d in docs if d.get("kind") == "Job")
     return job["spec"]["template"]["spec"]["containers"][0]["command"][-1]
+
+
+def _run_with_fake_curl(fake_curl):
+    with tempfile.TemporaryDirectory() as tmp:
+        curl_path = os.path.join(tmp, "curl")
+        with open(curl_path, "w", encoding="utf-8") as fh:
+            fh.write("#!/bin/sh\n" + textwrap.dedent(fake_curl))
+        os.chmod(curl_path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+        env = os.environ.copy()
+        env["PATH"] = tmp + os.pathsep + env["PATH"]
+        env["HARBOR_ADMIN_PASSWORD"] = "fixture-password-never-print"
+        return subprocess.run(
+            ["/bin/sh", "-c", _script()],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=20,
+        )
 
 
 class NoSilentCurlFailureTest(unittest.TestCase):
@@ -69,6 +91,32 @@ class NoSilentCurlFailureTest(unittest.TestCase):
         script = _script()
         self.assertIn("could not read back registry", script)
         self.assertIn("could not read back project", script)
+
+    def test_create_transport_failure_is_actionable_and_secret_safe(self):
+        result = _run_with_fake_curl(r'''
+            case "$*" in
+              */ping*) exit 0 ;;
+              *) exit 7 ;;
+            esac
+        ''')
+        output = result.stdout + result.stderr
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("create transport failure (curl exit 7)", output)
+        self.assertNotIn("fixture-password-never-print", output)
+
+    def test_readback_transport_failure_is_actionable_and_secret_safe(self):
+        result = _run_with_fake_curl(r'''
+            case "$*" in
+              */ping*) exit 0 ;;
+              *"-X POST"*) printf 409; exit 0 ;;
+              *"/registries?q="*) exit 7 ;;
+              *) exit 9 ;;
+            esac
+        ''')
+        output = result.stdout + result.stderr
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("readback transport failure (curl exit 7)", output)
+        self.assertNotIn("fixture-password-never-print", output)
 
     def test_never_prints_credentials(self):
         script = _script()

--- a/platform/tests/test_harbor_proxy_cache_diagnostics.py
+++ b/platform/tests/test_harbor_proxy_cache_diagnostics.py
@@ -92,6 +92,12 @@ class NoSilentCurlFailureTest(unittest.TestCase):
         self.assertIn("could not read back registry", script)
         self.assertIn("could not read back project", script)
 
+    def test_http_failures_emit_bounded_api_error_body(self):
+        script = _script()
+        self.assertIn("print_api_error", script)
+        self.assertIn("Harbor API response", script)
+        self.assertIn("cut -c1-500", script)
+
     def test_registry_id_lookup_filters_the_requested_name(self):
         script = _script()
         self.assertIn('grep -F "\\\"name\\\":\\\"${registry_name}\\\""', script)

--- a/platform/tests/test_harbor_proxy_cache_diagnostics.py
+++ b/platform/tests/test_harbor_proxy_cache_diagnostics.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""harbor-proxy-cache-config must fail loud, never silent (Issue #279).
+
+Confirmed runtime evidence: harbor-oidc-config always succeeds, but
+harbor-proxy-cache-config reaches ``BackoffLimitExceeded``. The Job's read-back
+branches (taken once a registry/project already exists from a prior sync,
+because ``BeforeHookCreation`` recreates this hook on every Harbor sync) do:
+
+    existing=$(${CURL} -sf -u "${AUTH}" "${HARBOR_API}/...")
+
+Under ``set -eu`` a *bare assignment* whose right-hand side is a failing
+command substitution kills the script immediately, with **no** echoed message
+-- unlike every other failure path in this script, which prints an explicit
+"ERROR: ..." line first. That silent-death shape is exactly what "harden with
+retained/safe diagnostics ... inspect its API payload/readback rather than
+guessing" calls for: today, if that one curl call fails, the pod dies with an
+empty tail of logs and nobody can tell whether Harbor was unreachable, the
+credential was wrong, or the API shape changed.
+
+The fix keeps every HTTP call's status code and body available via
+``-o file -w '%{http_code}'`` (the pattern the file already uses for its POSTs)
+instead of ``-f`` + bare assignment, and prints a clear diagnostic including the
+HTTP status before exiting non-zero. Credentials must never be printed (no
+``-v``/``--verbose``/``-i``/``--include`` curl flags, no echoing ``$AUTH`` or
+``$HARBOR_ADMIN_PASSWORD``).
+
+Pure python3 + PyYAML::
+
+    python3 platform/tests/test_harbor_proxy_cache_diagnostics.py
+"""
+import os
+import re
+import unittest
+
+import yaml
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+JOB = os.path.join(REPO_ROOT, "platform", "base", "harbor", "harbor-proxy-cache-job.yaml")
+
+
+def _script():
+    with open(JOB, encoding="utf-8") as fh:
+        docs = [d for d in yaml.safe_load_all(fh) if d]
+    job = next(d for d in docs if d.get("kind") == "Job")
+    return job["spec"]["template"]["spec"]["containers"][0]["command"][-1]
+
+
+class NoSilentCurlFailureTest(unittest.TestCase):
+    def test_no_bare_assignment_from_a_dash_f_curl_call(self):
+        script = _script()
+        # This is the exact silent-death shape: `var=$(... -sf ...)` outside an
+        # `if`/`while` test, which set -e kills with zero output.
+        self.assertNotRegex(
+            script, r"=\$\(\$\{CURL\}[^)]*-sf",
+            "curl -f response captured via bare assignment dies silently under "
+            "set -eu; capture the HTTP status explicitly instead",
+        )
+
+    def test_readback_calls_capture_explicit_http_status(self):
+        script = _script()
+        # Every readback GET must go through the same -o file -w "%{http_code}"
+        # shape already used for the POST calls, so a failure is diagnosable.
+        self.assertGreaterEqual(
+            len(re.findall(r'-w\s+"%\{http_code\}"', script)), 3,
+            "registry/project readback must capture an explicit HTTP status code",
+        )
+
+    def test_readback_failure_prints_actionable_error(self):
+        script = _script()
+        self.assertIn("could not read back registry", script)
+        self.assertIn("could not read back project", script)
+
+    def test_never_prints_credentials(self):
+        script = _script()
+        for flag in ("--verbose", " -v ", "--include", " -i "):
+            self.assertNotIn(flag, script, f"curl flag {flag!r} could leak the Basic-auth header")
+        self.assertNotRegex(script, r"echo.*\$\{?AUTH\}?\b")
+        self.assertNotRegex(script, r"echo.*HARBOR_ADMIN_PASSWORD")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_harbor_proxy_cache_diagnostics.py
+++ b/platform/tests/test_harbor_proxy_cache_diagnostics.py
@@ -92,6 +92,10 @@ class NoSilentCurlFailureTest(unittest.TestCase):
         self.assertIn("could not read back registry", script)
         self.assertIn("could not read back project", script)
 
+    def test_registry_id_lookup_filters_the_requested_name(self):
+        script = _script()
+        self.assertIn('grep -F "\\\"name\\\":\\\"${registry_name}\\\""', script)
+
     def test_create_transport_failure_is_actionable_and_secret_safe(self):
         result = _run_with_fake_curl(r'''
             case "$*" in

--- a/platform/tests/test_kind_node_pin.py
+++ b/platform/tests/test_kind_node_pin.py
@@ -21,6 +21,9 @@ class KindNodePinTest(unittest.TestCase):
         )
         self.assertIsNotNone(match)
         self.assertIn("kind create cluster --image $KIND_NODE_IMAGE", self.text)
+    def test_node_runtime_limits_cover_platform_watchers(self):
+        self.assertIn("fs.inotify.max_user_instances=8192", self.text)
+        self.assertIn("fs.inotify.max_user_watches=1048576", self.text)
 
 
 if __name__ == "__main__":

--- a/platform/tests/test_kind_node_pin.py
+++ b/platform/tests/test_kind_node_pin.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""The disposable KinD acceptance environment must be reproducible (Issue #279)."""
+import os
+import re
+import unittest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SETUP = os.path.join(REPO_ROOT, "scripts", "local-setup.nu")
+
+
+class KindNodePinTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open(SETUP, encoding="utf-8") as fh:
+            cls.text = fh.read()
+
+    def test_kubernetes_1361_node_image_is_digest_pinned(self):
+        match = re.search(
+            r'let KIND_NODE_IMAGE = "kindest/node:v1\.36\.1@sha256:([0-9a-f]{64})"',
+            self.text,
+        )
+        self.assertIsNotNone(match)
+        self.assertIn("kind create cluster --image $KIND_NODE_IMAGE", self.text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_kyverno_migration.py
+++ b/platform/tests/test_kyverno_migration.py
@@ -25,11 +25,16 @@ import yaml
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 KYVERNO_APP = os.path.join(REPO_ROOT, "apps", "platform", "kyverno.yaml")
 VERSIONS_DOC = os.path.join(REPO_ROOT, "docs", "guides", "platform-versions.md")
+POLICIES_DIR = os.path.join(REPO_ROOT, "policies", "kyverno")
+
+
+def _kyverno_app():
+    with open(KYVERNO_APP, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
 
 
 def _kyverno_values():
-    with open(KYVERNO_APP, encoding="utf-8") as fh:
-        app = yaml.safe_load(fh)
+    app = _kyverno_app()
     values_text = app["spec"]["source"]["helm"]["values"]
     return yaml.safe_load(values_text)
 
@@ -42,6 +47,36 @@ class KyvernoCleanInstallTest(unittest.TestCase):
             False,
             "clean-install default must not run the CRD migration post-upgrade hook",
         )
+
+    def test_only_api_defaulted_none_conversion_is_ignored(self):
+        rules = _kyverno_app()["spec"].get("ignoreDifferences", [])
+        self.assertEqual(len(rules), 1)
+        self.assertEqual(rules[0]["group"], "apiextensions.k8s.io")
+        self.assertEqual(rules[0]["kind"], "CustomResourceDefinition")
+        self.assertEqual(
+            rules[0]["jqPathExpressions"],
+            ['.spec.conversion | select(.strategy == "None")'],
+        )
+
+    def test_policy_api_defaults_are_declared(self):
+        policies = []
+        for root, _, files in os.walk(POLICIES_DIR):
+            for name in files:
+                if not name.endswith(".yaml") or name == "kustomization.yaml":
+                    continue
+                with open(os.path.join(root, name), encoding="utf-8") as fh:
+                    policies.extend(d for d in yaml.safe_load_all(fh) if d and d.get("kind") == "ClusterPolicy")
+        self.assertTrue(policies)
+        for policy in policies:
+            spec = policy["spec"]
+            self.assertIn("validationFailureAction", spec, policy["metadata"]["name"])
+            self.assertIn("background", spec, policy["metadata"]["name"])
+            self.assertEqual(spec.get("admission"), True, policy["metadata"]["name"])
+            self.assertEqual(spec.get("emitWarning"), False, policy["metadata"]["name"])
+            for rule in spec["rules"]:
+                self.assertEqual(rule.get("skipBackgroundRequests"), True, rule["name"])
+                if "validate" in rule:
+                    self.assertEqual(rule["validate"].get("allowExistingViolations"), True, rule["name"])
 
     def test_upgrade_path_is_documented(self):
         with open(VERSIONS_DOC, encoding="utf-8") as fh:

--- a/platform/tests/test_kyverno_migration.py
+++ b/platform/tests/test_kyverno_migration.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Kyverno's CRD migration hook must not churn on a clean-install cluster (#279).
+
+``crds.migration.enabled`` renders a Helm ``post-upgrade`` hook Job
+(``kyverno-migrate-resources``). Helm itself only runs ``post-upgrade`` hooks
+on ``helm upgrade``, never on a fresh ``helm install`` — but Argo CD renders
+every chart with ``helm template`` and maps ``post-upgrade``/``post-install``
+hooks onto ``PostSync`` for *every* sync, with no concept of "this is the first
+install". On a brand-new disposable KinD cluster there is no prior Kyverno CRD
+state to migrate, so the hook is pure churn/noise (confirmed in issue #279).
+
+The chart-default clean-install path must disable the migration hook; a real
+upgrade with prior state must explicitly re-enable it for that one promotion,
+per the documented procedure.
+
+Pure python3 + PyYAML::
+
+    python3 platform/tests/test_kyverno_migration.py
+"""
+import os
+import unittest
+
+import yaml
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+KYVERNO_APP = os.path.join(REPO_ROOT, "apps", "platform", "kyverno.yaml")
+VERSIONS_DOC = os.path.join(REPO_ROOT, "docs", "guides", "platform-versions.md")
+
+
+def _kyverno_values():
+    with open(KYVERNO_APP, encoding="utf-8") as fh:
+        app = yaml.safe_load(fh)
+    values_text = app["spec"]["source"]["helm"]["values"]
+    return yaml.safe_load(values_text)
+
+
+class KyvernoCleanInstallTest(unittest.TestCase):
+    def test_migration_hook_disabled_for_clean_bootstrap(self):
+        values = _kyverno_values()
+        self.assertEqual(
+            values.get("crds", {}).get("migration", {}).get("enabled"),
+            False,
+            "clean-install default must not run the CRD migration post-upgrade hook",
+        )
+
+    def test_upgrade_path_is_documented(self):
+        with open(VERSIONS_DOC, encoding="utf-8") as fh:
+            doc = fh.read()
+        self.assertIn("crds.migration.enabled", doc)
+        # Must document both states: off by default, and how to switch it on
+        # for a real upgrade with prior Kyverno state.
+        section = doc[doc.index("crds.migration.enabled") - 500:]
+        self.assertIn("upgrade", section.lower())
+        self.assertIn("true", section)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_kyverno_migration.py
+++ b/platform/tests/test_kyverno_migration.py
@@ -73,10 +73,23 @@ class KyvernoCleanInstallTest(unittest.TestCase):
             self.assertIn("background", spec, policy["metadata"]["name"])
             self.assertEqual(spec.get("admission"), True, policy["metadata"]["name"])
             self.assertEqual(spec.get("emitWarning"), False, policy["metadata"]["name"])
-            for rule in spec["rules"]:
-                self.assertEqual(rule.get("skipBackgroundRequests"), True, rule["name"])
+            for rule in spec.get("rules", []):
+                self.assertTrue(rule.get("skipBackgroundRequests"), policy["metadata"]["name"])
+                for match in rule.get("match", {}).get("any", []):
+                    resources = match.get("resources", {})
+                    self.assertNotIn("apiGroups", resources, policy["metadata"]["name"])
+                    for kind in resources.get("kinds", []):
+                        if kind.endswith("AppClaim"):
+                            self.assertEqual(
+                                kind,
+                                "platform.digiorg.io/v1alpha1/AppClaim",
+                                policy["metadata"]["name"],
+                            )
                 if "validate" in rule:
-                    self.assertEqual(rule["validate"].get("allowExistingViolations"), True, rule["name"])
+                    self.assertTrue(
+                        rule["validate"].get("allowExistingViolations"),
+                        policy["metadata"]["name"],
+                    )
 
     def test_upgrade_path_is_documented(self):
         with open(VERSIONS_DOC, encoding="utf-8") as fh:

--- a/platform/tests/test_kyverno_migration.py
+++ b/platform/tests/test_kyverno_migration.py
@@ -48,17 +48,35 @@ class KyvernoCleanInstallTest(unittest.TestCase):
             "clean-install default must not run the CRD migration post-upgrade hook",
         )
 
-    def test_only_api_defaulted_none_conversion_is_ignored(self):
+    def test_crd_api_normalization_ignores_are_exactly_scoped(self):
         rules = _kyverno_app()["spec"].get("ignoreDifferences", [])
-        self.assertEqual(len(rules), 1)
-        self.assertEqual(rules[0]["group"], "apiextensions.k8s.io")
-        self.assertEqual(rules[0]["kind"], "CustomResourceDefinition")
+        conversion_rules = [rule for rule in rules if "jqPathExpressions" in rule]
+        self.assertEqual(len(conversion_rules), 1)
         self.assertEqual(
-            rules[0]["jqPathExpressions"],
-            [
-                '.spec.conversion | select(.strategy == "None")',
-                ".metadata.labels | select(length == 0)",
-            ],
+            conversion_rules[0]["jqPathExpressions"],
+            ['.spec.conversion | select(.strategy == "None")'],
+        )
+        expected_empty_label_crds = {
+            "deletingpolicies.policies.kyverno.io",
+            "generatingpolicies.policies.kyverno.io",
+            "imagevalidatingpolicies.policies.kyverno.io",
+            "mutatingpolicies.policies.kyverno.io",
+            "namespaceddeletingpolicies.policies.kyverno.io",
+            "namespacedgeneratingpolicies.policies.kyverno.io",
+            "namespacedimagevalidatingpolicies.policies.kyverno.io",
+            "namespacedmutatingpolicies.policies.kyverno.io",
+            "namespacedvalidatingpolicies.policies.kyverno.io",
+            "policyexceptions.policies.kyverno.io",
+            "validatingpolicies.policies.kyverno.io",
+        }
+        label_rules = [rule for rule in rules if rule.get("jsonPointers") == ["/metadata/labels"]]
+        self.assertEqual({rule.get("name") for rule in label_rules}, expected_empty_label_crds)
+        self.assertTrue(
+            all(
+                rule.get("group") == "apiextensions.k8s.io"
+                and rule.get("kind") == "CustomResourceDefinition"
+                for rule in label_rules
+            )
         )
 
     def test_policy_api_defaults_are_declared(self):

--- a/platform/tests/test_kyverno_migration.py
+++ b/platform/tests/test_kyverno_migration.py
@@ -55,7 +55,10 @@ class KyvernoCleanInstallTest(unittest.TestCase):
         self.assertEqual(rules[0]["kind"], "CustomResourceDefinition")
         self.assertEqual(
             rules[0]["jqPathExpressions"],
-            ['.spec.conversion | select(.strategy == "None")'],
+            [
+                '.spec.conversion | select(.strategy == "None")',
+                ".metadata.labels | select(length == 0)",
+            ],
         )
 
     def test_policy_api_defaults_are_declared(self):

--- a/platform/tests/test_kyverno_migration.py
+++ b/platform/tests/test_kyverno_migration.py
@@ -48,35 +48,19 @@ class KyvernoCleanInstallTest(unittest.TestCase):
             "clean-install default must not run the CRD migration post-upgrade hook",
         )
 
-    def test_crd_api_normalization_ignores_are_exactly_scoped(self):
+    def test_only_api_defaulted_none_conversion_is_ignored(self):
         rules = _kyverno_app()["spec"].get("ignoreDifferences", [])
-        conversion_rules = [rule for rule in rules if "jqPathExpressions" in rule]
-        self.assertEqual(len(conversion_rules), 1)
+        self.assertEqual(len(rules), 1)
         self.assertEqual(
-            conversion_rules[0]["jqPathExpressions"],
+            rules[0]["jqPathExpressions"],
             ['.spec.conversion | select(.strategy == "None")'],
         )
-        expected_empty_label_crds = {
-            "deletingpolicies.policies.kyverno.io",
-            "generatingpolicies.policies.kyverno.io",
-            "imagevalidatingpolicies.policies.kyverno.io",
-            "mutatingpolicies.policies.kyverno.io",
-            "namespaceddeletingpolicies.policies.kyverno.io",
-            "namespacedgeneratingpolicies.policies.kyverno.io",
-            "namespacedimagevalidatingpolicies.policies.kyverno.io",
-            "namespacedmutatingpolicies.policies.kyverno.io",
-            "namespacedvalidatingpolicies.policies.kyverno.io",
-            "policyexceptions.policies.kyverno.io",
-            "validatingpolicies.policies.kyverno.io",
-        }
-        label_rules = [rule for rule in rules if rule.get("jsonPointers") == ["/metadata/labels"]]
-        self.assertEqual({rule.get("name") for rule in label_rules}, expected_empty_label_crds)
-        self.assertTrue(
-            all(
-                rule.get("group") == "apiextensions.k8s.io"
-                and rule.get("kind") == "CustomResourceDefinition"
-                for rule in label_rules
-            )
+
+    def test_policy_v2_crds_render_with_stable_labels(self):
+        values = _kyverno_values()
+        self.assertEqual(
+            values["kyverno-api"]["labels"],
+            {"app.kubernetes.io/managed-by": "kyverno"},
         )
 
     def test_policy_api_defaults_are_declared(self):

--- a/platform/tests/test_namespace_ownership.py
+++ b/platform/tests/test_namespace_ownership.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Every Namespace must be owned by exactly one Argo CD Application (Issue #279).
+
+``platform/base/namespaces`` is a dedicated wave -1 Application
+(``apps/platform/namespaces.yaml``) that pre-creates every platform namespace so
+concurrent wave-2+ Applications never race on ``CreateNamespace=true``. If a
+component's own Kustomize base *also* ships a ``Namespace`` resource for a name
+already declared there, Argo CD's resource-tracking annotation flips between the
+two owning Applications on every reconciliation, leaving at least one
+permanently ``OutOfSync`` — confirmed for NATS/``messaging`` in issue #279.
+
+This is a *general* regression contract: it walks every ``platform/base/*``
+Kustomization and fails if any of them declares a ``Namespace`` object whose
+name is also pre-created by ``platform/base/namespaces``, regardless of which
+component introduces it.
+
+Pure python3 + PyYAML, no cluster access::
+
+    python3 platform/tests/test_namespace_ownership.py
+"""
+
+import os
+import sys
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+BASE_DIR = os.path.join(REPO_ROOT, "platform", "base")
+CENTRAL_NAMESPACES_FILE = os.path.join(BASE_DIR, "namespaces", "namespaces.yaml")
+
+
+def _docs(path):
+    with open(path, encoding="utf-8") as fh:
+        return [d for d in yaml.safe_load_all(fh) if d]
+
+
+def _central_namespace_names():
+    names = set()
+    for doc in _docs(CENTRAL_NAMESPACES_FILE):
+        if doc.get("kind") == "Namespace":
+            names.add(doc["metadata"]["name"])
+    return names
+
+
+def _kustomization_namespace_resources(kustomization_path):
+    """Namespace names declared by any YAML resource this kustomization lists."""
+    comp_dir = os.path.dirname(kustomization_path)
+    with open(kustomization_path, encoding="utf-8") as fh:
+        kustomization = yaml.safe_load(fh) or {}
+    names = []
+    for resource in kustomization.get("resources", []):
+        resource_path = os.path.join(comp_dir, resource)
+        if not os.path.isfile(resource_path) or not resource.endswith((".yaml", ".yml")):
+            continue
+        for doc in _docs(resource_path):
+            if doc and doc.get("kind") == "Namespace":
+                names.append((doc["metadata"]["name"], os.path.relpath(resource_path, REPO_ROOT)))
+    return names
+
+
+def _all_component_kustomizations():
+    paths = []
+    for entry in sorted(os.listdir(BASE_DIR)):
+        comp_dir = os.path.join(BASE_DIR, entry)
+        kustomization = os.path.join(comp_dir, "kustomization.yaml")
+        if entry != "namespaces" and os.path.isfile(kustomization):
+            paths.append(kustomization)
+    return paths
+
+
+class NamespaceOwnershipTest(unittest.TestCase):
+    def test_central_namespaces_file_is_readable(self):
+        self.assertTrue(os.path.isfile(CENTRAL_NAMESPACES_FILE))
+        self.assertGreater(len(_central_namespace_names()), 0)
+
+    def test_no_component_duplicates_a_centrally_owned_namespace(self):
+        central = _central_namespace_names()
+        violations = []
+        for kustomization_path in _all_component_kustomizations():
+            for name, rel_path in _kustomization_namespace_resources(kustomization_path):
+                if name in central:
+                    violations.append(f"{rel_path} duplicates centrally-owned Namespace '{name}'")
+        self.assertEqual(
+            violations, [],
+            "Components must not ship a Namespace already owned by "
+            "platform/base/namespaces (causes permanent OutOfSync ping-pong):\n  "
+            + "\n  ".join(violations),
+        )
+
+    def test_nats_messaging_namespace_is_centrally_owned_only(self):
+        # Explicit regression for the diagnosed issue #279 case.
+        nats_kustomization = os.path.join(BASE_DIR, "nats", "kustomization.yaml")
+        names = [n for n, _ in _kustomization_namespace_resources(nats_kustomization)]
+        self.assertNotIn("messaging", names,
+                          "nats must not manage the 'messaging' Namespace owned by the "
+                          "central namespaces Application")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_namespace_ownership.py
+++ b/platform/tests/test_namespace_ownership.py
@@ -47,15 +47,36 @@ def _central_namespace_names():
     return names
 
 
-def _kustomization_namespace_resources(kustomization_path):
-    """Namespace names declared by any YAML resource this kustomization lists."""
+def _kustomization_namespace_resources(kustomization_path, visited=None):
+    """Recursively find Namespace resources reachable from a Kustomization."""
+    visited = set() if visited is None else visited
+    real_path = os.path.realpath(kustomization_path)
+    if real_path in visited:
+        return []
+    visited.add(real_path)
+
     comp_dir = os.path.dirname(kustomization_path)
     with open(kustomization_path, encoding="utf-8") as fh:
         kustomization = yaml.safe_load(fh) or {}
     names = []
     for resource in kustomization.get("resources", []):
-        resource_path = os.path.join(comp_dir, resource)
-        if not os.path.isfile(resource_path) or not resource.endswith((".yaml", ".yml")):
+        resource_path = os.path.normpath(os.path.join(comp_dir, resource))
+        if os.path.isdir(resource_path):
+            nested = next(
+                (
+                    os.path.join(resource_path, candidate)
+                    for candidate in ("kustomization.yaml", "kustomization.yml", "Kustomization")
+                    if os.path.isfile(os.path.join(resource_path, candidate))
+                ),
+                None,
+            )
+            if nested:
+                names.extend(_kustomization_namespace_resources(nested, visited))
+            continue
+        if not os.path.isfile(resource_path) or not resource_path.endswith((".yaml", ".yml")):
+            continue
+        if os.path.basename(resource_path).lower().startswith("kustomization"):
+            names.extend(_kustomization_namespace_resources(resource_path, visited))
             continue
         for doc in _docs(resource_path):
             if doc and doc.get("kind") == "Namespace":
@@ -65,12 +86,13 @@ def _kustomization_namespace_resources(kustomization_path):
 
 def _all_component_kustomizations():
     paths = []
-    for entry in sorted(os.listdir(BASE_DIR)):
-        comp_dir = os.path.join(BASE_DIR, entry)
-        kustomization = os.path.join(comp_dir, "kustomization.yaml")
-        if entry != "namespaces" and os.path.isfile(kustomization):
-            paths.append(kustomization)
-    return paths
+    central_dir = os.path.realpath(os.path.join(BASE_DIR, "namespaces"))
+    for root, dirs, files in os.walk(BASE_DIR):
+        dirs[:] = [d for d in dirs if os.path.realpath(os.path.join(root, d)) != central_dir]
+        for candidate in ("kustomization.yaml", "kustomization.yml", "Kustomization"):
+            if candidate in files and os.path.realpath(root) != central_dir:
+                paths.append(os.path.join(root, candidate))
+    return sorted(paths)
 
 
 class NamespaceOwnershipTest(unittest.TestCase):

--- a/platform/tests/test_namespace_ownership.py
+++ b/platform/tests/test_namespace_ownership.py
@@ -100,6 +100,16 @@ class NamespaceOwnershipTest(unittest.TestCase):
         self.assertTrue(os.path.isfile(CENTRAL_NAMESPACES_FILE))
         self.assertGreater(len(_central_namespace_names()), 0)
 
+    def test_central_namespaces_are_never_pruned_during_ownership_transfer(self):
+        docs = [doc for doc in _docs(CENTRAL_NAMESPACES_FILE) if doc.get("kind") == "Namespace"]
+        self.assertTrue(docs)
+        for doc in docs:
+            self.assertEqual(
+                doc["metadata"].get("annotations", {}).get("argocd.argoproj.io/sync-options"),
+                "Prune=false",
+                doc["metadata"]["name"],
+            )
+
     def test_no_component_duplicates_a_centrally_owned_namespace(self):
         central = _central_namespace_names()
         violations = []

--- a/platform/tests/test_nats_surveyor_startup.py
+++ b/platform/tests/test_nats_surveyor_startup.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""NATS Surveyor must not noisily crash-loop before NATS is reachable (#279).
+
+Confirmed runtime evidence: on first deployment ``nats-surveyor`` restarts with
+``Error: couldn't start surveyor: nats: no servers available for connection``
+because it starts before the NATS Service has a ready endpoint. It recovers on
+its own once ``nats-0`` is Ready, so the underlying wiring is correct — this is
+a startup-order/retry weakness, not a config bug.
+
+The fix is a bounded init container (mirrors the existing
+``wait-for-postgres`` pattern in ``platform/base/backstage/deployment.yaml``)
+that waits for the NATS Service to accept TCP connections before the surveyor
+container starts, so the Pod does not enter a noisy CrashLoopBackOff during the
+initial app-of-apps burst. The wait must be *bounded* (so a permanently broken
+NATS endpoint still surfaces as a failure) and must not touch the main
+container's auth/config args, so a genuine auth/config error still fails loud.
+
+Pure python3 + PyYAML::
+
+    python3 platform/tests/test_nats_surveyor_startup.py
+"""
+import os
+import sys
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SURVEYOR = os.path.join(REPO_ROOT, "platform", "base", "nats", "surveyor.yaml")
+
+
+def _docs():
+    with open(SURVEYOR, encoding="utf-8") as fh:
+        return [d for d in yaml.safe_load_all(fh) if d]
+
+
+class SurveyorStartupTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.deployment = next(d for d in _docs() if d.get("kind") == "Deployment")
+        cls.pod_spec = cls.deployment["spec"]["template"]["spec"]
+
+    def test_has_bounded_init_container_waiting_for_nats(self):
+        init_containers = self.pod_spec.get("initContainers", [])
+        self.assertTrue(init_containers, "surveyor must wait for NATS before starting")
+        wait_container = init_containers[0]
+        command_text = " ".join(wait_container.get("command", []))
+        self.assertIn("nats.messaging.svc.cluster.local", command_text)
+        self.assertIn("4222", command_text)
+        # Must be bounded — a fixed retry count, not an infinite `until`/`while true`.
+        self.assertRegex(command_text, r"seq 1 [0-9]+|for .* in 1\.\.[0-9]+")
+        self.assertNotRegex(command_text, r"while true|until true")
+
+    def test_main_container_auth_and_config_untouched(self):
+        main = next(c for c in self.pod_spec["containers"] if c["name"] == "nats-surveyor")
+        args = main["args"]
+        self.assertIn("sys", args)
+        self.assertIn("sys_password", args)
+        # A permanent auth/config error must still be visible: no retry/backoff
+        # flags added to the surveyor binary itself that would swallow it.
+        self.assertNotIn("--retry", args)
+
+    def test_main_container_probes_unchanged(self):
+        main = next(c for c in self.pod_spec["containers"] if c["name"] == "nats-surveyor")
+        self.assertEqual(main["livenessProbe"]["httpGet"]["path"], "/metrics")
+        self.assertEqual(main["readinessProbe"]["httpGet"]["path"], "/metrics")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_nats_surveyor_startup.py
+++ b/platform/tests/test_nats_surveyor_startup.py
@@ -83,6 +83,17 @@ class NatsStatefulSetDriftTest(unittest.TestCase):
         self.assertIsInstance(annotations, dict)
         self.assertTrue(annotations)
 
+    def test_pvc_template_declares_api_defaulted_identity_fields(self):
+        # Kubernetes injects these fields into StatefulSet volumeClaimTemplates;
+        # declaring them in the chart output prevents perpetual drift. Only the
+        # runtime status subresource remains ignored below.
+        with open(NATS_VALUES, encoding="utf-8") as fh:
+            values = yaml.safe_load(fh)
+        pvc = values["config"]["jetstream"]["fileStore"]["pvc"]["merge"]
+        self.assertEqual(pvc.get("apiVersion"), "v1")
+        self.assertEqual(pvc.get("kind"), "PersistentVolumeClaim")
+        self.assertEqual(pvc.get("spec", {}).get("volumeMode"), "Filesystem")
+
     def test_ignores_kubernetes_injected_pvc_template_status(self):
         # Kubernetes persists status.phase inside StatefulSet PVC templates.
         # Argo CD 3.4.5 does not normalize this nested status field and reports

--- a/platform/tests/test_nats_surveyor_startup.py
+++ b/platform/tests/test_nats_surveyor_startup.py
@@ -32,6 +32,7 @@ except ImportError:  # pragma: no cover
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 SURVEYOR = os.path.join(REPO_ROOT, "platform", "base", "nats", "surveyor.yaml")
 NATS_APP = os.path.join(REPO_ROOT, "apps", "platform", "nats.yaml")
+NATS_VALUES = os.path.join(REPO_ROOT, "platform", "base", "nats", "values.yaml")
 
 
 def _docs():
@@ -72,6 +73,16 @@ class SurveyorStartupTest(unittest.TestCase):
 
 
 class NatsStatefulSetDriftTest(unittest.TestCase):
+    def test_pod_template_annotations_are_not_rendered_as_null(self):
+        # Chart 2.14.2 emits `metadata.annotations: null` when no pod annotation
+        # is configured; Kubernetes drops the null map, and Argo CD 3.4.5 then
+        # reports the StatefulSet OutOfSync forever. Render a stable annotation.
+        with open(NATS_VALUES, encoding="utf-8") as fh:
+            values = yaml.safe_load(fh)
+        annotations = values.get("podTemplate", {}).get("merge", {}).get("metadata", {}).get("annotations")
+        self.assertIsInstance(annotations, dict)
+        self.assertTrue(annotations)
+
     def test_ignores_kubernetes_injected_pvc_template_status(self):
         # Kubernetes persists status.phase inside StatefulSet PVC templates.
         # Argo CD 3.4.5 does not normalize this nested status field and reports

--- a/platform/tests/test_nats_surveyor_startup.py
+++ b/platform/tests/test_nats_surveyor_startup.py
@@ -31,6 +31,7 @@ except ImportError:  # pragma: no cover
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 SURVEYOR = os.path.join(REPO_ROOT, "platform", "base", "nats", "surveyor.yaml")
+NATS_APP = os.path.join(REPO_ROOT, "apps", "platform", "nats.yaml")
 
 
 def _docs():
@@ -68,6 +69,25 @@ class SurveyorStartupTest(unittest.TestCase):
         main = next(c for c in self.pod_spec["containers"] if c["name"] == "nats-surveyor")
         self.assertEqual(main["livenessProbe"]["httpGet"]["path"], "/metrics")
         self.assertEqual(main["readinessProbe"]["httpGet"]["path"], "/metrics")
+
+
+class NatsStatefulSetDriftTest(unittest.TestCase):
+    def test_ignores_kubernetes_injected_pvc_template_status(self):
+        # Kubernetes persists status.phase inside StatefulSet PVC templates.
+        # Argo CD 3.4.5 does not normalize this nested status field and reports
+        # the otherwise-identical StatefulSet OutOfSync forever.
+        with open(NATS_APP, encoding="utf-8") as fh:
+            app = yaml.safe_load(fh)
+        rules = app["spec"].get("ignoreDifferences", [])
+        matching = [
+            rule for rule in rules
+            if rule.get("group") == "apps"
+            and rule.get("kind") == "StatefulSet"
+            and rule.get("name") == "nats"
+        ]
+        self.assertEqual(len(matching), 1)
+        expressions = matching[0].get("jqPathExpressions", [])
+        self.assertIn(".spec.volumeClaimTemplates[]?.status", expressions)
 
 
 if __name__ == "__main__":

--- a/platform/tests/test_opencost_ui_subpath.py
+++ b/platform/tests/test_opencost_ui_subpath.py
@@ -427,6 +427,13 @@ class HelmWiringTest(unittest.TestCase):
             self.image.get("tag", ""),
         )
 
+    def test_prometheus_endpoint_matches_kube_prometheus_service(self):
+        endpoint = self.values["opencost"]["prometheus"]["external"]["url"]
+        self.assertEqual(
+            endpoint,
+            "http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090",
+        )
+
     def test_ui_enabled(self):
         self.assertTrue(self.ui.get("enabled"))
 

--- a/platform/tests/test_repo_server_stability_gate.py
+++ b/platform/tests/test_repo_server_stability_gate.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""A post-root-app stability boundary must exist before gated sync (#279).
+
+Confirmed root cause: the root Application fans out into concurrent
+Git/Helm/Kustomize renders immediately, and the very first gated sync started
+while argocd-repo-server was still absorbing that burst (and, on the observed
+runs, mid-restart). Promoting gated Applications only after repo-server is
+Ready *and* has stopped restarting closes that race without masking a
+genuinely broken repo-server (the wait itself is bounded and fails closed).
+
+Pure python3, text/structural assertions on the Nushell script (no cluster)::
+
+    python3 platform/tests/test_repo_server_stability_gate.py
+"""
+import os
+import re
+import unittest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SETUP = os.path.join(REPO_ROOT, "scripts", "local-setup.nu")
+
+
+class RepoServerStabilityGateTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open(SETUP, encoding="utf-8") as fh:
+            cls.text = fh.read()
+
+    def test_stability_wait_function_defined(self):
+        self.assertRegex(self.text, r"def wait_for_repo_server_stable")
+
+    def test_checks_readiness_and_restart_stability(self):
+        start = self.text.index("def wait_for_repo_server_stable")
+        end = self.text.index("\ndef ", start + 10)
+        body = self.text[start:end]
+        self.assertIn("argocd-repo-server", body)
+        self.assertIn("restartCount", body)
+        self.assertRegex(body, r"error make", "must fail closed if repo-server never stabilizes")
+
+    def test_status_output_does_not_parse_label_as_a_subcommand(self):
+        # In Nushell interpolation, `(restarts: ($restarts))` is parsed as an
+        # attempted external command named `restarts:` at runtime even though
+        # `nu --ide-check` accepts the file. Keep labels outside interpolation.
+        start = self.text.index("def wait_for_repo_server_stable")
+        end = self.text.index("\ndef ", start + 10)
+        body = self.text[start:end]
+        self.assertNotIn("(restarts:", body)
+
+    def test_called_between_root_app_deploy_and_gated_sync(self):
+        deploy_start = self.text.index("def deploy_root_app")
+        deploy_end = self.text.index("\ndef ", deploy_start + 10)
+        body = self.text[deploy_start:deploy_end]
+        root_apply_pos = body.index("root-app.yaml")
+        stability_pos = body.index("wait_for_repo_server_stable")
+        gated_sync_pos = body.index("sync_gated_apps_for_local_dev")
+        self.assertTrue(
+            root_apply_pos < stability_pos < gated_sync_pos,
+            "must apply root-app, THEN wait for repo-server stability, THEN start gated sync",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_repo_server_stability_gate.py
+++ b/platform/tests/test_repo_server_stability_gate.py
@@ -37,6 +37,16 @@ class RepoServerStabilityGateTest(unittest.TestCase):
         self.assertIn("restartCount", body)
         self.assertRegex(body, r"error make", "must fail closed if repo-server never stabilizes")
 
+    def test_checks_every_pod_identity_and_deployment_rollout(self):
+        start = self.text.index("def wait_for_repo_server_stable")
+        end = self.text.index("\ndef ", start + 10)
+        body = self.text[start:end]
+        self.assertIn("metadata.uid", body)
+        self.assertIn("readyReplicas", body)
+        self.assertIn("updatedReplicas", body)
+        self.assertIn("availableReplicas", body)
+        self.assertNotIn("items | first", body)
+
     def test_status_output_does_not_parse_label_as_a_subcommand(self):
         # In Nushell interpolation, `(restarts: ($restarts))` is parsed as an
         # attempted external command named `restarts:` at runtime even though

--- a/platform/tests/test_sonarqube_migration.py
+++ b/platform/tests/test_sonarqube_migration.py
@@ -73,11 +73,15 @@ class ValuesMigrationTest(unittest.TestCase):
         self.assertEqual(self.values["community"]["buildNumber"], EXPECTED_BUILD,
                          "community.buildNumber must align with the 2026.x chart")
 
-    def test_community_image_is_digest_pinned(self):
+    def test_community_image_is_digest_pinned_with_label_safe_tag(self):
         image = self.values["image"]
         self.assertEqual(image.get("repository"), "sonarqube")
+        self.assertEqual(image.get("tag"), "26.5.0.122743-community")
+        pinned = self.values["global"]["azure"]["images"]["sonarqube"]
+        self.assertEqual(pinned.get("registry"), "docker.io")
+        self.assertEqual(pinned.get("image"), "sonarqube")
         self.assertEqual(
-            image.get("tag"),
+            pinned.get("tag"),
             "26.5.0.122743-community@sha256:223d0090322edce6211a5328298b6f646920f1535025ef8dd880cab6647bb1fa",
         )
 

--- a/policies/kyverno/appclaims/require-appclaim-fields.yaml
+++ b/policies/kyverno/appclaims/require-appclaim-fields.yaml
@@ -18,9 +18,7 @@ spec:
         any:
           - resources:
               kinds:
-                - AppClaim
-              apiGroups:
-                - platform.digiorg.io
+                - platform.digiorg.io/v1alpha1/AppClaim
       validate:
         allowExistingViolations: true
         message: "AppClaim spec.appName is required and must be non-empty"
@@ -34,9 +32,7 @@ spec:
         any:
           - resources:
               kinds:
-                - AppClaim
-              apiGroups:
-                - platform.digiorg.io
+                - platform.digiorg.io/v1alpha1/AppClaim
       validate:
         allowExistingViolations: true
         message: "AppClaim spec.team is required and must be non-empty"
@@ -50,9 +46,7 @@ spec:
         any:
           - resources:
               kinds:
-                - AppClaim
-              apiGroups:
-                - platform.digiorg.io
+                - platform.digiorg.io/v1alpha1/AppClaim
       validate:
         allowExistingViolations: true
         message: "AppClaim spec.size is required and must be non-empty (valid values: S, M, L)"

--- a/policies/kyverno/appclaims/require-appclaim-fields.yaml
+++ b/policies/kyverno/appclaims/require-appclaim-fields.yaml
@@ -9,8 +9,11 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  admission: true
+  emitWarning: false
   rules:
     - name: require-appname
+      skipBackgroundRequests: true
       match:
         any:
           - resources:
@@ -19,12 +22,14 @@ spec:
               apiGroups:
                 - platform.digiorg.io
       validate:
+        allowExistingViolations: true
         message: "AppClaim spec.appName is required and must be non-empty"
         pattern:
           spec:
             appName: "?*"
 
     - name: require-team
+      skipBackgroundRequests: true
       match:
         any:
           - resources:
@@ -33,12 +38,14 @@ spec:
               apiGroups:
                 - platform.digiorg.io
       validate:
+        allowExistingViolations: true
         message: "AppClaim spec.team is required and must be non-empty"
         pattern:
           spec:
             team: "?*"
 
     - name: require-size
+      skipBackgroundRequests: true
       match:
         any:
           - resources:
@@ -47,6 +54,7 @@ spec:
               apiGroups:
                 - platform.digiorg.io
       validate:
+        allowExistingViolations: true
         message: "AppClaim spec.size is required and must be non-empty (valid values: S, M, L)"
         pattern:
           spec:

--- a/policies/kyverno/appclaims/validate-size.yaml
+++ b/policies/kyverno/appclaims/validate-size.yaml
@@ -13,14 +13,18 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: true
+  admission: true
+  emitWarning: false
   rules:
     - name: validate-size
+      skipBackgroundRequests: true
       match:
         any:
           - resources:
               kinds:
                 - platform.digiorg.io/v1alpha1/AppClaim
       validate:
+        allowExistingViolations: true
         message: "spec.size must be one of: S, M, L"
         pattern:
           spec:

--- a/policies/kyverno/cluster-policies/block-appclaims-in-system-namespaces.yaml
+++ b/policies/kyverno/cluster-policies/block-appclaims-in-system-namespaces.yaml
@@ -24,7 +24,7 @@ spec:
         any:
           - resources:
               kinds:
-                - AppClaim
+                - platform.digiorg.io/v1alpha1/AppClaim
               namespaces:
                 # Kubernetes system namespaces
                 - kube-system

--- a/policies/kyverno/cluster-policies/block-appclaims-in-system-namespaces.yaml
+++ b/policies/kyverno/cluster-policies/block-appclaims-in-system-namespaces.yaml
@@ -15,8 +15,11 @@ metadata:
 spec:
   validationFailureAction: Enforce
   background: false
+  admission: true
+  emitWarning: false
   rules:
     - name: block-appclaims-in-system-namespaces
+      skipBackgroundRequests: true
       match:
         any:
           - resources:
@@ -44,6 +47,7 @@ spec:
                 - code-quality
                 - platform-apps
       validate:
+        allowExistingViolations: true
         message: >-
           AppClaims may not be created or updated in system or platform
           namespaces. Please use an application or team namespace instead.

--- a/policies/kyverno/cluster-policies/generate-app-namespace-netpol.yaml
+++ b/policies/kyverno/cluster-policies/generate-app-namespace-netpol.yaml
@@ -14,8 +14,13 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/category: Network
 spec:
+  validationFailureAction: Audit
+  background: true
+  admission: true
+  emitWarning: false
   rules:
     - name: generate-default-deny-ingress
+      skipBackgroundRequests: true
       # Triggered when a Namespace is created or updated with the app label.
       # AppClaim compositions must set: platform.digiorg.io/type: app
       match:

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -118,11 +118,16 @@ def "main bootstrap" [] {
     print "Waiting for cluster nodes..."
     kubectl wait --for=condition=Ready nodes --all --timeout=120s
     
-    # 2. Set vm.max_map_count on KinD node (required by OpenSearch)
-    print "1.2 Setting vm.max_map_count on KinD node..."
+    # 2. Set node runtime limits required by the local all-in-one platform.
+    # OpenSearch needs vm.max_map_count. The many Kubernetes controllers use
+    # inotify; KinD's default 128 user instances is exhausted during a full
+    # bootstrap and prevents hook containers from starting (issue #279).
+    print "1.2 Setting KinD node runtime limits..."
     let kind_node = $"($CLUSTER_NAME)-control-plane"
     docker exec $kind_node sysctl -w vm.max_map_count=262144
-    print $"(ansi green)✓ vm.max_map_count=262144 set on KinD node(ansi reset)"
+    docker exec $kind_node sysctl -w fs.inotify.max_user_instances=8192
+    docker exec $kind_node sysctl -w fs.inotify.max_user_watches=1048576
+    print $"(ansi green)✓ KinD node runtime limits configured(ansi reset)"
     
     # 3. Install Gateway API CRDs
     print "1.3 Installing Gateway API CRDs..."

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -770,13 +770,6 @@ def is_retryable_sync_error [message: string] {
     }
     let normalized = ($message | str lowercase)
 
-    # One narrowly identified resource-health race is transient even though the
-    # operation-level message is generic. Permanent init failures use different
-    # messages (CrashLoopBackOff, non-zero exit, BackoffLimitExceeded).
-    if ($normalized | str contains "containers with incomplete status:") {
-        return true
-    }
-
     # Deterministic render/apply/auth/policy errors always win over transport
     # words embedded in their text (for example "unexpected EOF" or a webhook
     # endpoint reporting "connection refused").
@@ -797,6 +790,12 @@ def is_retryable_sync_error [message: string] {
         if ($normalized | str contains $marker) {
             return false
         }
+    }
+
+    # One narrowly identified resource-health race is transient only when no
+    # deterministic marker occurs anywhere in the combined diagnostics.
+    if ($normalized | str contains "containers with incomplete status:") {
+        return true
     }
 
     # gRPC Unavailable/DeadlineExceeded and an explicit broken server read are
@@ -852,9 +851,10 @@ def is_retryable_sync_error [message: string] {
 # values. Classification still uses the original text; only output is redacted.
 def redact_sync_diagnostic [message: string] {
     $message
-    | str replace --all --regex '(?i)authorization\s*:\s*bearer\s+[^\s,;]+' 'Authorization: [REDACTED]'
+    | str replace --all --regex '(?i)authorization\s*[:=]\s*(bearer|basic)\s+[^\s,;]+' 'Authorization: [REDACTED]'
     | str replace --all --regex '(?i)https?://[^\s/@:]+:[^\s/@]+@' 'https://[REDACTED]@'
-    | str replace --all --regex '(?i)(password|token|api[_-]?key|client[_-]?secret)\s*[:=]\s*[^\s,;]+' '[REDACTED]'
+    | str replace --all --regex `(?i)["']?(password|token|api[_-]?key|client[_-]?secret|secret)["']?\s*[:=]\s*["'][^"']*["']` '[REDACTED]'
+    | str replace --all --regex `(?i)["']?(password|token|api[_-]?key|client[_-]?secret|secret)["']?\s*[:=]\s*[^\s,;}]+` '[REDACTED]'
     | str replace --all --regex '(?i)secret\s+data\s*[:=]\s*[^\s,;]+' 'Secret data: [REDACTED]'
 }
 

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -21,6 +21,7 @@
 # Configuration
 let CLUSTER_NAME = "digiorg-core-dev"
 let KIND_CONFIG = "platform/bootstrap/kind-config.yaml"
+let KIND_NODE_IMAGE = "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
 let KUBECONFIG_PATH = $"($env.PWD)/kubeconfig-local.yaml"
 
 # Main entry point
@@ -108,7 +109,7 @@ def "main bootstrap" [] {
         print $"(ansi yellow)✓ Cluster '($CLUSTER_NAME)' already exists(ansi reset)"
     } else {
         print "1.1 Creating KinD cluster..."
-        kind create cluster --config $KIND_CONFIG --kubeconfig $KUBECONFIG_PATH
+        kind create cluster --image $KIND_NODE_IMAGE --config $KIND_CONFIG --kubeconfig $KUBECONFIG_PATH
         print $"(ansi green)✓ KinD cluster created(ansi reset)"
     }
     $env.KUBECONFIG = $KUBECONFIG_PATH
@@ -682,34 +683,76 @@ def deploy_root_app [] {
 def wait_for_repo_server_stable [] {
     $env.KUBECONFIG = $KUBECONFIG_PATH
 
-    mut previous_restarts = -1
+    mut previous_snapshot = []
     mut stable_checks = 0
+    mut last_diagnostic = "repo-server state was not observed"
     for attempt in 1..60 {
-        let result = (do {
+        let pods_result = (do {
             kubectl get pods -n argocd -l app.kubernetes.io/name=argocd-repo-server -o json
         } | complete)
-        if $result.exit_code == 0 {
-            let pods = ($result.stdout | from json | get -o items | default [])
-            if ($pods | length) > 0 {
-                let pod = ($pods | first)
-                let ready = ($pod | get -o status.containerStatuses.0.ready | default false)
-                let restarts = ($pod | get -o status.containerStatuses.0.restartCount | default 0)
-                if $ready and $restarts == $previous_restarts {
-                    $stable_checks = $stable_checks + 1
-                } else {
-                    $stable_checks = 0
+        let deployment_result = (do {
+            kubectl get deployment argocd-repo-server -n argocd -o json
+        } | complete)
+
+        if $pods_result.exit_code == 0 and $deployment_result.exit_code == 0 {
+            let pods = ($pods_result.stdout | from json | get -o items | default [])
+            let deployment = ($deployment_result.stdout | from json)
+            let desired = ($deployment | get -o spec.replicas | default 0)
+            let ready_replicas = ($deployment | get -o status.readyReplicas | default 0)
+            let updated_replicas = ($deployment | get -o status.updatedReplicas | default 0)
+            let available_replicas = ($deployment | get -o status.availableReplicas | default 0)
+            let observed_generation = ($deployment | get -o status.observedGeneration | default 0)
+            let generation = ($deployment | get -o metadata.generation | default (-1))
+
+            let pod_snapshot = (
+                $pods
+                | each {|pod|
+                    let statuses = ($pod | get -o status.containerStatuses | default [])
+                    let ready = (($statuses | length) > 0) and ($statuses | all {|status| $status.ready })
+                    let restarts = if ($statuses | length) == 0 { 0 } else {
+                        $statuses | get restartCount | math sum
+                    }
+                    {
+                        name: ($pod | get -o metadata.name | default "")
+                        uid: ($pod | get -o metadata.uid | default "")
+                        ready: $ready
+                        restarts: $restarts
+                    }
                 }
-                $previous_restarts = $restarts
-                print $"  repo-server: ready=($ready) restartCount=($restarts) stable_checks=($stable_checks)/3"
-                if $stable_checks >= 3 {
-                    print $"(ansi green)✓ argocd-repo-server is Ready and restart-stable; restartCount=($restarts)(ansi reset)"
-                    return
-                }
+                | sort-by name
+            )
+            let all_pods_ready = (($pod_snapshot | length) == $desired) and ($pod_snapshot | all {|pod| $pod.ready })
+            let rollout_complete = (
+                $desired > 0
+                and $ready_replicas == $desired
+                and $updated_replicas == $desired
+                and $available_replicas == $desired
+                and $observed_generation == $generation
+            )
+            let unchanged = ($pod_snapshot == $previous_snapshot)
+
+            if $all_pods_ready and $rollout_complete and $unchanged {
+                $stable_checks = $stable_checks + 1
+            } else {
+                $stable_checks = 0
             }
+            $previous_snapshot = $pod_snapshot
+            $last_diagnostic = $"desired=($desired) ready=($ready_replicas) updated=($updated_replicas) available=($available_replicas) pods=($pod_snapshot | length)"
+            print $"  repo-server: ($last_diagnostic) stable_checks=($stable_checks)/3"
+            if $stable_checks >= 3 {
+                let total_restarts = ($pod_snapshot | get restarts | math sum)
+                print $"(ansi green)✓ argocd-repo-server rollout is Ready and identity-stable; totalRestarts=($total_restarts)(ansi reset)"
+                return
+            }
+        } else {
+            let stderr = ($pods_result.stderr + " " + $deployment_result.stderr | str trim)
+            $last_diagnostic = (redact_sync_diagnostic $stderr)
+            $stable_checks = 0
+            $previous_snapshot = []
         }
         sleep 5sec
     }
-    error make {msg: "argocd-repo-server did not become Ready and restart-stable within the timeout"}
+    error make {msg: $"argocd-repo-server did not become Ready and identity-stable within the timeout: ($last_diagnostic)"}
 }
 
 # Issue #279: classify an Argo CD operationState.message as retryable
@@ -720,28 +763,94 @@ def is_retryable_sync_error [message: string] {
     if ($message | str trim | is-empty) {
         return false
     }
-    let transient_markers = [
-        "code = Unavailable"
-        "code = DeadlineExceeded"
-        "EOF"
+    let normalized = ($message | str lowercase)
+
+    # One narrowly identified resource-health race is transient even though the
+    # operation-level message is generic. Permanent init failures use different
+    # messages (CrashLoopBackOff, non-zero exit, BackoffLimitExceeded).
+    if ($normalized | str contains "containers with incomplete status:") {
+        return true
+    }
+
+    # Deterministic render/apply/auth/policy errors always win over transport
+    # words embedded in their text (for example "unexpected EOF" or a webhook
+    # endpoint reporting "connection refused").
+    let deterministic_markers = [
+        "invalidargument"
+        "permissiondenied"
+        "unauthenticated"
+        "failed to unmarshal"
+        "yaml parse error"
+        "unexpected eof"
+        "helm template failed"
+        "admission webhook"
+        "failed calling webhook"
+        "backofflimitexceeded"
+        "is invalid:"
+    ]
+    for marker in $deterministic_markers {
+        if ($normalized | str contains $marker) {
+            return false
+        }
+    }
+
+    # gRPC Unavailable/DeadlineExceeded and an explicit broken server read are
+    # transport failures. Generic dial/EOF/timeout words require repository or
+    # comparison context below instead of being accepted globally.
+    let explicit_transport_markers = [
+        "code = unavailable"
+        "code = deadlineexceeded"
+        "error reading from server: eof"
         "transport is closing"
-        "connection refused"
         "connection reset by peer"
-        "server misbehaving"
-        "no route to host"
-        "i/o timeout"
-        "TLS handshake timeout"
-        "dial tcp"
-        "context deadline exceeded"
         "client connection lost"
         "broken pipe"
     ]
-    for marker in $transient_markers {
-        if ($message | str contains $marker) {
+    for marker in $explicit_transport_markers {
+        if ($normalized | str contains $marker) {
             return true
         }
     }
-    false
+
+    let repository_context_markers = [
+        "repo-server"
+        "repository"
+        "comparisonerror"
+        "manifest generation"
+        "failed to list refs"
+        "list refs"
+        "github.com"
+        "gitlab.com"
+        "bitbucket.org"
+        "helm repository"
+    ]
+    let generic_transport_markers = [
+        "eof"
+        "connection refused"
+        "server misbehaving"
+        "no route to host"
+        "i/o timeout"
+        "tls handshake timeout"
+        "dial tcp"
+        "context deadline exceeded"
+        "temporary failure in name resolution"
+        "no such host"
+    ]
+    let has_repository_context = ($repository_context_markers | any {|marker| $normalized | str contains $marker })
+    let has_transport_failure = ($generic_transport_markers | any {|marker| $normalized | str contains $marker })
+    $has_repository_context and $has_transport_failure
+}
+
+# Redact likely credentials from controller/admission messages before they are
+# printed or included in a terminal error. Diagnostics are untrusted text: a
+# failed webhook or tool can echo request headers, URLs with userinfo, or Secret
+# values. Classification still uses the original text; only output is redacted.
+def redact_sync_diagnostic [message: string] {
+    $message
+    | str replace --all --regex '(?i)authorization\s*:\s*bearer\s+[^\s,;]+' 'Authorization: [REDACTED]'
+    | str replace --all --regex '(?i)https?://[^\s/@:]+:[^\s/@]+@' 'https://[REDACTED]@'
+    | str replace --all --regex '(?i)(password|token|api[_-]?key|client[_-]?secret)\s*[:=]\s*[^\s,;]+' '[REDACTED]'
+    | str replace --all --regex '(?i)secret\s+data\s*[:=]\s*[^\s,;]+' 'Secret data: [REDACTED]'
 }
 
 # Print operationState.message plus any failed resource/hook messages so a
@@ -749,7 +858,8 @@ def is_retryable_sync_error [message: string] {
 def print_sync_diagnostics [state: record] {
     let message = ($state | get -o status.operationState.message | default "")
     if not ($message | is-empty) {
-        print $"(ansi red)    operationState.message: ($message)(ansi reset)"
+        let safe_message = (redact_sync_diagnostic $message)
+        print $"(ansi red)    operationState.message: ($safe_message)(ansi reset)"
     }
     let resources = ($state | get -o status.operationState.syncResult.resources | default [])
     for r in $resources {
@@ -759,7 +869,8 @@ def print_sync_diagnostics [state: record] {
             let kind = ($r | get -o kind | default "")
             let name = ($r | get -o name | default "")
             let rmsg = ($r | get -o message | default "")
-            print $"(ansi red)    ($kind)/($name): status=($rstatus) hookPhase=($hook_phase) ($rmsg)(ansi reset)"
+            let safe_rmsg = (redact_sync_diagnostic $rmsg)
+            print $"(ansi red)    ($kind)/($name): status=($rstatus) hookPhase=($hook_phase) ($safe_rmsg)(ansi reset)"
         }
     }
 }
@@ -804,6 +915,7 @@ def sync_gated_apps_for_local_dev [] {
         mut retry_count = 0
         loop {
             let previous_state = (kubectl get application $app -n argocd -o json | from json)
+            let previous_started = ($previous_state | get -o status.operationState.startedAt | default "")
             let previous_finished = ($previous_state | get -o status.operationState.finishedAt | default "")
             print $"  Syncing gated Application: ($app) \(attempt ($retry_count + 1)/($max_operation_retries + 1)\)"
             let sync_result = (do {
@@ -825,10 +937,11 @@ def sync_gated_apps_for_local_dev [] {
                     let state = ($state_result.stdout | from json)
                     $last_state = $state
                     let phase = ($state | get -o status.operationState.phase | default "")
+                    let started = ($state | get -o status.operationState.startedAt | default "")
                     let finished = ($state | get -o status.operationState.finishedAt | default "")
                     let sync = ($state | get -o status.sync.status | default "")
                     let health = ($state | get -o status.health.status | default "")
-                    if $phase == "Running" or $finished != $previous_finished {
+                    if not ($started | is-empty) and $started != $previous_started {
                         $saw_new_operation = true
                     }
                     if $saw_new_operation and $phase in ["Failed" "Error"] {
@@ -844,7 +957,12 @@ def sync_gated_apps_for_local_dev [] {
                 sleep 10sec
             }
             if not $completed {
-                error make {msg: $"Gated Application ($app) did not complete a new successful Synced+Healthy operation within 15 minutes"}
+                if not ($last_state | is-empty) {
+                    print_sync_diagnostics $last_state
+                }
+                let observed_started = ($last_state | get -o status.operationState.startedAt | default "")
+                let observed_finished = ($last_state | get -o status.operationState.finishedAt | default "")
+                error make {msg: $"Gated Application ($app) did not complete a fresh successful Synced+Healthy operation within 15 minutes; previousStarted=($previous_started) previousFinished=($previous_finished) observedStarted=($observed_started) observedFinished=($observed_finished)"}
             }
 
             if $succeeded {
@@ -855,16 +973,25 @@ def sync_gated_apps_for_local_dev [] {
             # Operation reached Failed/Error: surface full diagnostics before
             # deciding whether this is retryable.
             let message = ($last_state | get -o status.operationState.message | default "")
+            let resource_messages = (
+                $last_state
+                | get -o status.operationState.syncResult.resources
+                | default []
+                | each {|resource| $resource | get -o message | default "" }
+                | where {|resource_message| not ($resource_message | is-empty) }
+            )
+            let classification_text = ([$message] | append $resource_messages | str join "\n")
             print $"(ansi red)  ✗ ($app) sync failed(ansi reset)"
             print_sync_diagnostics $last_state
 
-            if (is_retryable_sync_error $message) and $retry_count < $max_operation_retries {
+            if (is_retryable_sync_error $classification_text) and $retry_count < $max_operation_retries {
                 let backoff = (10 * (2 ** $retry_count)) * 1sec
                 print $"(ansi yellow)  Transient error detected; retrying ($app) in ($backoff) with a fresh sync operation...(ansi reset)"
                 sleep $backoff
                 $retry_count = $retry_count + 1
             } else {
-                error make {msg: $"Gated Application ($app) sync failed with phase Error/Failed - not retryable or retries exhausted - : ($message)"}
+                let safe_message = (redact_sync_diagnostic $message)
+                error make {msg: $"Gated Application ($app) sync failed with phase Error/Failed - not retryable or retries exhausted: ($safe_message)"}
             }
         }
     }

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -1002,6 +1002,37 @@ def sync_gated_apps_for_local_dev [] {
     }
 }
 
+# Argo CD 3.x can retain stale per-resource OutOfSync status after a successful
+# Helm sync even when its own diff engine reports no material difference (seen
+# with API-defaulted CRD fields). Use the CLI only as a fail-closed secondary
+# check: exit 0 means no diff; any missing CLI, setup error, or non-zero exit
+# remains not ready. Diagnostics are captured and never printed.
+def argocd_app_has_no_material_diff [app: string] {
+    if (which argocd | is-empty) {
+        return false
+    }
+
+    let temp_kubeconfig = (mktemp --tmpdir argocd-core-kubeconfig.XXXXXX | str trim)
+    try {
+        cp $KUBECONFIG_PATH $temp_kubeconfig
+        let context = (do {
+            kubectl --kubeconfig $temp_kubeconfig config set-context --current --namespace=argocd
+        } | complete)
+        if $context.exit_code != 0 {
+            return false
+        }
+
+        let diff = (with-env {KUBECONFIG: $temp_kubeconfig} {
+            do { argocd app diff $app --core --refresh } | complete
+        })
+        $diff.exit_code == 0
+    } catch {
+        false
+    } finally {
+        rm -f $temp_kubeconfig
+    }
+}
+
 # Wait for ArgoCD apps to become healthy
 def wait_for_argocd_apps [] {
     $env.KUBECONFIG = $KUBECONFIG_PATH
@@ -1052,6 +1083,11 @@ def wait_for_argocd_apps [] {
                 let health = ($state | get -o status.health.status | default "")
                 let sync = ($state | get -o status.sync.status | default "")
                 if $health == "Healthy" and $sync == "Synced" {
+                    $ready_count = $ready_count + 1
+                } else if $health == "Healthy" and $sync == "OutOfSync" and (argocd_app_has_no_material_diff $app) {
+                    # Count only a successful, fresh Argo core diff with zero
+                    # material changes; every tool/error path remains closed.
+                    print $"  ($app): stale OutOfSync status, but Argo reports no material diff"
                     $ready_count = $ready_count + 1
                 }
             }

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -633,10 +633,10 @@ def build_tier1_images [] {
 # Deploy ArgoCD Root App (triggers App-of-Apps)
 def deploy_root_app [] {
     $env.KUBECONFIG = $KUBECONFIG_PATH
-    
+
     print "Deploying ArgoCD Root App..."
     kubectl apply -f platform/base/argocd/applications/root-app.yaml
-    
+
     print $"(ansi green)✓ Root App deployed - ArgoCD will now sync all platform components(ansi reset)"
     print ""
     print "ArgoCD Sync Waves:"
@@ -651,6 +651,17 @@ def deploy_root_app [] {
     print "  Wave  7: crossplane-xrds"
     print "  Wave  8: core-catalog"
 
+    # Issue #279: the root Application immediately fans out into many
+    # concurrent Git/Helm/Kustomize renders. Wait for argocd-repo-server to be
+    # Ready and restart-stable before promoting gated syncs, so the first gated
+    # operation doesn't race the initial render burst (confirmed cause of the
+    # repo-server liveness restart that severed External Secrets' manifest
+    # generation with gRPC Unavailable/EOF).
+    print ""
+    print $"(ansi cyan_bold)Waiting for argocd-repo-server to stabilize(ansi reset)"
+    print "────────────────────────────────────"
+    wait_for_repo_server_stable
+
     # The repository keeps major upgrades manual so a Git merge cannot trigger
     # them concurrently in a shared cluster. This script targets only the named
     # local KinD environment; invoking `main up` is the explicit approval to sync
@@ -664,8 +675,105 @@ def deploy_root_app [] {
     wait_for_argocd_apps
 }
 
+# Issue #279: wait for argocd-repo-server to be Ready AND to have stopped
+# restarting before promoting any gated Application. Bounded and fails closed
+# — a repo-server that never stabilizes surfaces as a clear error rather than
+# racing the first gated sync against it.
+def wait_for_repo_server_stable [] {
+    $env.KUBECONFIG = $KUBECONFIG_PATH
+
+    mut previous_restarts = -1
+    mut stable_checks = 0
+    for attempt in 1..60 {
+        let result = (do {
+            kubectl get pods -n argocd -l app.kubernetes.io/name=argocd-repo-server -o json
+        } | complete)
+        if $result.exit_code == 0 {
+            let pods = ($result.stdout | from json | get -o items | default [])
+            if ($pods | length) > 0 {
+                let pod = ($pods | first)
+                let ready = ($pod | get -o status.containerStatuses.0.ready | default false)
+                let restarts = ($pod | get -o status.containerStatuses.0.restartCount | default 0)
+                if $ready and $restarts == $previous_restarts {
+                    $stable_checks = $stable_checks + 1
+                } else {
+                    $stable_checks = 0
+                }
+                $previous_restarts = $restarts
+                print $"  repo-server: ready=($ready) restartCount=($restarts) stable_checks=($stable_checks)/3"
+                if $stable_checks >= 3 {
+                    print $"(ansi green)✓ argocd-repo-server is Ready and restart-stable; restartCount=($restarts)(ansi reset)"
+                    return
+                }
+            }
+        }
+        sleep 5sec
+    }
+    error make {msg: "argocd-repo-server did not become Ready and restart-stable within the timeout"}
+}
+
+# Issue #279: classify an Argo CD operationState.message as retryable
+# (transient repo-server/network/comparison failures) or fatal (deterministic
+# manifest/resource/hook/policy errors, which must fail immediately). Fail
+# closed: an unrecognized message is treated as fatal, not retryable.
+def is_retryable_sync_error [message: string] {
+    if ($message | str trim | is-empty) {
+        return false
+    }
+    let transient_markers = [
+        "code = Unavailable"
+        "code = DeadlineExceeded"
+        "EOF"
+        "transport is closing"
+        "connection refused"
+        "connection reset by peer"
+        "server misbehaving"
+        "no route to host"
+        "i/o timeout"
+        "TLS handshake timeout"
+        "dial tcp"
+        "context deadline exceeded"
+        "client connection lost"
+        "broken pipe"
+    ]
+    for marker in $transient_markers {
+        if ($message | str contains $marker) {
+            return true
+        }
+    }
+    false
+}
+
+# Print operationState.message plus any failed resource/hook messages so a
+# gated-sync failure is diagnosable from the script's own output.
+def print_sync_diagnostics [state: record] {
+    let message = ($state | get -o status.operationState.message | default "")
+    if not ($message | is-empty) {
+        print $"(ansi red)    operationState.message: ($message)(ansi reset)"
+    }
+    let resources = ($state | get -o status.operationState.syncResult.resources | default [])
+    for r in $resources {
+        let rstatus = ($r | get -o status | default "")
+        let hook_phase = ($r | get -o hookPhase | default "")
+        if ($rstatus == "SyncFailed") or ($hook_phase in ["Failed" "Error"]) {
+            let kind = ($r | get -o kind | default "")
+            let name = ($r | get -o name | default "")
+            let rmsg = ($r | get -o message | default "")
+            print $"(ansi red)    ($kind)/($name): status=($rstatus) hookPhase=($hook_phase) ($rmsg)(ansi reset)"
+        }
+    }
+}
+
 # Explicitly promote gated major upgrades on the disposable local KinD cluster.
 # Shared/production clusters must follow docs/guides/platform-versions.md instead.
+#
+# Issue #279: a gated Application's operation can fail with a transient
+# repo-server/comparison error (confirmed: repo-server liveness restart
+# severing manifest generation mid-render, surfaced as ComparisonError / gRPC
+# Unavailable / EOF). Those are retried with bounded exponential backoff by
+# reissuing a genuinely fresh sync operation (`kubectl patch` again, not
+# re-reading the stale terminal operation). Deterministic manifest/resource/
+# hook/policy errors fail immediately — no retry.
 def sync_gated_apps_for_local_dev [] {
     let gated_apps = [
         "external-secrets", "nats", "grafana", "opencost", "gitea",
@@ -673,6 +781,7 @@ def sync_gated_apps_for_local_dev [] {
         "crossplane-provider-configs", "crossplane-xrds", "core-catalog"
     ]
     let sync_payload = '{"operation":{"sync":{"prune":true,"syncOptions":["CreateNamespace=true","ServerSideApply=true"]}}}'
+    let max_operation_retries = 3
 
     print ""
     print $"(ansi cyan_bold)Promoting gated upgrades sequentially on local KinD(ansi reset)"
@@ -692,45 +801,72 @@ def sync_gated_apps_for_local_dev [] {
             error make {msg: $"ArgoCD Application ($app) was not created by the root app"}
         }
 
-        let previous_state = (kubectl get application $app -n argocd -o json | from json)
-        let previous_finished = ($previous_state | get -o status.operationState.finishedAt | default "")
-        print $"  Syncing gated Application: ($app)"
-        let sync_result = (do {
-            kubectl patch application $app -n argocd --type merge -p $sync_payload
-        } | complete)
-        if $sync_result.exit_code != 0 {
-            error make {msg: $"Could not start sync for ($app): ($sync_result.stderr | str trim)"}
-        }
-
-        mut completed = false
-        mut saw_new_operation = false
-        for attempt in 1..90 {
-            let state_result = (do {
-                kubectl get application $app -n argocd -o json
+        mut retry_count = 0
+        loop {
+            let previous_state = (kubectl get application $app -n argocd -o json | from json)
+            let previous_finished = ($previous_state | get -o status.operationState.finishedAt | default "")
+            print $"  Syncing gated Application: ($app) \(attempt ($retry_count + 1)/($max_operation_retries + 1)\)"
+            let sync_result = (do {
+                kubectl patch application $app -n argocd --type merge -p $sync_payload
             } | complete)
-            if $state_result.exit_code == 0 {
-                let state = ($state_result.stdout | from json)
-                let phase = ($state | get -o status.operationState.phase | default "")
-                let finished = ($state | get -o status.operationState.finishedAt | default "")
-                let sync = ($state | get -o status.sync.status | default "")
-                let health = ($state | get -o status.health.status | default "")
-                if $phase == "Running" or $finished != $previous_finished {
-                    $saw_new_operation = true
-                }
-                if $saw_new_operation and $phase in ["Failed" "Error"] {
-                    error make {msg: $"Gated Application ($app) sync failed with phase ($phase)"}
-                }
-                if $saw_new_operation and $phase == "Succeeded" and $sync == "Synced" and $health == "Healthy" {
-                    $completed = true
-                    break
-                }
+            if $sync_result.exit_code != 0 {
+                error make {msg: $"Could not start sync for ($app): ($sync_result.stderr | str trim)"}
             }
-            sleep 10sec
+
+            mut completed = false
+            mut saw_new_operation = false
+            mut succeeded = false
+            mut last_state = {}
+            for attempt in 1..90 {
+                let state_result = (do {
+                    kubectl get application $app -n argocd -o json
+                } | complete)
+                if $state_result.exit_code == 0 {
+                    let state = ($state_result.stdout | from json)
+                    $last_state = $state
+                    let phase = ($state | get -o status.operationState.phase | default "")
+                    let finished = ($state | get -o status.operationState.finishedAt | default "")
+                    let sync = ($state | get -o status.sync.status | default "")
+                    let health = ($state | get -o status.health.status | default "")
+                    if $phase == "Running" or $finished != $previous_finished {
+                        $saw_new_operation = true
+                    }
+                    if $saw_new_operation and $phase in ["Failed" "Error"] {
+                        $completed = true
+                        break
+                    }
+                    if $saw_new_operation and $phase == "Succeeded" and $sync == "Synced" and $health == "Healthy" {
+                        $completed = true
+                        $succeeded = true
+                        break
+                    }
+                }
+                sleep 10sec
+            }
+            if not $completed {
+                error make {msg: $"Gated Application ($app) did not complete a new successful Synced+Healthy operation within 15 minutes"}
+            }
+
+            if $succeeded {
+                print $"(ansi green)  ✓ ($app) sync Succeeded, Synced and Healthy(ansi reset)"
+                break
+            }
+
+            # Operation reached Failed/Error: surface full diagnostics before
+            # deciding whether this is retryable.
+            let message = ($last_state | get -o status.operationState.message | default "")
+            print $"(ansi red)  ✗ ($app) sync failed(ansi reset)"
+            print_sync_diagnostics $last_state
+
+            if (is_retryable_sync_error $message) and $retry_count < $max_operation_retries {
+                let backoff = (10 * (2 ** $retry_count)) * 1sec
+                print $"(ansi yellow)  Transient error detected; retrying ($app) in ($backoff) with a fresh sync operation...(ansi reset)"
+                sleep $backoff
+                $retry_count = $retry_count + 1
+            } else {
+                error make {msg: $"Gated Application ($app) sync failed with phase Error/Failed - not retryable or retries exhausted - : ($message)"}
+            }
         }
-        if not $completed {
-            error make {msg: $"Gated Application ($app) did not complete a new successful Synced+Healthy operation within 15 minutes"}
-        }
-        print $"(ansi green)  ✓ ($app) sync Succeeded, Synced and Healthy(ansi reset)"
     }
 }
 


### PR DESCRIPTION
## Summary

- make gated Argo CD promotion diagnosable, secret-safe, bounded, and fail-closed
- retry only confirmed transient repository/transport failures and the exact Prometheus init race, requiring a fresh `startedAt` operation
- stabilize a clean KinD Kubernetes v1.36.1 bootstrap, including repo-server resources/probes, inotify limits, API-default drift, namespace ownership, and generated-secret drift
- fix Harbor proxy-cache convergence, NATS/PostgreSQL/OpenSearch drift, OpenCost Prometheus discovery, SonarQube image labeling, Kyverno v1.18 policy compatibility, Grafana generated credentials, and CNPG backup-PVC health
- migrate the external local Crossplane catalog to v2 pipeline Compositions and pin its immutable commit plus `function-patch-and-transform:v0.10.7`
- handle Argo CD 3.x stale `OutOfSync` resource status only when the Application is Healthy and a fresh, secret-suppressed Argo core diff exits successfully with no material changes; every missing-tool/error/nonzero path remains closed

Closes #279

## External dependency

- Catalog PR: https://github.com/digiorg/core-catalog/pull/17
- Immutable catalog commit: `4c30d9c3fa5c3c401c19f26b66a025854c65ee02`

## Validation

### Static

- `make test` — 251 tests passed
- `python3 scripts/check_pins.py` — passed
- `python3 scripts/render_platform_charts.py` — `HELM_RENDER_PASS=12`; no floating rendered image tags
- `git diff --check` — passed
- `nu --ide-check 999 scripts/local-setup.nu` — passed
- final working tree clean and HEAD equals the pushed remote branch

### Independent review

- full diff independently reviewed for merge blockers
- namespace/prune safety, retry collisions, diagnostic redaction, minimal Harbor/Grafana ignores, Kyverno, and Crossplane v2 were explicitly covered

### Remote clean KinD

Validated on a fresh remote KinD cluster:

- Kubernetes server `v1.36.1`
- Argo repo-server identity-stable with zero restarts
- all 11 gated Applications completed `Succeeded`, `Synced`, and `Healthy`
- aggregate gate passed `26/26` on the first continuation check
- Kyverno's retained `OutOfSync/Healthy` status was independently checked with `argocd app diff --core --refresh`: exit `0`, zero-byte diff
- External Secrets webhook Secret has four expected data fields
- NATS and Surveyor are Ready with zero restarts
- Crossplane Function and all three Providers report `Installed=True`, `Healthy=True`
- `core-catalog` reports `Synced/Healthy`
- SonarQube is Ready with zero restarts
- CNPG's idle backup PVC remains intentionally `Pending` with its selective health annotation
- OpenCost targets `prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090`
- centrally owned namespaces retain `Prune=false`
- no non-ready Running pods; pod readiness/restart state remained unchanged across a 30-second stability sample

## Notes

- The clean run exercised the known Prometheus `init-config-reloader` race: two fresh bounded retries were issued and the third operation converged.
- Runtime-only revision pins remain isolated on `test/issue-279-runtime` and are not part of this PR.
- This PR does not merge either repository PR automatically.
