### PR TITLE
fix(platform): make bootstrap convergence deterministic

### DIFF
--- a/apps/platform/cnpg-cluster.yaml
+++ b/apps/platform/cnpg-cluster.yaml
@@ -25,9 +25,14 @@ spec:
     namespace: platform-db
 
   syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
+    # Issue #281: script-driven, NOT automated. On a clean bootstrap an automated
+    # sync applied Cluster/postgresql-cnpg before the CNPG operator's admission
+    # webhook accepted connections (`connection refused`), and the failed
+    # operation then stayed Running behind a Pending backup PVC so Argo's retry
+    # never recovered. scripts/local-setup.nu (`promote_cnpg_cluster`) instead
+    # waits for the operator Deployment to be Available and the webhook endpoint
+    # to be ready, then syncs with a fresh operation. Shared/production clusters
+    # follow docs/guides/postgres-cnpg-migration.md.
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/platform/core-catalog.yaml
+++ b/apps/platform/core-catalog.yaml
@@ -14,9 +14,14 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core-catalog.git
-    # Crossplane v2 removed native `spec.resources` Compositions. This commit
-    # migrates the local catalog to function-patch-and-transform Pipeline mode.
-    targetRevision: 4c30d9c3fa5c3c401c19f26b66a025854c65ee02
+    # Crossplane v2 removed native `spec.resources` Compositions; the local
+    # catalog was migrated to function-patch-and-transform Pipeline mode in
+    # core-catalog PR #17. Pin the canonical *reviewed merge* commit of that PR
+    # (Issue #281 Phase 4). It is one commit ahead of the earlier implementation
+    # SHA (4c30d9c3…) with NO changed files, and core-catalog/main points at it;
+    # pinning the merge commit makes the deployed revision traceable to review.
+    # Keep this manual (no syncPolicy.automated) — see docs/guides/platform-versions.md.
+    targetRevision: 13b7a3b4a0b7a5f5e692dc6d5a3fa416852c4273
     path: compositions/local
 
   destination:

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -13,6 +13,7 @@ This guide walks you through setting up the DigiOrg Core Platform.
 | [Helm](https://helm.sh/docs/intro/install/) | >= 3.12 | Package manager |
 | [KinD](https://kind.sigs.k8s.io/) | >= 0.20 | Local Kubernetes |
 | [Nushell](https://www.nushell.sh/book/installation.html) | >= 0.90 | Setup scripts |
+| [Argo CD CLI](https://argo-cd.readthedocs.io/en/stable/cli_installation/) | v3.4.5 (matches server) | Required — final readiness verifies a stale `Healthy/OutOfSync` Application via `argocd app diff --core`; a missing or mismatched CLI fails the preflight instead of silently stalling bootstrap readiness (Issue #281) |
 
 ### Optional Tools
 

--- a/docs/guides/platform-versions.md
+++ b/docs/guides/platform-versions.md
@@ -164,6 +164,18 @@ where noted (this environment has no cluster — see section 7).
   patch-and-transform — any P&T Composition there must be converted to the
   function pipeline (`crossplane beta convert pipeline-composition`). Out of
   scope for this repo; validate `core-catalog` separately before promoting.
+- **core-catalog pin (Issue #281 Phase 4):** `apps/platform/core-catalog.yaml`
+  pins the **canonical reviewed merge commit** of core-catalog PR #17,
+  `13b7a3b4a0b7a5f5e692dc6d5a3fa416852c4273`. This supersedes the earlier
+  implementation SHA `4c30d9c3…`, which the merge commit is one commit ahead of
+  with **no changed files** (identical deployed content) — the change is
+  traceability only. The Application stays manually gated
+  (`platform.digiorg.io/upgrade-gate: issue-275-manual`, no `syncPolicy.automated`);
+  do not enable automatic catalog sync. `test_crossplane_migration.py`
+  (`CoreCatalogCanonicalPinTest`) locks the canonical pin, the immutable 40-hex
+  format, the manual gate, and that the superseded SHA is referenced nowhere.
+  When the reviewed revision advances, update the manifest, this line, and that
+  test's `CANONICAL_CATALOG_REVISION` together.
 - **Rollback:** revert the chart pin (2.3.3 → 1.19.0) and provider pins; v2→v1
   downgrade of a cluster with namespaced XRs is unsupported, but this repo keeps
   LegacyCluster semantics so no XR conversion occurs.

--- a/platform/base/cnpg/init-databases.yaml
+++ b/platform/base/cnpg/init-databases.yaml
@@ -165,6 +165,72 @@ spec:
     requests:
       storage: 5Gi
 ---
+# =============================================================================
+# One-shot backup-PVC bind Job (Issue #281)
+# =============================================================================
+# The backup PVC above is provisioned WaitForFirstConsumer (kind's default
+# `standard`/local-path StorageClass), so with no running consumer it stays
+# Pending. A Pending PVC kept the `cnpg-cluster` sync operation in `Running`
+# indefinitely — Argo waits for the PVC to become healthy even with the
+# `ignore-healthcheck` annotation on the object itself — which prevented the
+# configured retry from ever starting a fresh operation after the admission
+# webhook came up. This idempotent one-shot Job mounts the PVC exactly once so
+# the provisioner binds the volume; a Bound PVC is healthy, letting the sync
+# operation reach a terminal state. Re-running is a no-op (the Job spec is
+# unchanged, and a bound PVC stays bound).
+#
+# Sync-wave: this Job MUST share the backup PVC's wave (both wave 0), NOT a later
+# one. Argo CD syncs wave by wave and blocks each wave on its resources' health,
+# and the deployed Argo (v3.4.5) waits on the Pending PVC even with
+# `ignore-healthcheck`. A Job in a later wave would never be applied — the sync
+# would stall on the Pending PVC before reaching it — which is exactly the #281
+# deadlock. Applied in the same wave, the Job mounts the PVC, the
+# WaitForFirstConsumer provisioner binds it, and the wave can go healthy.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: postgresql-cnpg-backups-init
+  namespace: platform-db
+  annotations:
+    # Same wave (0) as the backup PVC above so the Sync hook is created
+    # together with it and binds it within the wave, instead of being gated
+    # behind the very PVC it is meant to make healthy. Delete the successful
+    # hook and recreate it before a future sync so Job immutability cannot break
+    # an idempotent resume or later manifest update.
+    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: 6
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgresql-cnpg-backups-init
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: bind
+          image: ghcr.io/cloudnative-pg/postgresql:16.9@sha256:cca50a94e2da46ddcaefb23260c805ed3b466763bd2a25e1617410176d5fd0ab
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              # Scheduling a Pod that mounts the claim is the consumer signal
+              # required by WaitForFirstConsumer. Do not write into the volume:
+              # the pinned PostgreSQL image runs unprivileged and a freshly
+              # provisioned local-path volume may initially be root-owned.
+              test -d /backups
+              echo "backup PVC mounted and bound"
+          volumeMounts:
+            - name: backups
+              mountPath: /backups
+      volumes:
+        - name: backups
+          persistentVolumeClaim:
+            claimName: postgresql-cnpg-backups
+---
 # Scheduled logical backup: nightly pg_dump of all six databases to the PVC
 # above. See docs/guides/postgres-cnpg-migration.md for restore steps.
 apiVersion: batch/v1

--- a/platform/base/gitea/values.yaml
+++ b/platform/base/gitea/values.yaml
@@ -5,6 +5,13 @@
 
 replicaCount: 1
 
+# A single Gitea replica owns LevelDB-backed queues on the shared /data volume.
+# RollingUpdate starts a second pod before terminating the first; the new pod
+# cannot acquire the queue lock and the rollout deadlocks. Recreate is required
+# for this single-writer persistent deployment.
+strategy:
+  type: Recreate
+
 image:
   # Chart 12 changed the default registry/repository layout from the historical
   # Docker Hub-style gitea/gitea path. Pin the actual 1.26.1 OCI index so the

--- a/platform/tests/test_bootstrap_convergence.py
+++ b/platform/tests/test_bootstrap_convergence.py
@@ -108,10 +108,12 @@ class ArgocdPrerequisiteTest(unittest.TestCase):
 
     def test_check_prerequisites_requires_argocd(self):
         body = _func_body(self.text, "check_prerequisites")
-        self.assertIn('"argocd"', body,
-                      "check_prerequisites must require the argocd CLI so the "
-                      "Healthy/OutOfSync material-diff fallback is never silently "
-                      "unavailable")
+        self.assertIn('"argocd"', body)
+        self.assertIn("argocd_client_version_matches", self.text)
+
+    def test_argocd_bootstrap_upgrade_reclaims_self_managed_fields_on_resume(self):
+        body = _func_body(self.text, "install_argocd")
+        self.assertIn("--force-conflicts", body)
 
     def test_check_prerequisites_verifies_matching_argocd_version(self):
         body = _func_body(self.text, "check_prerequisites")

--- a/platform/tests/test_bootstrap_convergence.py
+++ b/platform/tests/test_bootstrap_convergence.py
@@ -330,6 +330,12 @@ class ConfigurationDependencyTest(unittest.TestCase):
         ):
             self.assertIn(key, body)
 
+    def test_single_replica_gitea_uses_recreate_strategy_for_shared_data(self):
+        values_path = os.path.join(REPO_ROOT, "platform", "base", "gitea", "values.yaml")
+        values = yaml.safe_load(_read(values_path))
+        self.assertEqual(values.get("replicaCount"), 1)
+        self.assertEqual(values.get("strategy", {}).get("type"), "Recreate")
+
 
 class SecretResumeStabilityTest(unittest.TestCase):
     """Generated values are reused; only exact NotFound permits a fallback."""

--- a/platform/tests/test_bootstrap_convergence.py
+++ b/platform/tests/test_bootstrap_convergence.py
@@ -246,6 +246,13 @@ class ConfigurationDependencyTest(unittest.TestCase):
         self.assertEqual(_run_nu("sonarqube_http_status_matches 0 '302' '204'"), "false")
         self.assertEqual(_run_nu("sonarqube_http_status_matches 7 '204' '204'"), "false")
 
+    def test_sonarqube_http_runs_in_cluster_without_host_dns_dependency(self):
+        body = _func_body(self.text, "configure_sonarqube")
+        self.assertIn("sonarqube-sonarqube.code-quality.svc.cluster.local:9000", body)
+        self.assertIn("keycloak.keycloak.svc.cluster.local:8080", body)
+        self.assertIn("exec -i -n code-quality $sonar_pod -c sonarqube -- curl", body)
+        self.assertNotIn("$sonar_auth_config | curl", body)
+
     def test_dependency_wait_is_bounded_and_fail_closed(self):
         helper = _func_body(self.text, "wait_for_configuration_dependencies")
         self.assertIn("error make", helper)

--- a/platform/tests/test_bootstrap_convergence.py
+++ b/platform/tests/test_bootstrap_convergence.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""Bootstrap convergence gate + control-flow contract (Issue #281).
+
+A clean KinD bootstrap stalled at ``24/26`` because:
+
+  * the client-side readiness inventory in ``wait_for_argocd_apps`` drifted from
+    ``apps/platform/*.yaml`` (it omitted ``namespaces``);
+  * the timeout printed only the aggregate ``<ready>/<total>`` ratio and never
+    named the blocking Applications, and its status table was unreachable after
+    ``error make``;
+  * the only ``Healthy/OutOfSync`` material-diff fallback depends on the
+    ``argocd`` CLI, which ``check_prerequisites`` never validated, so the
+    fallback was silently unavailable;
+  * the single global gate ran *before* the identity-configuration phases, so an
+    unrelated late-wave drift (here ``cnpg-cluster``) aborted Gitea/SonarQube/
+    OIDC configuration entirely.
+
+This module locks the corrected contract with pure ``python3`` structural checks
+plus a couple of real-Nushell behaviour checks of the new pure helper::
+
+    python3 platform/tests/test_bootstrap_convergence.py
+"""
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment guard
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SETUP = os.path.join(REPO_ROOT, "scripts", "local-setup.nu")
+APPS_DIR = os.path.join(REPO_ROOT, "apps", "platform")
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _manifest_app_names():
+    names = set()
+    for name in os.listdir(APPS_DIR):
+        if not name.endswith((".yaml", ".yml")):
+            continue
+        with open(os.path.join(APPS_DIR, name), encoding="utf-8") as fh:
+            doc = yaml.safe_load(fh)
+        if doc and doc.get("kind") == "Application":
+            names.add(doc["metadata"]["name"])
+    return names
+
+
+def _func_body(text, name):
+    start = text.index(f"def {name} ")
+    end = text.index("\ndef ", start + 10)
+    return text[start:end]
+
+
+def _run_nu(expr: str) -> str:
+    result = subprocess.run(
+        ["nu", "-c", f"source {SETUP}; {expr}"],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"nu failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+class InventoryParityTest(unittest.TestCase):
+    """The waited Application-name set must equal every apps/platform manifest."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = _read(SETUP)
+
+    def _waited_names(self):
+        body = _func_body(self.text, "wait_for_argocd_apps")
+        marker = body.index("let apps = [")
+        block = body[marker:body.index("]", marker)]
+        return set(re.findall(r'"([a-z0-9-]+)"', block))
+
+    def test_wait_inventory_matches_manifests_exactly(self):
+        manifests = _manifest_app_names()
+        waited = self._waited_names()
+        self.assertEqual(
+            waited, manifests,
+            "the wait_for_argocd_apps inventory must match apps/platform/*.yaml "
+            f"exactly; missing={manifests - waited} extra={waited - manifests}",
+        )
+
+    def test_namespaces_is_included(self):
+        # The #281 evidence identified `namespaces` as the omitted child app.
+        self.assertIn("namespaces", self._waited_names())
+
+
+class ArgocdPrerequisiteTest(unittest.TestCase):
+    """The material-diff fallback depends on argocd; make the dep explicit."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = _read(SETUP)
+
+    def test_check_prerequisites_requires_argocd(self):
+        body = _func_body(self.text, "check_prerequisites")
+        self.assertIn('"argocd"', body,
+                      "check_prerequisites must require the argocd CLI so the "
+                      "Healthy/OutOfSync material-diff fallback is never silently "
+                      "unavailable")
+
+    def test_check_prerequisites_verifies_matching_argocd_version(self):
+        body = _func_body(self.text, "check_prerequisites")
+        self.assertIn("argocd version --client", body)
+        self.assertIn("v3.4.5", body)
+        self.assertIn("argocd_client_version_matches", body)
+
+    def test_argocd_version_match_is_exact_but_allows_build_metadata(self):
+        self.assertEqual(
+            _run_nu('argocd_client_version_matches "argocd: v3.4.5+564b949" "3.4.5"'),
+            "true",
+        )
+        self.assertEqual(
+            _run_nu('argocd_client_version_matches "argocd: v3.4.50+fake" "3.4.5"'),
+            "false",
+        )
+        self.assertEqual(
+            _run_nu('argocd_client_version_matches "garbage v3.4.5" "3.4.5"'),
+            "false",
+        )
+
+
+class NonReadyDiagnosticsTest(unittest.TestCase):
+    """Timeout must name every non-ready Application with bounded redacted state."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = _read(SETUP)
+        cls.wait = _func_body(cls.text, "wait_for_argocd_apps")
+
+    def test_collects_health_sync_and_phase(self):
+        self.assertIn("status.operationState.phase", self.wait)
+        self.assertIn("status.health.status", self.wait)
+        self.assertIn("status.sync.status", self.wait)
+
+    def test_diagnostics_are_redacted(self):
+        # Application state is untrusted text; the reporting helper reuses the
+        # existing redaction as defence-in-depth.
+        helper = _func_body(self.text, "format_non_ready_report")
+        self.assertIn("redact_sync_diagnostic", helper)
+
+    def test_non_ready_report_printed_before_timeout_error(self):
+        # The bounded non-ready report and the status table must both appear
+        # before `error make` fires on timeout.
+        error_pos = self.wait.index("error make")
+        report_pos = self.wait.index("format_non_ready_report")
+        table_pos = self.wait.index("get applications -n argocd -o wide")
+        self.assertLess(report_pos, error_pos,
+                        "non-ready report must print before the timeout error")
+        self.assertLess(table_pos, error_pos,
+                        "status table must print before the timeout error")
+
+    def test_status_table_on_success_path_too(self):
+        # The final status table must be on BOTH the success and failure paths;
+        # i.e. it appears at least twice in the function.
+        self.assertGreaterEqual(
+            self.wait.count("get applications -n argocd -o wide"), 2,
+            "status table must be reachable on both success and timeout paths",
+        )
+
+
+class NonReadyReportHelperTest(unittest.TestCase):
+    """The pure formatter turns app-state records into bounded redacted lines."""
+
+    def test_formats_name_health_sync_phase(self):
+        expr = (
+            "format_non_ready_report ["
+            "{name: cnpg-cluster, health: Healthy, sync: OutOfSync, phase: Running}, "
+            "{name: kyverno, health: Healthy, sync: OutOfSync, phase: Succeeded}]"
+        )
+        out = _run_nu(expr)
+        self.assertIn("cnpg-cluster", out)
+        self.assertIn("OutOfSync", out)
+        self.assertIn("Running", out)
+        self.assertIn("kyverno", out)
+
+    def test_report_is_empty_for_no_non_ready_apps(self):
+        self.assertEqual(_run_nu("format_non_ready_report []"), "")
+
+
+class ConfigurationDependencyTest(unittest.TestCase):
+    """Each identity phase has explicit, fail-closed direct dependency gates."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = _read(SETUP)
+        cls.up = _func_body(cls.text, '"main up"')
+
+    def test_gitea_dependencies_are_waited_before_configuration(self):
+        wait = self.up.index('wait_for_configuration_dependencies "Gitea"')
+        configure = self.up.index("configure_gitea")
+        self.assertLess(wait, configure)
+        block = self.up[wait:configure]
+        for app in ("gitea", "keycloak", "cert-manager"):
+            self.assertIn(f'"{app}"', block)
+        self.assertIn("digiorg-local-ca", block)
+        self.assertIn("digiorg-local-tls", block)
+
+    def test_sonarqube_dependencies_are_waited_before_configuration(self):
+        wait = self.up.index('wait_for_configuration_dependencies "SonarQube"')
+        configure = self.up.index("configure_sonarqube")
+        self.assertLess(wait, configure)
+        block = self.up[wait:configure]
+        for app in ("sonarqube", "keycloak", "cert-manager"):
+            self.assertIn(f'"{app}"', block)
+        self.assertIn("digiorg-local-ca", block)
+        self.assertIn("digiorg-local-tls", block)
+
+    def test_sonarqube_configuration_is_verified_by_readback(self):
+        body = _func_body(self.text, "configure_sonarqube")
+        self.assertIn('secrets "sonarqube-admin-secret" not found', body)
+        self.assertIn('default "admin"', body)
+        self.assertIn("Failed to read the SonarQube admin password", body)
+        self.assertIn("/api/settings/values", body)
+        self.assertIn("sonarqube_settings_match", body)
+        self.assertIn("sonarqube_setting_present", body)
+        self.assertIn("sonarqube_http_status_matches", body)
+        self.assertIn("SonarQube settings readback did not match", body)
+        good = '{"settings":[{"key":"sonar.auth.saml.enabled","value":"true"},{"key":"sonar.auth.saml.certificate.secured"}]}'
+        bad = '{"settings":[{"key":"sonar.auth.saml.enabled","value":"false"}]}'
+        missing = '{"settings":[]}'
+        expected = '{"sonar.auth.saml.enabled":"true"}'
+        self.assertEqual(_run_nu(f"sonarqube_settings_match '{good}' '{expected}'"), "true")
+        self.assertEqual(_run_nu(f"sonarqube_settings_match '{bad}' '{expected}'"), "false")
+        self.assertEqual(_run_nu(f"sonarqube_settings_match '{missing}' '{expected}'"), "false")
+        self.assertEqual(_run_nu("sonarqube_settings_match 'not-json' '{\"x\":\"y\"}'"), "false")
+        self.assertEqual(_run_nu(f"sonarqube_setting_present '{good}' 'sonar.auth.saml.certificate.secured'"), "true")
+        self.assertEqual(_run_nu(f"sonarqube_setting_present '{missing}' 'sonar.auth.saml.certificate.secured'"), "false")
+        self.assertEqual(_run_nu("sonarqube_http_status_matches 0 '204' '204'"), "true")
+        self.assertEqual(_run_nu("sonarqube_http_status_matches 0 '302' '204'"), "false")
+        self.assertEqual(_run_nu("sonarqube_http_status_matches 7 '204' '204'"), "false")
+
+    def test_dependency_wait_is_bounded_and_fail_closed(self):
+        helper = _func_body(self.text, "wait_for_configuration_dependencies")
+        self.assertIn("error make", helper)
+        self.assertIn("status.health.status", helper)
+        self.assertIn("status.sync.status", helper)
+        self.assertIn("Certificate", helper)
+        self.assertIn("Ready", helper)
+
+    def test_configuration_functions_do_not_silently_skip(self):
+        for name in ("configure_gitea", "configure_sonarqube", "patch_argocd_oidc_ca"):
+            body = _func_body(self.text, name)
+            self.assertNotIn("skipping", body.lower(),
+                             f"{name} must fail closed rather than report success after skipping")
+            self.assertIn("error make", body)
+
+    def test_gitea_api_uses_generated_token_without_process_arg_exposure(self):
+        body = _func_body(self.text, "configure_gitea")
+        self.assertIn("$gitea_token | kubectl", body)
+        self.assertIn("curl --config -", body)
+        self.assertIn("__DIGIORG_TOKEN_PLACEHOLDER__", body)
+        self.assertNotIn('curl -fsSk -H "Authorization: token ${token}"', body)
+        self.assertNotIn('--token="${token}"', body)
+        self.assertNotIn("Authorization: token ($gitea_token)", body)
+        self.assertNotIn("Authorization: token ***", body)
+
+    def test_required_oidc_restarts_fail_closed_after_configuration(self):
+        body = _func_body(self.text, "restart_oidc_dependent_pods")
+        self.assertNotIn("catch", body)
+        self.assertIn("restart_oidc_deployment", body)
+        self.assertIn("wait_for_configuration_dependencies", body)
+        self.assertIn('"argocd" "grafana" "backstage" "landingpage"', body)
+        helper = _func_body(self.text, "restart_oidc_deployment")
+        self.assertIn("error make", helper)
+        self.assertNotIn("is not present; final convergence", helper)
+
+    def test_gitea_final_readback_requires_both_bootstrap_members(self):
+        body = _func_body(self.text, "configure_gitea")
+        self.assertIn("missing_members", body)
+        self.assertIn('"digiorgadmin" "digiorgdeveloper"', body)
+        self.assertIn("Required Gitea Owners team members are missing", body)
+
+
+class GiteaTokenTransportTest(unittest.TestCase):
+    """The real token travels over stdin/config, never through child argv."""
+
+    def test_curl_receives_authorization_via_stdin_config_not_argv(self):
+        sentinel = "sentinel-token-never-in-argv"
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = os.path.join(tmp, "curl")
+            argv_log = os.path.join(tmp, "argv")
+            stdin_log = os.path.join(tmp, "stdin")
+            with open(fake, "w", encoding="utf-8") as fh:
+                fh.write("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$ARGV_LOG\"\ncat > \"$STDIN_LOG\"\nprintf '[]'\n")
+            os.chmod(fake, 0o755)
+            env = os.environ.copy()
+            env["PATH"] = tmp + os.pathsep + env.get("PATH", "")
+            env["ARGV_LOG"] = argv_log
+            env["STDIN_LOG"] = stdin_log
+            shell = (
+                'IFS= read -r token; '
+                'printf "header = \\\"Authorization: token %s\\\"\\n" "$token" '
+                '| curl --config - -fsSk https://example.invalid/api'
+            )
+            result = subprocess.run(
+                ["sh", "-c", shell], input=sentinel + "\n", text=True,
+                capture_output=True, env=env, timeout=10,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            with open(argv_log, encoding="utf-8") as fh:
+                self.assertNotIn(sentinel, fh.read())
+            with open(stdin_log, encoding="utf-8") as fh:
+                self.assertIn(sentinel, fh.read())
+            self.assertNotIn(sentinel, result.stdout + result.stderr)
+
+    def test_tea_receives_only_placeholder_then_shell_rewrites_config(self):
+        sentinel = "sentinel-tea-token-never-in-argv"
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = os.path.join(tmp, "tea")
+            argv_log = os.path.join(tmp, "tea-argv")
+            with open(fake, "w", encoding="utf-8") as fh:
+                fh.write(
+                    "#!/bin/sh\n"
+                    "printf '%s\\n' \"$@\" > \"$TEA_ARGV_LOG\"\n"
+                    "last=\nfor arg do last=$arg; done\n"
+                    "value=${last#--token=}\n"
+                    "mkdir -p \"$HOME/.config/tea\"\n"
+                    "printf 'logins:\\n  - token: %s\\n' \"$value\" > \"$HOME/.config/tea/config.yml\"\n"
+                )
+            os.chmod(fake, 0o755)
+            env = os.environ.copy()
+            env["PATH"] = tmp + os.pathsep + env.get("PATH", "")
+            env["HOME"] = tmp
+            env["TEA_ARGV_LOG"] = argv_log
+            shell = (
+                'set -eu; IFS= read -r token; placeholder=__DIGIORG_TOKEN_PLACEHOLDER__; '
+                'tea login add --name=test --url=https://example.invalid --token="$placeholder" >/dev/null; '
+                'cfg="${HOME:-/root}/.config/tea/config.yml"; tmpfile="${cfg}.tmp"; : > "$tmpfile"; '
+                'while IFS= read -r line; do case "$line" in *"$placeholder"*) '
+                'prefix=${line%%$placeholder*}; suffix=${line#*$placeholder}; '
+                'printf "%s%s%s\\n" "$prefix" "$token" "$suffix" ;; '
+                '*) printf "%s\\n" "$line" ;; esac; done < "$cfg" > "$tmpfile"; '
+                'mv "$tmpfile" "$cfg"'
+            )
+            result = subprocess.run(
+                ["sh", "-c", shell], input=sentinel + "\n", text=True,
+                capture_output=True, env=env, timeout=10,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            with open(argv_log, encoding="utf-8") as fh:
+                argv = fh.read()
+            self.assertNotIn(sentinel, argv)
+            self.assertIn("__DIGIORG_TOKEN_PLACEHOLDER__", argv)
+            with open(os.path.join(tmp, ".config", "tea", "config.yml"), encoding="utf-8") as fh:
+                config = fh.read()
+            self.assertIn(sentinel, config)
+            self.assertNotIn("__DIGIORG_TOKEN_PLACEHOLDER__", config)
+            self.assertNotIn(sentinel, result.stdout + result.stderr)
+
+
+class OidcRestartRuntimeTest(unittest.TestCase):
+    """Required deployment lookup, restart and rollout failures are all fatal."""
+
+    FAKE_KUBECTL = r'''#!/bin/sh
+args="$*"
+case "$args" in
+  *"get deployment testdep"*)
+    [ "$FAKE_SCENARIO" = lookup_failure ] && exit 1
+    echo deployment.apps/testdep
+    ;;
+  *"rollout restart deployment testdep"*)
+    [ "$FAKE_SCENARIO" = restart_failure ] && exit 1
+    echo restarted
+    ;;
+  *"rollout status deployment testdep"*)
+    [ "$FAKE_SCENARIO" = rollout_failure ] && exit 1
+    echo complete
+    ;;
+  *) exit 2 ;;
+esac
+'''
+
+    def _run(self, scenario):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = os.path.join(tmp, "kubectl")
+            with open(fake, "w", encoding="utf-8") as fh:
+                fh.write(self.FAKE_KUBECTL)
+            os.chmod(fake, 0o755)
+            env = os.environ.copy()
+            env["PATH"] = tmp + os.pathsep + env.get("PATH", "")
+            env["FAKE_SCENARIO"] = scenario
+            return subprocess.run(
+                ["nu", "-c", f"source {SETUP}; restart_oidc_deployment testns testdep 1s"],
+                capture_output=True, text=True, timeout=10, env=env,
+            )
+
+    def test_lookup_failure_is_fatal(self):
+        result = self._run("lookup_failure")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("is not present", result.stderr)
+
+    def test_restart_failure_is_fatal(self):
+        result = self._run("restart_failure")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Failed to restart", result.stderr)
+
+    def test_rollout_failure_is_fatal(self):
+        result = self._run("rollout_failure")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("did not complete", result.stderr)
+
+    def test_success_requires_completed_rollout(self):
+        result = self._run("success")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("testns/testdep restarted", result.stdout)
+
+
+class ControlFlowTest(unittest.TestCase):
+    """Config phases run dependency-aware; the global gate is the FINAL gate."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = _read(SETUP)
+        cls.up = _func_body(cls.text, '"main up"')
+        cls.deploy = _func_body(cls.text, "deploy_root_app")
+
+    def test_final_convergence_gate_runs_after_config_phases(self):
+        up = self.up
+        gitea = up.index("configure_gitea")
+        sonar = up.index("configure_sonarqube")
+        restart = up.index("restart_oidc_dependent_pods")
+        gate = up.index("wait_for_argocd_apps")
+        ready = up.index("Platform Ready")
+        self.assertTrue(
+            gitea < gate and sonar < gate and restart < gate < ready,
+            "the all-Application convergence gate must run AFTER the identity "
+            "configuration phases and immediately before the Platform Ready banner",
+        )
+
+    def test_deploy_root_app_does_not_run_global_gate(self):
+        # The global gate must not abort configuration; deploy_root_app promotes
+        # gated syncs but must NOT invoke the all-app convergence gate.
+        self.assertNotIn("wait_for_argocd_apps", self.deploy,
+                         "the all-app gate must not run inside deploy_root_app "
+                         "(it would abort identity configuration on unrelated drift)")
+
+    def test_final_gate_remains_fail_closed(self):
+        # wait_for_argocd_apps must still error on timeout (fail-closed).
+        wait = _func_body(self.text, "wait_for_argocd_apps")
+        self.assertIn("error make", wait)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_bootstrap_convergence.py
+++ b/platform/tests/test_bootstrap_convergence.py
@@ -294,6 +294,11 @@ class ConfigurationDependencyTest(unittest.TestCase):
         self.assertIn('"digiorgadmin" "digiorgdeveloper"', body)
         self.assertIn("Required Gitea Owners team members are missing", body)
 
+    def test_gitea_membership_get_uses_exact_http_200(self):
+        body = _func_body(self.text, "configure_gitea")
+        self.assertIn('($admin_check.stdout | str trim) == "200"', body)
+        self.assertIn('($dev_check.stdout | str trim) == "200"', body)
+
 
 class GiteaTokenTransportTest(unittest.TestCase):
     """The real token travels over stdin/config, never through child argv."""

--- a/platform/tests/test_bootstrap_convergence.py
+++ b/platform/tests/test_bootstrap_convergence.py
@@ -239,7 +239,8 @@ class ConfigurationDependencyTest(unittest.TestCase):
 
     def test_sonarqube_configuration_is_verified_by_readback(self):
         body = _func_body(self.text, "configure_sonarqube")
-        self.assertIn('secrets "sonarqube-admin-secret" not found', body)
+        self.assertIn("kubectl_error_is_exact_not_found", body)
+        self.assertIn('"sonarqube-admin-secret"', body)
         self.assertIn('default "admin"', body)
         self.assertIn("Failed to read the SonarQube admin password", body)
         self.assertIn("/api/settings/values", body)
@@ -334,6 +335,11 @@ class ConfigurationDependencyTest(unittest.TestCase):
         ):
             self.assertIn(key, body)
 
+    def test_all_secret_fallbacks_use_exact_notfound_classifier(self):
+        self.assertIn("kubectl_error_is_exact_not_found", _func_body(self.text, "secret_value_or_default"))
+        self.assertIn("kubectl_error_is_exact_not_found", _func_body(self.text, "configure_gitea"))
+        self.assertIn("kubectl_error_is_exact_not_found", _func_body(self.text, "configure_sonarqube"))
+
     def test_single_replica_gitea_uses_recreate_strategy_for_shared_data(self):
         values_path = os.path.join(REPO_ROOT, "platform", "base", "gitea", "values.yaml")
         values = yaml.safe_load(_read(values_path))
@@ -356,6 +362,12 @@ class SecretResumeStabilityTest(unittest.TestCase):
                     "    print(base64.b64encode(b'existing-value').decode(), end='')\n"
                     "elif scenario == 'notfound':\n"
                     "    print('Error from server (NotFound): secrets \\\"sample\\\" not found', file=sys.stderr); sys.exit(1)\n"
+                    "elif scenario == 'namespace_notfound':\n"
+                    "    print('Error from server (NotFound): namespaces \\\"testns\\\" not found', file=sys.stderr); sys.exit(1)\n"
+                    "elif scenario == 'wrong_name_notfound':\n"
+                    "    print('Error from server (NotFound): secrets \\\"other\\\" not found', file=sys.stderr); sys.exit(1)\n"
+                    "elif scenario == 'mixed_forbidden':\n"
+                    "    print('Error from server (Forbidden): audit context: secrets \\\"sample\\\" not found', file=sys.stderr); sys.exit(1)\n"
                     "else:\n"
                     "    print('forbidden', file=sys.stderr); sys.exit(1)\n"
                 )
@@ -378,10 +390,17 @@ class SecretResumeStabilityTest(unittest.TestCase):
         result = self._run("notfound")
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "fallback-value")
+        namespace = self._run("namespace_notfound")
+        self.assertEqual(namespace.returncode, 0, namespace.stderr)
+        self.assertEqual(namespace.stdout.strip(), "fallback-value")
 
     def test_lookup_failure_is_fatal_and_override_wins(self):
         failed = self._run("forbidden")
         self.assertNotEqual(failed.returncode, 0)
+        mixed = self._run("mixed_forbidden")
+        self.assertNotEqual(mixed.returncode, 0)
+        wrong_name = self._run("wrong_name_notfound")
+        self.assertNotEqual(wrong_name.returncode, 0)
         overridden = self._run("forbidden", "explicit-value")
         self.assertEqual(overridden.returncode, 0, overridden.stderr)
         self.assertEqual(overridden.stdout.strip(), "explicit-value")

--- a/platform/tests/test_bootstrap_convergence.py
+++ b/platform/tests/test_bootstrap_convergence.py
@@ -261,6 +261,8 @@ class ConfigurationDependencyTest(unittest.TestCase):
 
     def test_gitea_api_uses_generated_token_without_process_arg_exposure(self):
         body = _func_body(self.text, "configure_gitea")
+        self.assertNotIn("--page", body, "the pinned Gitea admin user list command has no pagination flags")
+        self.assertNotIn("--page-size", body)
         self.assertIn("$gitea_token | kubectl", body)
         self.assertIn("curl --config -", body)
         self.assertIn("__DIGIORG_TOKEN_PLACEHOLDER__", body)

--- a/platform/tests/test_bootstrap_convergence.py
+++ b/platform/tests/test_bootstrap_convergence.py
@@ -185,6 +185,10 @@ class NonReadyDiagnosticsTest(unittest.TestCase):
             "status table must be reachable on both success and timeout paths",
         )
 
+    def test_bootstrap_summary_does_not_print_default_credentials(self):
+        disallowed = "admin" + " / " + "admin"
+        self.assertNotIn(disallowed, self.text)
+
 
 class NonReadyReportHelperTest(unittest.TestCase):
     """The pure formatter turns app-state records into bounded redacted lines."""

--- a/platform/tests/test_bootstrap_convergence.py
+++ b/platform/tests/test_bootstrap_convergence.py
@@ -269,9 +269,12 @@ class ConfigurationDependencyTest(unittest.TestCase):
         self.assertIn("su git -c 'gitea admin auth list'", body)
         self.assertIn("$gitea_token | kubectl", body)
         self.assertIn("curl --config -", body)
-        self.assertIn("__DIGIORG_TOKEN_PLACEHOLDER__", body)
-        self.assertNotIn('curl -fsSk -H "Authorization: token ${token}"', body)
-        self.assertNotIn('--token="${token}"', body)
+        self.assertIn("gitea-bootstrap-token", body)
+        self.assertIn("--from-file=token=/dev/stdin", body)
+        self.assertIn("/api/v1/orgs/DigiOrg", body)
+        self.assertNotIn("tea login", body)
+        self.assertNotIn('curl -fsSk -H "Authorization: token ***"', body)
+
         self.assertNotIn("Authorization: token ($gitea_token)", body)
         self.assertNotIn("Authorization: token ***", body)
 
@@ -324,34 +327,32 @@ class GiteaTokenTransportTest(unittest.TestCase):
                 self.assertIn(sentinel, fh.read())
             self.assertNotIn(sentinel, result.stdout + result.stderr)
 
-    def test_tea_receives_only_placeholder_then_shell_rewrites_config(self):
-        sentinel = "sentinel-tea-token-never-in-argv"
+    def test_kubernetes_secret_receives_token_via_stdin_not_argv(self):
+        sentinel = "sentinel-kubernetes-secret-token-never-in-argv"
         with tempfile.TemporaryDirectory() as tmp:
-            fake = os.path.join(tmp, "tea")
-            argv_log = os.path.join(tmp, "tea-argv")
+            fake = os.path.join(tmp, "kubectl")
+            argv_log = os.path.join(tmp, "kubectl-argv")
+            token_stdin = os.path.join(tmp, "token-stdin")
+            apply_stdin = os.path.join(tmp, "apply-stdin")
             with open(fake, "w", encoding="utf-8") as fh:
                 fh.write(
                     "#!/bin/sh\n"
-                    "printf '%s\\n' \"$@\" > \"$TEA_ARGV_LOG\"\n"
-                    "last=\nfor arg do last=$arg; done\n"
-                    "value=${last#--token=}\n"
-                    "mkdir -p \"$HOME/.config/tea\"\n"
-                    "printf 'logins:\\n  - token: %s\\n' \"$value\" > \"$HOME/.config/tea/config.yml\"\n"
+                    "printf '%s\\n' \"$@\" >> \"$KUBECTL_ARGV_LOG\"\n"
+                    "case \"$1\" in\n"
+                    "  create) cat > \"$TOKEN_STDIN_LOG\"; printf 'apiVersion: v1\\nkind: Secret\\n' ;;\n"
+                    "  apply) cat > \"$APPLY_STDIN_LOG\"; printf 'secret/gitea-bootstrap-token configured\\n' ;;\n"
+                    "  *) exit 2 ;;\n"
+                    "esac\n"
                 )
             os.chmod(fake, 0o755)
             env = os.environ.copy()
             env["PATH"] = tmp + os.pathsep + env.get("PATH", "")
-            env["HOME"] = tmp
-            env["TEA_ARGV_LOG"] = argv_log
+            env["KUBECTL_ARGV_LOG"] = argv_log
+            env["TOKEN_STDIN_LOG"] = token_stdin
+            env["APPLY_STDIN_LOG"] = apply_stdin
             shell = (
-                'set -eu; IFS= read -r token; placeholder=__DIGIORG_TOKEN_PLACEHOLDER__; '
-                'tea login add --name=test --url=https://example.invalid --token="$placeholder" >/dev/null; '
-                'cfg="${HOME:-/root}/.config/tea/config.yml"; tmpfile="${cfg}.tmp"; : > "$tmpfile"; '
-                'while IFS= read -r line; do case "$line" in *"$placeholder"*) '
-                'prefix=${line%%$placeholder*}; suffix=${line#*$placeholder}; '
-                'printf "%s%s%s\\n" "$prefix" "$token" "$suffix" ;; '
-                '*) printf "%s\\n" "$line" ;; esac; done < "$cfg" > "$tmpfile"; '
-                'mv "$tmpfile" "$cfg"'
+                "kubectl create secret generic gitea-bootstrap-token -n gitea "
+                "--from-file=token=/dev/stdin --dry-run=client -o yaml | kubectl apply -f -"
             )
             result = subprocess.run(
                 ["sh", "-c", shell], input=sentinel + "\n", text=True,
@@ -359,13 +360,11 @@ class GiteaTokenTransportTest(unittest.TestCase):
             )
             self.assertEqual(result.returncode, 0, result.stderr)
             with open(argv_log, encoding="utf-8") as fh:
-                argv = fh.read()
-            self.assertNotIn(sentinel, argv)
-            self.assertIn("__DIGIORG_TOKEN_PLACEHOLDER__", argv)
-            with open(os.path.join(tmp, ".config", "tea", "config.yml"), encoding="utf-8") as fh:
-                config = fh.read()
-            self.assertIn(sentinel, config)
-            self.assertNotIn("__DIGIORG_TOKEN_PLACEHOLDER__", config)
+                self.assertNotIn(sentinel, fh.read())
+            with open(token_stdin, encoding="utf-8") as fh:
+                self.assertIn(sentinel, fh.read())
+            with open(apply_stdin, encoding="utf-8") as fh:
+                self.assertIn("kind: Secret", fh.read())
             self.assertNotIn(sentinel, result.stdout + result.stderr)
 
 

--- a/platform/tests/test_bootstrap_convergence.py
+++ b/platform/tests/test_bootstrap_convergence.py
@@ -21,6 +21,7 @@ plus a couple of real-Nushell behaviour checks of the new pure helper::
     python3 platform/tests/test_bootstrap_convergence.py
 """
 
+import base64
 import os
 import re
 import subprocess
@@ -111,9 +112,19 @@ class ArgocdPrerequisiteTest(unittest.TestCase):
         self.assertIn('"argocd"', body)
         self.assertIn("argocd_client_version_matches", self.text)
 
-    def test_argocd_bootstrap_upgrade_reclaims_self_managed_fields_on_resume(self):
-        body = _func_body(self.text, "install_argocd")
-        self.assertIn("--force-conflicts", body)
+    def test_argocd_bootstrap_upgrade_handles_helm3_and_helm4(self):
+        install = _func_body(self.text, "install_argocd")
+        oidc = _func_body(self.text, "patch_argocd_oidc_ca")
+        self.assertIn("...$helm_conflict_args", install)
+        self.assertIn("...$helm_conflict_args", oidc)
+        self.assertEqual(
+            _run_nu('helm_force_conflicts_args_for_version "v3.12.3+g3a31588" | to json --raw'),
+            "[]",
+        )
+        self.assertEqual(
+            _run_nu('helm_force_conflicts_args_for_version "v4.2.3+gabcdef" | to json --raw'),
+            '["--force-conflicts"]',
+        )
 
     def test_check_prerequisites_verifies_matching_argocd_version(self):
         body = _func_body(self.text, "check_prerequisites")
@@ -280,7 +291,8 @@ class ConfigurationDependencyTest(unittest.TestCase):
         self.assertIn("$gitea_token | kubectl", body)
         self.assertIn("curl --config -", body)
         self.assertIn("gitea-bootstrap-token", body)
-        self.assertIn("--from-file=token=/dev/stdin", body)
+        self.assertIn("persist_gitea_bootstrap_token", body)
+        self.assertNotIn("/dev/stdin", body)
         self.assertIn("/api/v1/orgs/DigiOrg", body)
         self.assertNotIn("tea login", body)
         self.assertNotIn('curl -fsSk -H "Authorization: token ***"', body)
@@ -342,45 +354,74 @@ class GiteaTokenTransportTest(unittest.TestCase):
                 self.assertIn(sentinel, fh.read())
             self.assertNotIn(sentinel, result.stdout + result.stderr)
 
-    def test_kubernetes_secret_receives_token_via_stdin_not_argv(self):
+    def _run_secret_transport(self, scenario):
         sentinel = "sentinel-kubernetes-secret-token-never-in-argv"
         with tempfile.TemporaryDirectory() as tmp:
             fake = os.path.join(tmp, "kubectl")
             argv_log = os.path.join(tmp, "kubectl-argv")
-            token_stdin = os.path.join(tmp, "token-stdin")
-            apply_stdin = os.path.join(tmp, "apply-stdin")
+            manifest_log = os.path.join(tmp, "manifest.json")
             with open(fake, "w", encoding="utf-8") as fh:
                 fh.write(
-                    "#!/bin/sh\n"
-                    "printf '%s\\n' \"$@\" >> \"$KUBECTL_ARGV_LOG\"\n"
-                    "case \"$1\" in\n"
-                    "  create) cat > \"$TOKEN_STDIN_LOG\"; printf 'apiVersion: v1\\nkind: Secret\\n' ;;\n"
-                    "  apply) cat > \"$APPLY_STDIN_LOG\"; printf 'secret/gitea-bootstrap-token configured\\n' ;;\n"
-                    "  *) exit 2 ;;\n"
-                    "esac\n"
+                    "#!/usr/bin/env python3\n"
+                    "import json, os, sys\n"
+                    "args = sys.argv[1:]\n"
+                    "with open(os.environ['KUBECTL_ARGV_LOG'], 'a', encoding='utf-8') as log: "
+                    "log.write(json.dumps(args) + '\\n')\n"
+                    "scenario = os.environ.get('FAKE_SCENARIO', 'success')\n"
+                    "if 'apply' in args:\n"
+                    "    data = sys.stdin.read()\n"
+                    "    if scenario == 'apply_failure': sys.exit(1)\n"
+                    "    open(os.environ['MANIFEST_LOG'], 'w', encoding='utf-8').write(data)\n"
+                    "    print('secret/gitea-bootstrap-token configured')\n"
+                    "elif 'get' in args:\n"
+                    "    if scenario == 'readback_failure': sys.exit(1)\n"
+                    "    obj = json.load(open(os.environ['MANIFEST_LOG'], encoding='utf-8'))\n"
+                    "    value = obj['data']['token']\n"
+                    "    print('d3Jvbmc=' if scenario == 'readback_mismatch' else value, end='')\n"
+                    "else:\n"
+                    "    sys.exit(2)\n"
                 )
             os.chmod(fake, 0o755)
             env = os.environ.copy()
             env["PATH"] = tmp + os.pathsep + env.get("PATH", "")
             env["KUBECTL_ARGV_LOG"] = argv_log
-            env["TOKEN_STDIN_LOG"] = token_stdin
-            env["APPLY_STDIN_LOG"] = apply_stdin
-            shell = (
-                "kubectl create secret generic gitea-bootstrap-token -n gitea "
-                "--from-file=token=/dev/stdin --dry-run=client -o yaml | kubectl apply -f -"
-            )
+            env["MANIFEST_LOG"] = manifest_log
+            env["FAKE_SCENARIO"] = scenario
+            env["TEST_TOKEN"] = sentinel
             result = subprocess.run(
-                ["sh", "-c", shell], input=sentinel + "\n", text=True,
-                capture_output=True, env=env, timeout=10,
+                ["nu", "-c", f"source {SETUP}; persist_gitea_bootstrap_token $env.TEST_TOKEN"],
+                capture_output=True, text=True, env=env, timeout=10,
             )
-            self.assertEqual(result.returncode, 0, result.stderr)
-            with open(argv_log, encoding="utf-8") as fh:
-                self.assertNotIn(sentinel, fh.read())
-            with open(token_stdin, encoding="utf-8") as fh:
-                self.assertIn(sentinel, fh.read())
-            with open(apply_stdin, encoding="utf-8") as fh:
-                self.assertIn("kind: Secret", fh.read())
-            self.assertNotIn(sentinel, result.stdout + result.stderr)
+            argv = ""
+            if os.path.exists(argv_log):
+                with open(argv_log, encoding="utf-8") as fh:
+                    argv = fh.read()
+            manifest = None
+            if os.path.exists(manifest_log):
+                with open(manifest_log, encoding="utf-8") as fh:
+                    manifest = yaml.safe_load(fh)
+            return result, sentinel, argv, manifest
+
+    def test_kubernetes_secret_manifest_is_cross_platform_and_verified(self):
+        result, sentinel, argv, manifest = self._run_secret_transport("success")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn(sentinel, argv)
+        self.assertNotIn("/dev/stdin", _func_body(_read(SETUP), "persist_gitea_bootstrap_token"))
+        self.assertNotIn(sentinel, result.stdout + result.stderr)
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(manifest["metadata"]["name"], "gitea-bootstrap-token")
+        self.assertEqual(base64.b64decode(manifest["data"]["token"]).decode(), sentinel)
+
+    def test_kubernetes_secret_apply_failure_is_fatal(self):
+        result, _, _, _ = self._run_secret_transport("apply_failure")
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_kubernetes_secret_readback_failure_and_mismatch_are_fatal(self):
+        for scenario in ("readback_failure", "readback_mismatch"):
+            with self.subTest(scenario=scenario):
+                result, _, _, _ = self._run_secret_transport(scenario)
+                self.assertNotEqual(result.returncode, 0)
 
 
 class OidcRestartRuntimeTest(unittest.TestCase):

--- a/platform/tests/test_bootstrap_convergence.py
+++ b/platform/tests/test_bootstrap_convergence.py
@@ -228,8 +228,9 @@ class ConfigurationDependencyTest(unittest.TestCase):
         self.assertIn('default "admin"', body)
         self.assertIn("Failed to read the SonarQube admin password", body)
         self.assertIn("/api/settings/values", body)
+        self.assertIn("/api/settings/list_definitions", body)
         self.assertIn("sonarqube_settings_match", body)
-        self.assertIn("sonarqube_setting_present", body)
+        self.assertIn("sonarqube_setting_definition_present", body)
         self.assertIn("sonarqube_http_status_matches", body)
         self.assertIn("SonarQube settings readback did not match", body)
         good = '{"settings":[{"key":"sonar.auth.saml.enabled","value":"true"},{"key":"sonar.auth.saml.certificate.secured"}]}'
@@ -240,8 +241,10 @@ class ConfigurationDependencyTest(unittest.TestCase):
         self.assertEqual(_run_nu(f"sonarqube_settings_match '{bad}' '{expected}'"), "false")
         self.assertEqual(_run_nu(f"sonarqube_settings_match '{missing}' '{expected}'"), "false")
         self.assertEqual(_run_nu("sonarqube_settings_match 'not-json' '{\"x\":\"y\"}'"), "false")
-        self.assertEqual(_run_nu(f"sonarqube_setting_present '{good}' 'sonar.auth.saml.certificate.secured'"), "true")
-        self.assertEqual(_run_nu(f"sonarqube_setting_present '{missing}' 'sonar.auth.saml.certificate.secured'"), "false")
+        definitions = '{"definitions":[{"key":"sonar.auth.saml.certificate.secured","type":"PASSWORD"}]}'
+        no_definitions = '{"definitions":[]}'
+        self.assertEqual(_run_nu(f"sonarqube_setting_definition_present '{definitions}' 'sonar.auth.saml.certificate.secured'"), "true")
+        self.assertEqual(_run_nu(f"sonarqube_setting_definition_present '{no_definitions}' 'sonar.auth.saml.certificate.secured'"), "false")
         self.assertEqual(_run_nu("sonarqube_http_status_matches 0 '204' '204'"), "true")
         self.assertEqual(_run_nu("sonarqube_http_status_matches 0 '302' '204'"), "false")
         self.assertEqual(_run_nu("sonarqube_http_status_matches 7 '204' '204'"), "false")

--- a/platform/tests/test_bootstrap_convergence.py
+++ b/platform/tests/test_bootstrap_convergence.py
@@ -321,6 +321,61 @@ class ConfigurationDependencyTest(unittest.TestCase):
         self.assertIn('($admin_check.stdout | str trim) == "200"', body)
         self.assertIn('($dev_check.stdout | str trim) == "200"', body)
 
+    def test_generated_platform_secrets_are_reused_on_resume(self):
+        body = _func_body(self.text, "create_platform_namespaces_secrets")
+        self.assertIn("secret_value_or_default", body)
+        for key in (
+            "POSTGRES_PASSWORD", "KEYCLOAK_DB_PASSWORD", "BACKSTAGE_DB_PASSWORD",
+            "GITEA_DB_PASSWORD", "SONARQUBE_DB_PASSWORD", "HARBOR_DB_PASSWORD",
+        ):
+            self.assertIn(key, body)
+
+
+class SecretResumeStabilityTest(unittest.TestCase):
+    """Generated values are reused; only exact NotFound permits a fallback."""
+
+    def _run(self, scenario, override=""):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = os.path.join(tmp, "kubectl")
+            with open(fake, "w", encoding="utf-8") as fh:
+                fh.write(
+                    "#!/usr/bin/env python3\n"
+                    "import base64, os, sys\n"
+                    "scenario = os.environ['FAKE_SCENARIO']\n"
+                    "if scenario == 'existing':\n"
+                    "    print(base64.b64encode(b'existing-value').decode(), end='')\n"
+                    "elif scenario == 'notfound':\n"
+                    "    print('Error from server (NotFound): secrets \\\"sample\\\" not found', file=sys.stderr); sys.exit(1)\n"
+                    "else:\n"
+                    "    print('forbidden', file=sys.stderr); sys.exit(1)\n"
+                )
+            os.chmod(fake, 0o755)
+            env = os.environ.copy()
+            env["PATH"] = tmp + os.pathsep + env.get("PATH", "")
+            env["FAKE_SCENARIO"] = scenario
+            env["TEST_OVERRIDE"] = override
+            return subprocess.run(
+                ["nu", "-c", f"source {SETUP}; secret_value_or_default testns sample TOKEN $env.TEST_OVERRIDE fallback-value"],
+                capture_output=True, text=True, timeout=10, env=env,
+            )
+
+    def test_existing_value_is_reused(self):
+        result = self._run("existing")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "existing-value")
+
+    def test_exact_notfound_uses_fallback(self):
+        result = self._run("notfound")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "fallback-value")
+
+    def test_lookup_failure_is_fatal_and_override_wins(self):
+        failed = self._run("forbidden")
+        self.assertNotEqual(failed.returncode, 0)
+        overridden = self._run("forbidden", "explicit-value")
+        self.assertEqual(overridden.returncode, 0, overridden.stderr)
+        self.assertEqual(overridden.stdout.strip(), "explicit-value")
+
 
 class GiteaTokenTransportTest(unittest.TestCase):
     """The real token travels over stdin/config, never through child argv."""

--- a/platform/tests/test_bootstrap_convergence.py
+++ b/platform/tests/test_bootstrap_convergence.py
@@ -265,6 +265,8 @@ class ConfigurationDependencyTest(unittest.TestCase):
         body = _func_body(self.text, "configure_gitea")
         self.assertNotIn("--page", body, "the pinned Gitea admin user list command has no pagination flags")
         self.assertNotIn("--page-size", body)
+        self.assertNotIn("--vertical", body, "the pinned Gitea auth list command has no --vertical flag")
+        self.assertIn("su git -c 'gitea admin auth list'", body)
         self.assertIn("$gitea_token | kubectl", body)
         self.assertIn("curl --config -", body)
         self.assertIn("__DIGIORG_TOKEN_PLACEHOLDER__", body)

--- a/platform/tests/test_cnpg_startup_ordering.py
+++ b/platform/tests/test_cnpg_startup_ordering.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""CNPG Cluster startup ordering + backup-PVC binding (Issue #281).
+
+Confirmed #281 root cause: on a clean bootstrap the ``cnpg-cluster`` Application
+tried to apply ``Cluster/postgresql-cnpg`` before the CNPG operator's admission
+webhook (``cnpg-webhook-service``) accepted connections, so admission failed
+with ``connection refused``. The failed sync operation then stayed ``Running``
+forever because the intentionally idle ``WaitForFirstConsumer`` backup PVC
+(``postgresql-cnpg-backups``) remained ``Pending`` and Argo waited on its health
+despite the ``ignore-healthcheck`` annotation — so the configured retry never
+started a fresh operation.
+
+The fix has two halves, both locked here:
+
+  1. A script-side readiness gate waits for the operator Deployment to be
+     Available and for a ready webhook endpoint (via ``discovery.k8s.io/v1``
+     EndpointSlice, NOT the deprecated core ``Endpoints`` API) before the Cluster
+     is applied, then syncs with a genuinely fresh operation. It fails closed.
+  2. An idempotent one-shot bootstrap consumer Job mounts the backup PVC so the
+     provisioner binds it, so a Pending PVC can no longer hold the operation
+     open.
+
+Pure-Nushell behaviour checks of the parsing predicates plus structural checks::
+
+    python3 platform/tests/test_cnpg_startup_ordering.py
+"""
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SETUP = os.path.join(REPO_ROOT, "scripts", "local-setup.nu")
+INIT_YAML = os.path.join(REPO_ROOT, "platform", "base", "cnpg", "init-databases.yaml")
+CLUSTER_APP_YAML = os.path.join(REPO_ROOT, "apps", "platform", "cnpg-cluster.yaml")
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _docs(path):
+    with open(path, encoding="utf-8") as fh:
+        return [d for d in yaml.safe_load_all(fh) if d]
+
+
+def _find(docs, kind, name=None):
+    for d in docs:
+        if d.get("kind") == kind and (name is None or d.get("metadata", {}).get("name") == name):
+            return d
+    return None
+
+
+def _func_body(text, name):
+    start = text.index(f"def {name} ")
+    end = text.index("\ndef ", start + 10)
+    return text[start:end]
+
+
+def _run_nu(expr: str) -> str:
+    result = subprocess.run(
+        ["nu", "-c", f"source {SETUP}; {expr}"],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"nu failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+class WebhookEndpointPredicateTest(unittest.TestCase):
+    """cnpg_webhook_endpoint_ready parses discovery.k8s.io/v1 EndpointSlices."""
+
+    READY = (
+        '{"kind":"EndpointSliceList","items":[{"endpoints":['
+        '{"addresses":["10.244.0.20"],"conditions":{"ready":true}}]}]}'
+    )
+    NOT_READY = (
+        '{"kind":"EndpointSliceList","items":[{"endpoints":['
+        '{"addresses":["10.244.0.20"],"conditions":{"ready":false}}]}]}'
+    )
+    EMPTY = '{"kind":"EndpointSliceList","items":[]}'
+    NO_ADDRS = (
+        '{"kind":"EndpointSliceList","items":[{"endpoints":['
+        '{"addresses":[],"conditions":{"ready":true}}]}]}'
+    )
+
+    def _call(self, payload):
+        escaped = payload.replace("\\", "\\\\").replace("'", "\\'")
+        return _run_nu(f"cnpg_webhook_endpoint_ready '{escaped}'")
+
+    def test_ready_endpoint_is_true(self):
+        self.assertEqual(self._call(self.READY), "true")
+
+    def test_not_ready_endpoint_is_false(self):
+        self.assertEqual(self._call(self.NOT_READY), "false")
+
+    def test_no_endpoints_is_false(self):
+        self.assertEqual(self._call(self.EMPTY), "false")
+
+    def test_ready_but_no_address_is_false(self):
+        self.assertEqual(self._call(self.NO_ADDRS), "false")
+
+    def test_garbage_is_false(self):
+        # Fail closed on unparseable input.
+        self.assertEqual(self._call("not-json"), "false")
+
+
+class OperatorAvailablePredicateTest(unittest.TestCase):
+    """cnpg_operator_available accepts a Deployment or a List and checks health."""
+
+    AVAILABLE_LIST = (
+        '{"kind":"DeploymentList","items":[{"spec":{"replicas":1},'
+        '"status":{"availableReplicas":1}}]}'
+    )
+    UNAVAILABLE_LIST = (
+        '{"kind":"DeploymentList","items":[{"spec":{"replicas":1},'
+        '"status":{"availableReplicas":0}}]}'
+    )
+    EMPTY_LIST = '{"kind":"DeploymentList","items":[]}'
+
+    def _call(self, payload):
+        escaped = payload.replace("\\", "\\\\").replace("'", "\\'")
+        return _run_nu(f"cnpg_operator_available '{escaped}'")
+
+    def test_available_is_true(self):
+        self.assertEqual(self._call(self.AVAILABLE_LIST), "true")
+
+    def test_unavailable_is_false(self):
+        self.assertEqual(self._call(self.UNAVAILABLE_LIST), "false")
+
+    def test_no_deployment_is_false(self):
+        self.assertEqual(self._call(self.EMPTY_LIST), "false")
+
+    def test_garbage_is_false(self):
+        self.assertEqual(self._call("not-json"), "false")
+
+
+class WebhookWaitStructureTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = _read(SETUP)
+        cls.wait = _func_body(cls.text, "wait_for_cnpg_webhook_ready")
+
+    def test_uses_endpointslice_not_deprecated_endpoints(self):
+        self.assertIn("endpointslices.discovery.k8s.io", self.wait,
+                      "must query discovery.k8s.io/v1 EndpointSlices")
+        # The deprecated core Endpoints API must not be used for this check.
+        self.assertNotRegex(self.wait, r"kubectl get endpoints\b")
+
+    def test_checks_operator_deployment_and_webhook_endpoint(self):
+        self.assertIn("cnpg_operator_available", self.wait)
+        self.assertIn("cnpg_webhook_endpoint_ready", self.wait)
+
+    def test_fails_closed_with_bounded_redacted_diagnostic(self):
+        self.assertIn("error make", self.wait)
+        self.assertIn("redact_sync_diagnostic", self.wait)
+
+
+class PromoteClusterStructureTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = _read(SETUP)
+        cls.promote = _func_body(cls.text, "promote_cnpg_cluster")
+        cls.deploy = _func_body(cls.text, "deploy_root_app")
+
+    def test_waits_for_webhook_before_syncing_cluster(self):
+        wait_pos = self.promote.index("wait_for_cnpg_webhook_ready")
+        patch_pos = self.promote.index("kubectl patch application cnpg-cluster")
+        self.assertLess(wait_pos, patch_pos,
+                        "must confirm operator/webhook readiness BEFORE applying "
+                        "the Cluster")
+
+    def test_uses_fresh_operation_identity(self):
+        # A retry/resync must be a genuinely fresh operation (new startedAt).
+        self.assertIn("status.operationState.startedAt", self.promote)
+        self.assertIn("previous_started", self.promote)
+        self.assertIn("started != $previous_started", self.promote)
+
+    def test_resume_observes_existing_running_operation_before_patching(self):
+        running = self.promote.index('initial_phase == "Running"')
+        patch = self.promote.index("kubectl patch application cnpg-cluster")
+        self.assertLess(running, patch,
+                        "resume must observe an in-flight operation instead of "
+                        "overwriting it with another operation")
+        self.assertIn("resuming_existing_operation", self.promote)
+
+    def test_already_converged_cluster_is_a_noop(self):
+        patch = self.promote.index("kubectl patch application cnpg-cluster")
+        ready = self.promote.index('initial_sync == "Synced"')
+        self.assertLess(ready, patch)
+
+    def test_promoted_before_gated_sync_in_deploy_root_app(self):
+        promote_pos = self.deploy.index("promote_cnpg_cluster")
+        gated_pos = self.deploy.index("sync_gated_apps_for_local_dev")
+        self.assertLess(promote_pos, gated_pos)
+
+
+class PromoteClusterResumeRuntimeTest(unittest.TestCase):
+    """Exercise CNPG operation-state branches through the real Nushell function."""
+
+    FAKE_KUBECTL = r'''#!/bin/sh
+args="$*"
+printf '%s\n' "$args" >> "$FAKE_LOG"
+case "$args" in
+  *"get application cnpg-cluster"*"-o name"*)
+    echo application.argoproj.io/cnpg-cluster
+    ;;
+  *"get deployment"*"-l app.kubernetes.io/name=cloudnative-pg"*)
+    printf '%s\n' '{"kind":"DeploymentList","items":[{"spec":{"replicas":1},"status":{"availableReplicas":1}}]}'
+    ;;
+  *"get endpointslices"*)
+    printf '%s\n' '{"items":[{"endpoints":[{"conditions":{"ready":true},"addresses":["10.0.0.1"]}]}]}'
+    ;;
+  *"get application cnpg-cluster"*"-o json"*)
+    count=$(cat "$FAKE_STATE" 2>/dev/null || echo 0)
+    count=$((count + 1))
+    printf '%s' "$count" > "$FAKE_STATE"
+    case "$FAKE_SCENARIO" in
+      running_success)
+        if [ "$count" -eq 1 ]; then phase=Running; started=old; sync=OutOfSync; else phase=Succeeded; started=old; sync=Synced; fi
+        ;;
+      already_ready)
+        phase=Succeeded; started=old; sync=Synced
+        ;;
+      stale_fresh)
+        if [ "$count" -eq 1 ]; then phase=Failed; started=old; sync=OutOfSync; elif [ "$count" -eq 2 ]; then phase=Running; started=old; sync=OutOfSync; else phase=Succeeded; started=new; sync=Synced; fi
+        ;;
+      fresh_failed)
+        if [ "$count" -eq 1 ]; then phase=Failed; started=old; else phase=Failed; started=new; fi; sync=OutOfSync
+        ;;
+      patch_failure)
+        phase=Failed; started=old; sync=OutOfSync
+        ;;
+      running_identity_change)
+        if [ "$count" -eq 1 ]; then phase=Running; started=old; sync=OutOfSync; else phase=Succeeded; started=new; sync=Synced; fi
+        ;;
+      running_no_identity)
+        phase=Running; started=; sync=OutOfSync
+        ;;
+      invalid_json)
+        printf '%s\n' 'not-json'; exit 0
+        ;;
+      get_failure)
+        exit 1
+        ;;
+      *) exit 2 ;;
+    esac
+    printf '{"status":{"operationState":{"phase":"%s","startedAt":"%s"},"sync":{"status":"%s"},"health":{"status":"Healthy"}}}\n' "$phase" "$started" "$sync"
+    ;;
+  *"patch application cnpg-cluster"*)
+    : > "$FAKE_PATCH"
+    [ "$FAKE_SCENARIO" = patch_failure ] && exit 1
+    printf '%s\n' '{}'
+    ;;
+  *)
+    printf 'unexpected kubectl call: %s\n' "$args" >&2
+    exit 1
+    ;;
+esac
+'''
+
+    def _run_scenario(self, scenario):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        kubectl = os.path.join(tmp.name, "kubectl")
+        state = os.path.join(tmp.name, "state")
+        patch_marker = os.path.join(tmp.name, "patch-called")
+        call_log = os.path.join(tmp.name, "calls.log")
+        with open(kubectl, "w", encoding="utf-8") as fh:
+            fh.write(self.FAKE_KUBECTL)
+        os.chmod(kubectl, 0o755)
+        env = os.environ.copy()
+        env["PATH"] = tmp.name + os.pathsep + env.get("PATH", "")
+        env.update({
+            "FAKE_STATE": state,
+            "FAKE_PATCH": patch_marker,
+            "FAKE_LOG": call_log,
+            "FAKE_SCENARIO": scenario,
+        })
+        result = subprocess.run(
+            ["nu", "-c", f"source {SETUP}; promote_cnpg_cluster 0sec"],
+            capture_output=True, text=True, timeout=12, env=env,
+        )
+        return result, patch_marker, call_log
+
+    def test_running_operation_is_observed_not_patched(self):
+        result, patch_marker, _ = self._run_scenario("running_success")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(os.path.exists(patch_marker), result.stdout)
+        self.assertIn("Resuming observation", result.stdout)
+
+    def test_already_ready_is_a_noop(self):
+        result, patch_marker, _ = self._run_scenario("already_ready")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(os.path.exists(patch_marker), result.stdout)
+        self.assertIn("already Synced and Healthy", result.stdout)
+
+    def test_terminal_state_starts_and_waits_for_fresh_operation(self):
+        result, patch_marker, _ = self._run_scenario("stale_fresh")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(os.path.exists(patch_marker))
+        self.assertIn("sync Succeeded", result.stdout)
+
+    def test_fresh_failed_operation_fails_closed(self):
+        result, patch_marker, _ = self._run_scenario("fresh_failed")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(os.path.exists(patch_marker))
+        self.assertIn("CNPG Cluster sync failed", result.stderr)
+
+    def test_resumed_operation_identity_change_is_rejected(self):
+        result, patch_marker, _ = self._run_scenario("running_identity_change")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(os.path.exists(patch_marker))
+        self.assertIn("identity changed unexpectedly", result.stderr)
+
+    def test_running_operation_without_identity_fails_without_patch(self):
+        result, patch_marker, _ = self._run_scenario("running_no_identity")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(os.path.exists(patch_marker))
+        self.assertIn("has no startedAt identity", result.stderr)
+
+    def test_invalid_application_json_fails_closed(self):
+        result, _, _ = self._run_scenario("invalid_json")
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_application_get_failure_fails_closed(self):
+        result, _, _ = self._run_scenario("get_failure")
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_operation_patch_failure_fails_closed(self):
+        result, patch_marker, _ = self._run_scenario("patch_failure")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(os.path.exists(patch_marker))
+        self.assertIn("Could not start CNPG Cluster sync", result.stderr)
+
+
+class ClusterAppScriptDrivenTest(unittest.TestCase):
+    """cnpg-cluster is promoted by the script after webhook readiness, so it must
+    not auto-sync the Cluster (which is exactly what caused the webhook race)."""
+
+    def test_cluster_app_is_not_automated(self):
+        app = _find(_docs(CLUSTER_APP_YAML), "Application", "cnpg-cluster")
+        self.assertIsNotNone(app)
+        policy = app["spec"].get("syncPolicy", {})
+        self.assertNotIn(
+            "automated", policy,
+            "cnpg-cluster must be script-driven (webhook-ordered), not automated",
+        )
+
+
+class BackupPvcConsumerTest(unittest.TestCase):
+    """An idempotent one-shot Job binds the WaitForFirstConsumer backup PVC."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.docs = _docs(INIT_YAML)
+
+    def _consumer_job(self):
+        pvc_name = "postgresql-cnpg-backups"
+        for d in self.docs:
+            if d.get("kind") != "Job":
+                continue
+            spec = d["spec"]["template"]["spec"]
+            for vol in spec.get("volumes", []):
+                claim = vol.get("persistentVolumeClaim", {})
+                if claim.get("claimName") == pvc_name:
+                    return d
+        return None
+
+    def test_a_job_mounts_the_backup_pvc(self):
+        job = self._consumer_job()
+        self.assertIsNotNone(
+            job,
+            "a bootstrap Job must mount postgresql-cnpg-backups so the "
+            "WaitForFirstConsumer PVC binds and cannot hold the sync open",
+        )
+
+    def test_consumer_job_is_not_the_nightly_cronjob(self):
+        # The binding must happen at bootstrap, not only at the nightly pg_dump.
+        job = self._consumer_job()
+        self.assertNotEqual(job["metadata"]["name"], "postgresql-cnpg-pgdump")
+
+    def test_consumer_is_an_idempotent_sync_hook(self):
+        job = self._consumer_job()
+        self.assertIsNotNone(job)
+        assert job is not None
+        annotations = job["metadata"].get("annotations", {})
+        self.assertEqual(annotations.get("argocd.argoproj.io/hook"), "Sync")
+        policy = annotations.get("argocd.argoproj.io/hook-delete-policy", "")
+        self.assertIn("BeforeHookCreation", policy)
+        self.assertIn("HookSucceeded", policy)
+
+    def test_consumer_job_image_is_digest_pinned(self):
+        job = self._consumer_job()
+        image = job["spec"]["template"]["spec"]["containers"][0]["image"]
+        self.assertRegex(image, r"@sha256:[0-9a-f]{64}$",
+                         "consumer Job image must be digest-pinned")
+
+    def test_backup_pvc_still_ignores_healthcheck_as_defence_in_depth(self):
+        pvc = _find(self.docs, "PersistentVolumeClaim", "postgresql-cnpg-backups")
+        self.assertEqual(
+            pvc["metadata"].get("annotations", {}).get("argocd.argoproj.io/ignore-healthcheck"),
+            "true",
+        )
+
+    @staticmethod
+    def _wave(doc):
+        # Effective Argo CD sync-wave: the annotation value, or 0 when absent.
+        ann = doc["metadata"].get("annotations", {}) or {}
+        return int(ann.get("argocd.argoproj.io/sync-wave", "0"))
+
+    def test_consumer_job_not_in_later_wave_than_backup_pvc(self):
+        # The whole point of the consumer is to bind the PVC. Argo syncs wave by
+        # wave and blocks each wave on its resources' health, and the deployed
+        # Argo (v3.4.5) waited on the Pending backup PVC despite ignore-healthcheck.
+        # If the consumer Job is in a LATER wave than the PVC, the sync never
+        # advances to apply it (the original #281 deadlock). It must therefore
+        # share the PVC's wave (not earlier either — then the PVC would not yet
+        # exist to mount).
+        job = self._consumer_job()
+        pvc = _find(self.docs, "PersistentVolumeClaim", "postgresql-cnpg-backups")
+        self.assertEqual(
+            self._wave(job), self._wave(pvc),
+            "the backup-PVC bind Job must be in the SAME sync-wave as the PVC so "
+            "it applies together with it and binds it within that wave; a later "
+            "wave reproduces the deadlock, an earlier one has no PVC to mount",
+        )
+
+    def test_consumer_job_binds_before_nightly_backup_cronjob(self):
+        # The nightly pg_dump CronJob is the other consumer; the bootstrap bind
+        # must not be gated behind (a later wave than) it.
+        job = self._consumer_job()
+        cronjob = _find(self.docs, "CronJob")
+        if cronjob is not None:
+            self.assertLessEqual(self._wave(job), self._wave(cronjob))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_crossplane_migration.py
+++ b/platform/tests/test_crossplane_migration.py
@@ -36,10 +36,21 @@ except ImportError:  # pragma: no cover
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 APP = os.path.join(REPO_ROOT, "apps", "platform", "crossplane.yaml")
+CATALOG_APP = os.path.join(REPO_ROOT, "apps", "platform", "core-catalog.yaml")
 PKG_DIR = os.path.join(REPO_ROOT, "crossplane", "providers", "packages")
 XRD = os.path.join(REPO_ROOT, "crossplane", "xrds", "application.yaml")
 FUNCTION = os.path.join(PKG_DIR, "function-patch-and-transform.yaml")
 PROVIDER_KUSTOMIZATION = os.path.join(PKG_DIR, "kustomization.yaml")
+VERSIONS_DOC = os.path.join(REPO_ROOT, "docs", "guides", "platform-versions.md")
+
+# core-catalog PR #17 merged as this commit; a GitHub comparison shows it one
+# commit ahead of the old implementation SHA with NO changed files, and
+# core-catalog/main points at it. Pin the canonical *reviewed merge* commit for
+# traceability (Issue #281 Phase 4). Update this constant, the manifest, and the
+# versions doc together when the reviewed revision advances.
+CANONICAL_CATALOG_REVISION = "13b7a3b4a0b7a5f5e692dc6d5a3fa416852c4273"
+# The prior (non-canonical) implementation SHA must no longer be referenced.
+SUPERSEDED_CATALOG_REVISION = "4c30d9c3fa5c3c401c19f26b66a025854c65ee02"
 
 # Revalidated compatible provider package versions (exact pins).
 EXPECTED_PROVIDERS = {
@@ -52,6 +63,11 @@ EXPECTED_PROVIDERS = {
 def _docs(path):
     with open(path, encoding="utf-8") as fh:
         return [d for d in yaml.safe_load_all(fh) if d]
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
 
 
 class ChartPinTest(unittest.TestCase):
@@ -126,6 +142,47 @@ class XrdLegacyClusterCompatTest(unittest.TestCase):
                       "claimNames must be retained for LegacyCluster claim support")
         self.assertNotEqual(self.xrd["spec"].get("scope"), "Namespaced",
                             "Namespaced scope drops Claims support in Crossplane v2")
+
+
+class CoreCatalogCanonicalPinTest(unittest.TestCase):
+    """core-catalog must pin the canonical reviewed merge commit, stay immutable,
+    and remain manually gated (Issue #281 Phase 4)."""
+
+    def setUp(self):
+        self.app = _docs(CATALOG_APP)[0]
+
+    def test_pins_canonical_merge_commit(self):
+        rev = str(self.app["spec"]["source"]["targetRevision"])
+        self.assertEqual(
+            rev, CANONICAL_CATALOG_REVISION,
+            "core-catalog must pin the canonical reviewed merge commit",
+        )
+
+    def test_superseded_revision_not_referenced_anywhere(self):
+        # The old implementation SHA must be gone from the manifest and the doc.
+        self.assertNotIn(SUPERSEDED_CATALOG_REVISION, _read(CATALOG_APP))
+        self.assertNotIn(SUPERSEDED_CATALOG_REVISION, _read(VERSIONS_DOC))
+
+    def test_revision_is_immutable_40_hex(self):
+        rev = str(self.app["spec"]["source"]["targetRevision"])
+        self.assertRegex(rev, r"^[0-9a-f]{40}$",
+                         "catalog revision must be an immutable 40-hex commit")
+
+    def test_remains_manually_gated(self):
+        # Manual promotion must be preserved: no automated sync, gate annotation kept.
+        policy = self.app["spec"].get("syncPolicy", {})
+        self.assertNotIn("automated", policy,
+                         "core-catalog must not auto-sync (manual promotion gate)")
+        self.assertEqual(
+            self.app["metadata"].get("annotations", {}).get("platform.digiorg.io/upgrade-gate"),
+            "issue-275-manual",
+        )
+
+    def test_versions_doc_records_canonical_revision(self):
+        # The reviewed revision must be documented so the pin is traceable.
+        self.assertIn(CANONICAL_CATALOG_REVISION,
+                      _read(VERSIONS_DOC),
+                      "platform-versions.md must record the canonical catalog revision")
 
 
 if __name__ == "__main__":

--- a/platform/tests/test_gated_sync_retry_classification.py
+++ b/platform/tests/test_gated_sync_retry_classification.py
@@ -144,6 +144,10 @@ class DiagnosticRedactionTest(unittest.TestCase):
                 self.assertNotIn(sensitive, out)
                 self.assertIn("[REDACTED]", out)
 
+    def test_redacted_diagnostic_is_length_bounded(self):
+        out = _run_nu(f'redact_sync_diagnostic "{"x" * 5000}"')
+        self.assertLessEqual(len(out), 1024)
+
 
 class RetryWiringStructureTest(unittest.TestCase):
     @classmethod

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -412,6 +412,11 @@ data:
     print $"(ansi green)✓ CoreDNS configured for digiorg.local [($ingress_ip)](ansi reset)"
 }
 
+def kubectl_error_is_exact_not_found [stderr: string, resource: string, name: string] {
+    let expected = (["Error from server (NotFound): " $resource ' "' $name '" not found'] | str join)
+    ($stderr | str trim) == $expected
+}
+
 def secret_value_or_default [namespace: string, secret: string, key: string, override, fallback] {
     let explicit = ($override | default "")
     if ($explicit | into string) != "" {
@@ -429,8 +434,8 @@ def secret_value_or_default [namespace: string, secret: string, key: string, ove
         return $existing
     }
 
-    let secret_missing = ($lookup.stderr | str contains $'secrets "($secret)" not found')
-    let namespace_missing = ($lookup.stderr | str contains $'namespaces "($namespace)" not found')
+    let secret_missing = (kubectl_error_is_exact_not_found $lookup.stderr "secrets" $secret)
+    let namespace_missing = (kubectl_error_is_exact_not_found $lookup.stderr "namespaces" $namespace)
     if $secret_missing or $namespace_missing {
         return ($fallback | into string)
     }
@@ -1651,7 +1656,7 @@ def configure_gitea [] {
         }
         print $"(ansi yellow)✓ Existing Gitea bootstrap token reused(ansi reset)"
         $stored_token
-    } else if ($token_secret.stderr | str contains 'secrets "gitea-bootstrap-token" not found') {
+    } else if (kubectl_error_is_exact_not_found $token_secret.stderr "secrets" "gitea-bootstrap-token") {
         let token_name = $"local-setup-((date now | format date '%Y%m%d%H%M%S'))"
         let token_result = (do {
             kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c $'gitea admin user generate-access-token --username gitea_admin --token-name "($token_name)" --scopes write:activitypub,write:admin,write:issue,write:misc,write:notification,write:organization,write:package,write:repository,write:user --raw'
@@ -1812,7 +1817,7 @@ def configure_sonarqube [] {
     let admin_pass = (do -i { kubectl --kubeconfig $KUBECONFIG_PATH get secret sonarqube-admin-secret -n code-quality -o jsonpath='{.data.password}' } | complete)
     let password = if $admin_pass.exit_code == 0 {
         try { $admin_pass.stdout | str trim | decode base64 } catch { "" }
-    } else if ($admin_pass.stderr | str contains 'secrets "sonarqube-admin-secret" not found') {
+    } else if (kubectl_error_is_exact_not_found $admin_pass.stderr "secrets" "sonarqube-admin-secret") {
         # The upstream local-development chart starts with the documented default
         # admin password and does not create an admin Secret. Operators can provide
         # SONARQUBE_ADMIN_PASSWORD after changing it. Only exact NotFound falls back;

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -105,7 +105,7 @@ def "main up" [] {
     print ""
     print "Access services (all via https://digiorg.local):"
     print "  Landing Page: https://digiorg.local/          (Login via Keycloak)"
-    print "  Keycloak:     https://digiorg.local/keycloak  (admin / admin)"
+    print "  Keycloak:     https://digiorg.local/keycloak  (admin console)"
     print "  Backstage:    https://digiorg.local/backstage (Login via Keycloak)"
     print "  Gitea:        https://digiorg.local/gitea     (Login via Keycloak)"
     print "  SonarQube:    https://digiorg.local/sonarqube (Login via Keycloak)"

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -1722,8 +1722,18 @@ def sonarqube_http_status_matches [exit_code: int, status: string, expected: str
 
 # Configure SonarQube
 def configure_sonarqube [] {
+    # Persisted browser-facing URLs remain public, while bootstrap traffic stays
+    # inside the cluster and does not depend on a host /etc/hosts entry.
     let sonar_url = "https://digiorg.local/sonarqube"
-    let keycloak_saml_descriptor_url = "https://digiorg.local/keycloak/realms/digiorg-core-platform/protocol/saml/descriptor"
+    let sonar_api_url = "http://sonarqube-sonarqube.code-quality.svc.cluster.local:9000/sonarqube"
+    let keycloak_saml_descriptor_url = "http://keycloak.keycloak.svc.cluster.local:8080/keycloak/realms/digiorg-core-platform/protocol/saml/descriptor"
+    let sonar_pod_result = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH get pods -n code-quality -l app=sonarqube -o jsonpath='{.items[0].metadata.name}'
+    } | complete)
+    let sonar_pod = ($sonar_pod_result.stdout | str trim)
+    if $sonar_pod_result.exit_code != 0 or ($sonar_pod | is-empty) {
+        error make {msg: "Failed to find the SonarQube pod for in-cluster configuration"}
+    }
     let admin_pass = (do -i { kubectl --kubeconfig $KUBECONFIG_PATH get secret sonarqube-admin-secret -n code-quality -o jsonpath='{.data.password}' } | complete)
     let password = if $admin_pass.exit_code == 0 {
         try { $admin_pass.stdout | str trim | decode base64 } catch { "" }
@@ -1747,7 +1757,7 @@ def configure_sonarqube [] {
     mut sonar_ready = false
     for attempt in 1..30 {
         let status = (do -i {
-            $sonar_auth_config | curl --config - --noproxy "*" -fsSk $"($sonar_url)/api/system/status"
+            $sonar_auth_config | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n code-quality $sonar_pod -c sonarqube -- curl --config - -fsS $"($sonar_api_url)/api/system/status"
         } | complete)
         if $status.exit_code == 0 and ($status.stdout | str contains '"status":"UP"') {
             $sonar_ready = true
@@ -1762,7 +1772,7 @@ def configure_sonarqube [] {
     }
 
     # Set sonar.core.serverBaseURL via Settings API
-    let result = (do -i { $sonar_auth_config | curl --config - --noproxy "*" -sSk -o /dev/null -w "%{http_code}" -X POST $"($sonar_url)/api/settings/set" --data-urlencode "key=sonar.core.serverBaseURL" --data-urlencode $"value=($sonar_url)" } | complete)
+    let result = (do -i { $sonar_auth_config | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n code-quality $sonar_pod -c sonarqube -- curl --config - -sS -o /dev/null -w "%{http_code}" -X POST $"($sonar_api_url)/api/settings/set" --data-urlencode "key=sonar.core.serverBaseURL" --data-urlencode $"value=($sonar_url)" } | complete)
 
     if (sonarqube_http_status_matches $result.exit_code $result.stdout "204") {
         print $"(ansi green)✓ SonarQube Server Base URL set to ($sonar_url)(ansi reset)"
@@ -1774,7 +1784,7 @@ def configure_sonarqube [] {
     # The SAML metadata descriptor endpoint returns the full X.509 certificate
     # (not just the raw public key), which is what SonarQube requires.
     print "  1. Fetching Keycloak IdP X.509 certificate from SAML descriptor..."
-    let cert_result = (do -i { curl --noproxy "*" -fsSk $keycloak_saml_descriptor_url } | complete)
+    let cert_result = (do -i { kubectl --kubeconfig $KUBECONFIG_PATH exec -n code-quality $sonar_pod -c sonarqube -- curl -fsS $keycloak_saml_descriptor_url } | complete)
     if $cert_result.exit_code != 0 {
         error make {msg: "Failed to reach the Keycloak SAML descriptor endpoint"}
     }
@@ -1802,7 +1812,7 @@ def configure_sonarqube [] {
 
     mut all_ok = true
     for setting in $saml_settings {
-        let r = (do -i { $sonar_auth_config | curl --config - --noproxy "*" -sSk -o /dev/null -w "%{http_code}" -X POST $"($sonar_url)/api/settings/set" --data-urlencode $"key=($setting.key)" --data-urlencode $"value=($setting.value)" } | complete)
+        let r = (do -i { $sonar_auth_config | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n code-quality $sonar_pod -c sonarqube -- curl --config - -sS -o /dev/null -w "%{http_code}" -X POST $"($sonar_api_url)/api/settings/set" --data-urlencode $"key=($setting.key)" --data-urlencode $"value=($setting.value)" } | complete)
         if not (sonarqube_http_status_matches $r.exit_code $r.stdout "204") {
             print $"(ansi red)✗ Failed to set ($setting.key)(ansi reset)"
             $all_ok = false
@@ -1810,7 +1820,7 @@ def configure_sonarqube [] {
     }
 
     # --- Step 4: Enable SAML ---
-    let enable_result = (do -i { $sonar_auth_config | curl --config - --noproxy "*" -sSk -o /dev/null -w "%{http_code}" -X POST $"($sonar_url)/api/settings/set" --data-urlencode "key=sonar.auth.saml.enabled" --data-urlencode "value=true" } | complete)
+    let enable_result = (do -i { $sonar_auth_config | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n code-quality $sonar_pod -c sonarqube -- curl --config - -sS -o /dev/null -w "%{http_code}" -X POST $"($sonar_api_url)/api/settings/set" --data-urlencode "key=sonar.auth.saml.enabled" --data-urlencode "value=true" } | complete)
     if not (sonarqube_http_status_matches $enable_result.exit_code $enable_result.stdout "204") {
         print $"(ansi red)✗ Failed to enable SAML(ansi reset)"
         $all_ok = false
@@ -1839,7 +1849,7 @@ def configure_sonarqube [] {
     let secured_certificate_key = "sonar.auth.saml.certificate.secured"
     let readback_keys = ($expected_readback | columns | append $secured_certificate_key | str join ",")
     let readback = (do -i {
-        $sonar_auth_config | curl --config - --noproxy "*" -sSk -w "\n%{http_code}" --get $"($sonar_url)/api/settings/values" --data-urlencode $"keys=($readback_keys)"
+        $sonar_auth_config | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n code-quality $sonar_pod -c sonarqube -- curl --config - -sS -w "\n%{http_code}" --get $"($sonar_api_url)/api/settings/values" --data-urlencode $"keys=($readback_keys)"
     } | complete)
     let readback_lines = ($readback.stdout | lines)
     let readback_status = ($readback_lines | last | default "")

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -1707,13 +1707,13 @@ def sonarqube_settings_match [settings_json: string, expected_json: string] {
     }
 }
 
-def sonarqube_setting_present [settings_json: string, required_key: string] {
-    let parsed = (try { $settings_json | from json } catch { null })
+def sonarqube_setting_definition_present [definitions_json: string, required_key: string] {
+    let parsed = (try { $definitions_json | from json } catch { null })
     if (($parsed | describe | str starts-with "record") == false) {
         return false
     }
-    let settings = ($parsed | get -o settings | default [])
-    $settings | any {|setting| ($setting | get -o key | default "") == $required_key }
+    let definitions = ($parsed | get -o definitions | default [])
+    $definitions | any {|definition| ($definition | get -o key | default "") == $required_key }
 }
 
 def sonarqube_http_status_matches [exit_code: int, status: string, expected: string] {
@@ -1847,15 +1847,28 @@ def configure_sonarqube [] {
         "sonar.auth.saml.enabled": "true"
     }
     let secured_certificate_key = "sonar.auth.saml.certificate.secured"
-    let readback_keys = ($expected_readback | columns | append $secured_certificate_key | str join ",")
+    let readback_keys = ($expected_readback | columns | str join ",")
     let readback = (do -i {
         $sonar_auth_config | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n code-quality $sonar_pod -c sonarqube -- curl --config - -sS -w "\n%{http_code}" --get $"($sonar_api_url)/api/settings/values" --data-urlencode $"keys=($readback_keys)"
     } | complete)
     let readback_lines = ($readback.stdout | lines)
     let readback_status = ($readback_lines | last | default "")
     let readback_body = ($readback_lines | drop 1 | str join "\n")
-    if not (sonarqube_http_status_matches $readback.exit_code $readback_status "200") or not (sonarqube_settings_match $readback_body ($expected_readback | to json)) or not (sonarqube_setting_present $readback_body $secured_certificate_key) {
+    if not (sonarqube_http_status_matches $readback.exit_code $readback_status "200") or not (sonarqube_settings_match $readback_body ($expected_readback | to json)) {
         error make {msg: "SonarQube settings readback did not match the required SAML configuration"}
+    }
+
+    # Secured values are intentionally omitted from /api/settings/values even
+    # when configured. Verify the non-secret setting definition instead; together
+    # with the exact 204 mutation status this is the strongest available signal.
+    let definitions = (do -i {
+        $sonar_auth_config | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n code-quality $sonar_pod -c sonarqube -- curl --config - -sS -w "\n%{http_code}" $"($sonar_api_url)/api/settings/list_definitions"
+    } | complete)
+    let definition_lines = ($definitions.stdout | lines)
+    let definition_status = ($definition_lines | last | default "")
+    let definition_body = ($definition_lines | drop 1 | str join "\n")
+    if not (sonarqube_http_status_matches $definitions.exit_code $definition_status "200") or not (sonarqube_setting_definition_present $definition_body $secured_certificate_key) {
+        error make {msg: "SonarQube does not expose the required secured SAML certificate setting definition"}
     }
 
     print $"(ansi green)✓ SAML fully configured, enabled and verified in SonarQube(ansi reset)"

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -1530,7 +1530,7 @@ def configure_gitea [] {
     print "3. Ensuring initial users exist in Gitea..."
 
     let users_result = (do {
-        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c 'gitea admin user list --page 1 --page-size 1000'
+        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c 'gitea admin user list'
     } | complete)
     if $users_result.exit_code != 0 {
         error make {msg: "Failed to list existing Gitea users"}

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -1556,49 +1556,25 @@ def configure_gitea [] {
     }
     print $"(ansi green)✓ Initial users are present(ansi reset)"
 
-    # --- Step 4: Create DigiOrg organisation via tea CLI ---
-    print "4. Creating DigiOrg organisation in Gitea..."
+    # --- Step 4: Create DigiOrg organisation via the Gitea API ---
+    print "4. Ensuring DigiOrg organisation exists in Gitea..."
 
-    # 4a: Install tea CLI if not already present
-    let tea_check = (do {
-        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- sh -c 'test -x /usr/local/bin/tea && echo "exists"'
+    # Persist the bootstrap token in Kubernetes rather than a CLI config file.
+    # The value travels only over stdin and is never placed in a process argument.
+    let token_secret = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH get secret gitea-bootstrap-token -n gitea -o jsonpath='{.data.token}'
     } | complete)
-
-    if ($tea_check.exit_code == 0) and ($tea_check.stdout | str contains "exists") {
-        print $"(ansi yellow)✓ tea CLI already installed(ansi reset)"
-    } else {
-        let tea_install = (do {
-            kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- sh -c 'wget -qO /usr/local/bin/tea https://dl.gitea.com/tea/0.9.2/tea-0.9.2-linux-amd64 && chmod +x /usr/local/bin/tea'
-        } | complete)
-        if $tea_install.exit_code == 0 {
-            print $"(ansi green)✓ tea CLI installed(ansi reset)"
-        } else {
-            error make {msg: "Failed to install the pinned tea CLI in Gitea"}
+    let gitea_token = if $token_secret.exit_code == 0 {
+        let stored_token = (try { $token_secret.stdout | str trim | decode base64 } catch { "" })
+        if ($stored_token | is-empty) {
+            error make {msg: "The existing gitea-bootstrap-token Secret has no usable token"}
         }
-    }
-
-    # 4b: Check if tea login already exists (idempotency check first)
-    let login_check = (do {
-        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- sh -c 'tea login list 2>/dev/null | grep -q "teaadmin-digiorg" && echo "exists"'
-    } | complete)
-
-    # 4b/4c/4d: Resolve gitea_token — immutable, derived from both branches
-    # Nushell does not allow capturing mut variables in closures; use let + if expression instead.
-    let gitea_token = if ($login_check.exit_code == 0) and ($login_check.stdout | str contains "exists") {
-        print $"(ansi yellow)✓ tea login 'teaadmin-digiorg' already configured(ansi reset)"
-        # Extract stored token from tea config for subsequent API calls
-        let token_extract = (do {
-            kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- sh -c 'grep -A10 "teaadmin-digiorg" /root/.config/tea/config.yml | grep "token:" | head -1 | sed "s/.*token: //"'
-        } | complete)
-        let stored_token = ($token_extract.stdout | str trim)
-        if $token_extract.exit_code != 0 or ($stored_token | is-empty) {
-            error make {msg: "The existing Gitea tea login has no usable stored token"}
-        }
+        print $"(ansi yellow)✓ Existing Gitea bootstrap token reused(ansi reset)"
         $stored_token
-    } else {
-        # 4c: Generate access token — must run as git user, not root
+    } else if ($token_secret.stderr | str contains 'secrets "gitea-bootstrap-token" not found') {
+        let token_name = $"local-setup-((date now | format date '%Y%m%d%H%M%S'))"
         let token_result = (do {
-            kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c 'gitea admin user generate-access-token --username gitea_admin --token-name teaadmin --scopes write:activitypub,write:admin,write:issue,write:misc,write:notification,write:organization,write:package,write:repository,write:user --raw'
+            kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c $'gitea admin user generate-access-token --username gitea_admin --token-name "($token_name)" --scopes write:activitypub,write:admin,write:issue,write:misc,write:notification,write:organization,write:package,write:repository,write:user --raw'
         } | complete)
         if $token_result.exit_code != 0 {
             error make {msg: "Failed to generate the Gitea configuration access token"}
@@ -1607,39 +1583,39 @@ def configure_gitea [] {
         if ($token | is-empty) {
             error make {msg: "Gitea returned an empty configuration access token"}
         }
-        print $"(ansi green)✓ Access token generated(ansi reset)"
-
-        # 4d: Set up tea login without placing the token in a process argument.
-        # Tea itself receives only a fixed placeholder. POSIX-shell builtins then
-        # replace that placeholder in tea's config while the real token arrives
-        # exclusively over stdin; no child process sees it in argv.
-        let login_add = (do {
-            $token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'set -eu; IFS= read -r token; placeholder=__DIGIORG_TOKEN_PLACEHOLDER__; tea login add --name=teaadmin-digiorg --url=https://digiorg.local/gitea --token="$placeholder" >/dev/null; cfg="${HOME:-/root}/.config/tea/config.yml"; tmp="${cfg}.tmp"; : > "$tmp"; while IFS= read -r line; do case "$line" in *"$placeholder"*) prefix=${line%%$placeholder*}; suffix=${line#*$placeholder}; printf "%s%s%s\n" "$prefix" "$token" "$suffix" ;; *) printf "%s\n" "$line" ;; esac; done < "$cfg" > "$tmp"; mv "$tmp" "$cfg"'
+        let token_store = (do {
+            $token | kubectl --kubeconfig $KUBECONFIG_PATH create secret generic gitea-bootstrap-token -n gitea --from-file=token=/dev/stdin --dry-run=client -o yaml | kubectl --kubeconfig $KUBECONFIG_PATH apply -f -
         } | complete)
-        if $login_add.exit_code == 0 {
-            print $"(ansi green)✓ tea login 'teaadmin-digiorg' configured(ansi reset)"
-        } else {
-            error make {msg: "Failed to configure the Gitea tea login"}
+        if $token_store.exit_code != 0 {
+            error make {msg: "Failed to persist the Gitea bootstrap token"}
         }
+        print $"(ansi green)✓ Gitea bootstrap token generated and persisted(ansi reset)"
         $token
+    } else {
+        error make {msg: "Failed to read the gitea-bootstrap-token Secret"}
     }
 
-    # 4e: Create DigiOrg organisation (idempotent)
+    # Create the organisation through the API so no CLI configuration needs the
+    # administrative token in argv. Exact HTTP status handling is fail-closed.
     let org_check = (do {
-        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- sh -c 'tea organizations list --login teaadmin-digiorg 2>/dev/null | grep -q "DigiOrg" && echo "exists"'
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -sSk -o /dev/null -w "%{http_code}" https://digiorg.local/gitea/api/v1/orgs/DigiOrg'
     } | complete)
-
-    if ($org_check.exit_code == 0) and ($org_check.stdout | str contains "exists") {
+    if $org_check.exit_code != 0 {
+        error make {msg: "Failed to query the DigiOrg organisation in Gitea"}
+    }
+    let org_status = ($org_check.stdout | str trim)
+    if $org_status == "200" {
         print $"(ansi yellow)✓ Organisation 'DigiOrg' already exists(ansi reset)"
-    } else {
+    } else if $org_status == "404" {
         let org_create = (do {
-            kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- sh -c 'tea organization create --description "DigiOrg Organization" --visibility public --repo-admins-can-change-team-access --login teaadmin-digiorg DigiOrg'
+            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -sSk -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" --data "{\"username\":\"DigiOrg\",\"full_name\":\"DigiOrg Organization\",\"visibility\":\"public\",\"repo_admin_change_team_access\":true}" https://digiorg.local/gitea/api/v1/orgs'
         } | complete)
-        if $org_create.exit_code == 0 {
-            print $"(ansi green)✓ Organisation 'DigiOrg' created(ansi reset)"
-        } else {
+        if $org_create.exit_code != 0 or (($org_create.stdout | str trim) != "201") {
             error make {msg: "Failed to create the DigiOrg organisation in Gitea"}
         }
+        print $"(ansi green)✓ Organisation 'DigiOrg' created(ansi reset)"
+    } else {
+        error make {msg: $"Unexpected HTTP status while querying the DigiOrg organisation: ($org_status)"}
     }
 
     # 4f: Get Owners team ID via Gitea API. Feed the token on stdin so it is

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -412,21 +412,47 @@ data:
     print $"(ansi green)✓ CoreDNS configured for digiorg.local [($ingress_ip)](ansi reset)"
 }
 
+def secret_value_or_default [namespace: string, secret: string, key: string, override, fallback] {
+    let explicit = ($override | default "")
+    if ($explicit | into string) != "" {
+        return ($explicit | into string)
+    }
+
+    let lookup = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH get secret $secret -n $namespace -o $"jsonpath={.data.($key)}"
+    } | complete)
+    if $lookup.exit_code == 0 {
+        let existing = (try { $lookup.stdout | str trim | decode base64 | decode utf-8 } catch { "" })
+        if ($existing | is-empty) {
+            error make {msg: $"Existing Secret ($namespace)/($secret) has no usable ($key) value"}
+        }
+        return $existing
+    }
+
+    let secret_missing = ($lookup.stderr | str contains $'secrets "($secret)" not found')
+    let namespace_missing = ($lookup.stderr | str contains $'namespaces "($namespace)" not found')
+    if $secret_missing or $namespace_missing {
+        return ($fallback | into string)
+    }
+    error make {msg: $"Failed to read Secret ($namespace)/($secret) while resolving ($key)"}
+}
+
 def create_platform_namespaces_secrets [] {
-    # Generate passwords (can be overridden via environment variables)
-    let postgres_password = ($env.POSTGRES_PASSWORD? | default (generate_password))
-    let keycloak_db_password = ($env.KEYCLOAK_DB_PASSWORD? | default (generate_password))
-    let backstage_db_password = ($env.BACKSTAGE_DB_PASSWORD? | default (generate_password))
-    let backstage_session_secret = ($env.AUTH_SESSION_SECRET? | default (generate_password))
-    let backstage_oidc_secret = ($env.AUTH_OIDC_CLIENT_SECRET? | default "backstage-client-secret")
-    let gitea_db_password = ($env.GITEA_DB_PASSWORD? | default (generate_password))
-    let gitea_oidc_secret = ($env.GITEA_OIDC_CLIENT_SECRET? | default "gitea-client-secret")
-    let sonarqube_db_password = ($env.SONARQUBE_DB_PASSWORD? | default (generate_password))
-    let sonarqube_monitoring_passcode = ($env.SONARQUBE_MONITORING_PASSCODE? | default (generate_password))
-    let harbor_admin_password = ($env.HARBOR_ADMIN_PASSWORD? | default "Harbor12345")
-    let harbor_secret_key = ($env.HARBOR_SECRET_KEY? | default "not-a-secure-key")
-    let harbor_db_password = ($env.HARBOR_DB_PASSWORD? | default (generate_password))
-    let harbor_oidc_secret = ($env.HARBOR_OIDC_CLIENT_SECRET? | default "harbor-client-secret")
+    # Preserve existing values on resume. Environment variables are explicit
+    # rotation requests; random/default values are used only on a clean cluster.
+    let postgres_password = (secret_value_or_default "platform-db" "postgresql-secrets" "POSTGRES_PASSWORD" $env.POSTGRES_PASSWORD? (generate_password))
+    let keycloak_db_password = (secret_value_or_default "platform-db" "postgresql-secrets" "KEYCLOAK_DB_PASSWORD" $env.KEYCLOAK_DB_PASSWORD? (generate_password))
+    let backstage_db_password = (secret_value_or_default "platform-db" "postgresql-secrets" "BACKSTAGE_DB_PASSWORD" $env.BACKSTAGE_DB_PASSWORD? (generate_password))
+    let backstage_session_secret = (secret_value_or_default "backstage" "backstage-secrets" "AUTH_SESSION_SECRET" $env.AUTH_SESSION_SECRET? (generate_password))
+    let backstage_oidc_secret = (secret_value_or_default "backstage" "backstage-secrets" "AUTH_OIDC_CLIENT_SECRET" $env.AUTH_OIDC_CLIENT_SECRET? "backstage-client-secret")
+    let gitea_db_password = (secret_value_or_default "platform-db" "postgresql-secrets" "GITEA_DB_PASSWORD" $env.GITEA_DB_PASSWORD? (generate_password))
+    let gitea_oidc_secret = (secret_value_or_default "gitea" "gitea-secrets" "AUTH_OIDC_CLIENT_SECRET" $env.GITEA_OIDC_CLIENT_SECRET? "gitea-client-secret")
+    let sonarqube_db_password = (secret_value_or_default "platform-db" "postgresql-secrets" "SONARQUBE_DB_PASSWORD" $env.SONARQUBE_DB_PASSWORD? (generate_password))
+    let sonarqube_monitoring_passcode = (secret_value_or_default "code-quality" "sonarqube-monitoring-secret" "SONAR_WEB_SYSTEMPASSCODE" $env.SONARQUBE_MONITORING_PASSCODE? (generate_password))
+    let harbor_admin_password = (secret_value_or_default "harbor" "harbor-admin-secret" "HARBOR_ADMIN_PASSWORD" $env.HARBOR_ADMIN_PASSWORD? "Harbor12345")
+    let harbor_secret_key = (secret_value_or_default "harbor" "harbor-secret-key" "secretKey" $env.HARBOR_SECRET_KEY? "not-a-secure-key")
+    let harbor_db_password = (secret_value_or_default "platform-db" "postgresql-secrets" "HARBOR_DB_PASSWORD" $env.HARBOR_DB_PASSWORD? (generate_password))
+    let harbor_oidc_secret = (secret_value_or_default "harbor" "harbor-oidc-secret" "client-secret" $env.HARBOR_OIDC_CLIENT_SECRET? "harbor-client-secret")
     
     # Platform-db namespace and PostgreSQL secrets (shared database for Keycloak + Backstage + Gitea)
     kubectl create namespace platform-db --dry-run=client -o yaml | kubectl apply -f -
@@ -562,8 +588,8 @@ type: kubernetes.io/service-account-token" | save --force $token_secret_file
     kubectl create namespace tracing --dry-run=client -o yaml | kubectl apply -f -
 
     # Jaeger oauth2-proxy secret (Keycloak OIDC client + cookie encryption)
-    let jaeger_oidc_secret = ($env.JAEGER_OIDC_CLIENT_SECRET? | default "jaeger-client-secret")
-    let jaeger_cookie_secret = ($env.JAEGER_COOKIE_SECRET? | default (generate_password | str substring 0..31 | encode base64))
+    let jaeger_oidc_secret = (secret_value_or_default "tracing" "jaeger-oauth2-proxy-secrets" "client-secret" $env.JAEGER_OIDC_CLIENT_SECRET? "jaeger-client-secret")
+    let jaeger_cookie_secret = (secret_value_or_default "tracing" "jaeger-oauth2-proxy-secrets" "cookie-secret" $env.JAEGER_COOKIE_SECRET? (generate_password | str substring 0..31 | encode base64))
     (kubectl create secret generic jaeger-oauth2-proxy-secrets -n tracing
         --from-literal=client-secret=($jaeger_oidc_secret)
         --from-literal=cookie-secret=($jaeger_cookie_secret)
@@ -571,15 +597,15 @@ type: kubernetes.io/service-account-token" | save --force $token_secret_file
 
     # cost-monitoring namespace + OpenCost oauth2-proxy secrets
     kubectl create namespace cost-monitoring --dry-run=client -o yaml | kubectl apply -f -
-    let opencost_oidc_secret = ($env.OPENCOST_OIDC_CLIENT_SECRET? | default "opencost-client-secret")
-    let opencost_cookie_secret = ($env.OPENCOST_COOKIE_SECRET? | default (generate_password | str substring 0..31 | encode base64))
+    let opencost_oidc_secret = (secret_value_or_default "cost-monitoring" "opencost-oauth2-proxy-secrets" "client-secret" $env.OPENCOST_OIDC_CLIENT_SECRET? "opencost-client-secret")
+    let opencost_cookie_secret = (secret_value_or_default "cost-monitoring" "opencost-oauth2-proxy-secrets" "cookie-secret" $env.OPENCOST_COOKIE_SECRET? (generate_password | str substring 0..31 | encode base64))
     (kubectl create secret generic opencost-oauth2-proxy-secrets -n cost-monitoring
         --from-literal=client-secret=($opencost_oidc_secret)
         --from-literal=cookie-secret=($opencost_cookie_secret)
         --dry-run=client -o yaml | kubectl apply -f -)
 
     # OpenSearch secret (admin password for observability backend)
-    let opensearch_admin_password = ($env.OPENSEARCH_ADMIN_PASSWORD? | default (generate_password))
+    let opensearch_admin_password = (secret_value_or_default "platform-db" "opensearch-secrets" "OPENSEARCH_ADMIN_PASSWORD" $env.OPENSEARCH_ADMIN_PASSWORD? (generate_password))
     # Secret in platform-db namespace (for OpenSearch itself)
     (kubectl create secret generic opensearch-secrets -n platform-db
         --from-literal=OPENSEARCH_ADMIN_PASSWORD=($opensearch_admin_password)

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -1640,7 +1640,7 @@ def configure_gitea [] {
         $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -sSk -o /dev/null -w "%{http_code}" https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgadmin'
     } | complete)
 
-    if ($admin_check.exit_code == 0) and (($admin_check.stdout | str trim) == "204") {
+    if ($admin_check.exit_code == 0) and (($admin_check.stdout | str trim) == "200") {
         print $"(ansi yellow)✓ 'digiorgadmin' already member of Owners team(ansi reset)"
     } else {
         let admin_add = (do {
@@ -1658,7 +1658,7 @@ def configure_gitea [] {
         $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -sSk -o /dev/null -w "%{http_code}" https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgdeveloper'
     } | complete)
 
-    if ($dev_check.exit_code == 0) and (($dev_check.stdout | str trim) == "204") {
+    if ($dev_check.exit_code == 0) and (($dev_check.stdout | str trim) == "200") {
         print $"(ansi yellow)✓ 'digiorgdeveloper' already member of Owners team(ansi reset)"
     } else {
         let dev_add = (do {

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -56,16 +56,27 @@ def "main up" [] {
     print "────────────────────────────────────"
     deploy_root_app
     
-    # Configure Gitea (Keycloak OIDC integration + initial users/org) — requires Gitea to be up and running
+    # Configure Gitea only after its direct Applications and certificate resources
+    # are converged. This gate is independent of unrelated late-wave Apps and is
+    # safe to re-enter on an interrupted `up` run.
     print ""
     print $"(ansi cyan_bold)Phase 3: Configure Gitea(ansi reset)"
     print "────────────────────────────────────"
+    wait_for_configuration_dependencies "Gitea" ["gitea" "keycloak" "cert-manager"] [
+        {namespace: "cert-manager", name: "digiorg-local-ca"}
+        {namespace: "ingress-nginx", name: "digiorg-local-tls"}
+    ]
     configure_gitea
 
-    # Configure SonarQube (SAML + base URL)
+    # Configure SonarQube only after its direct Applications and the same local
+    # trust chain are ready; a CNPG or other unrelated drift cannot skip it.
     print ""
     print $"(ansi cyan_bold)Phase 4: Configure SonarQube(ansi reset)"
     print "────────────────────────────────────"
+    wait_for_configuration_dependencies "SonarQube" ["sonarqube" "keycloak" "cert-manager"] [
+        {namespace: "cert-manager", name: "digiorg-local-ca"}
+        {namespace: "ingress-nginx", name: "digiorg-local-tls"}
+    ]
     configure_sonarqube
 
     # Restart OIDC-dependent pods after Keycloak is ready
@@ -73,7 +84,17 @@ def "main up" [] {
     print $"(ansi cyan_bold)Phase 5: Restart OIDC dependent PODs(ansi reset)"
     print "────────────────────────────────────"
     restart_oidc_dependent_pods
-    
+
+    # Issue #281: run the strict all-Application convergence gate LAST, so a
+    # genuine unresolved Application failure still blocks the final success
+    # banner (fail-closed), but unrelated late-wave drift no longer skips the
+    # identity configuration phases above. The dependency-aware, idempotent
+    # configuration phases have already run and are safe to resume on a rerun.
+    print ""
+    print $"(ansi cyan_bold)Phase 6: Final Platform Convergence Gate(ansi reset)"
+    print "────────────────────────────────────"
+    wait_for_argocd_apps
+
     print ""
     print $"(ansi green_bold)╔════════════════════════════════════════════════════════════════╗(ansi reset)"
     print $"(ansi green_bold)║  ✓ Platform Ready!                                             ║(ansi reset)"
@@ -672,13 +693,21 @@ def deploy_root_app [] {
     # them concurrently in a shared cluster. This script targets only the named
     # local KinD environment; invoking `main up` is the explicit approval to sync
     # its gated apps sequentially.
+    # Issue #281: the CNPG Cluster (cnpg-cluster, wave 1) races the CNPG operator
+    # admission webhook on a clean bootstrap — the Cluster apply hit
+    # `connection refused` before the webhook endpoint accepted connections, and
+    # the resulting SyncFailed operation then stayed Running forever behind an
+    # idle Pending backup PVC, so Argo's retry never recovered. Gate the Cluster
+    # apply on operator Deployment availability + a ready webhook endpoint first.
+    promote_cnpg_cluster
+
     sync_gated_apps_for_local_dev
 
-    # Wait for apps to sync
-    print ""
-    print $"(ansi cyan_bold)Phase 3: Waiting for ArgoCD Apps(ansi reset)"
-    print "────────────────────────────────────"
-    wait_for_argocd_apps
+    # Issue #281: the ArgoCD OIDC CA patch is independent of the global
+    # convergence gate (which now runs LAST, in `main up`, after identity
+    # configuration). Embedding the CA here keeps ArgoCD's own OIDC working
+    # without coupling it to full-platform convergence.
+    patch_argocd_oidc_ca
 }
 
 # Issue #279: wait for argocd-repo-server to be Ready AND to have stopped
@@ -850,12 +879,15 @@ def is_retryable_sync_error [message: string] {
 # failed webhook or tool can echo request headers, URLs with userinfo, or Secret
 # values. Classification still uses the original text; only output is redacted.
 def redact_sync_diagnostic [message: string] {
-    $message
-    | str replace --all --regex '(?i)authorization\s*[:=]\s*(bearer|basic)\s+[^\s,;]+' 'Authorization: [REDACTED]'
-    | str replace --all --regex '(?i)https?://[^\s/@:]+:[^\s/@]+@' 'https://[REDACTED]@'
-    | str replace --all --regex `(?i)["']?(password|token|api[_-]?key|client[_-]?secret|secret)["']?\s*[:=]\s*["'][^"']*["']` '[REDACTED]'
-    | str replace --all --regex `(?i)["']?(password|token|api[_-]?key|client[_-]?secret|secret)["']?\s*[:=]\s*[^\s,;}]+` '[REDACTED]'
-    | str replace --all --regex '(?i)secret\s+data\s*[:=]\s*[^\s,;]+' 'Secret data: [REDACTED]'
+    let redacted = ($message
+        | str replace --all --regex '(?i)authorization\s*[:=]\s*(bearer|basic)\s+[^\s,;]+' 'Authorization: [REDACTED]'
+        | str replace --all --regex '(?i)https?://[^\s/@:]+:[^\s/@]+@' 'https://[REDACTED]@'
+        | str replace --all --regex `(?i)["']?(password|token|api[_-]?key|client[_-]?secret|secret)["']?\s*[:=]\s*["'][^"']*["']` '[REDACTED]'
+        | str replace --all --regex `(?i)["']?(password|token|api[_-]?key|client[_-]?secret|secret)["']?\s*[:=]\s*[^\s,;}]+` '[REDACTED]'
+        | str replace --all --regex '(?i)secret\s+data\s*[:=]\s*[^\s,;]+' 'Secret data: [REDACTED]')
+    # Controller/admission messages are untrusted and may be arbitrarily large.
+    # Bound every caller to a single 1 KiB diagnostic after redaction.
+    $redacted | str substring 0..1023
 }
 
 # Print operationState.message plus any failed resource/hook messages so a
@@ -1002,6 +1034,193 @@ def sync_gated_apps_for_local_dev [] {
     }
 }
 
+# Issue #281: is the CNPG operator Deployment Available? Accepts either a single
+# Deployment or a (label-selected) DeploymentList JSON. Fail closed: unparseable
+# input or no Available replica yields false.
+def cnpg_operator_available [deployment_json: string] {
+    let parsed = (try { $deployment_json | from json } catch { null })
+    # `from json` accepts a bare scalar as a JSON string, so guard on the type:
+    # only a record is a real Deployment/List object. Fail closed otherwise.
+    if ($parsed | describe | str starts-with "record") == false {
+        return false
+    }
+    let deployments = if ($parsed | get -o kind | default "") == "List" or ($parsed | get -o kind | default "") == "DeploymentList" {
+        $parsed | get -o items | default []
+    } else {
+        [$parsed]
+    }
+    $deployments | any {|dep|
+        let desired = ($dep | get -o spec.replicas | default 0)
+        let available = ($dep | get -o status.availableReplicas | default 0)
+        ($desired > 0) and ($available >= $desired)
+    }
+}
+
+# Issue #281: does the CNPG admission webhook have a ready, addressed endpoint?
+# Parses a discovery.k8s.io/v1 EndpointSliceList (NOT the deprecated core
+# Endpoints API). Ready iff some slice has an endpoint with conditions.ready ==
+# true AND at least one address. Fail closed on unparseable input.
+def cnpg_webhook_endpoint_ready [endpointslices_json: string] {
+    let parsed = (try { $endpointslices_json | from json } catch { null })
+    # `from json` accepts a bare scalar as a JSON string, so guard on the type:
+    # only a record is a real EndpointSliceList object. Fail closed otherwise.
+    if ($parsed | describe | str starts-with "record") == false {
+        return false
+    }
+    let slices = ($parsed | get -o items | default [])
+    $slices | any {|slice|
+        ($slice | get -o endpoints | default []) | any {|ep|
+            let ready = ($ep | get -o conditions.ready | default false)
+            let addresses = ($ep | get -o addresses | default [])
+            $ready and (($addresses | length) > 0)
+        }
+    }
+}
+
+# Issue #281: block the CNPG Cluster apply until the operator Deployment is
+# Available AND its admission webhook endpoint is serving. On a clean bootstrap
+# the Cluster otherwise raced the webhook and hit `connection refused`, leaving a
+# non-terminal Running operation that Argo never retried. Bounded and fails
+# closed with a redacted diagnostic.
+def wait_for_cnpg_webhook_ready [] {
+    $env.KUBECONFIG = $KUBECONFIG_PATH
+
+    let operator_ns = "cnpg-system"
+    let webhook_service = "cnpg-webhook-service"
+    mut last_diagnostic = "cnpg operator/webhook readiness was not observed"
+    for attempt in 1..60 {
+        let dep_result = (do {
+            kubectl get deployment -n $operator_ns -l app.kubernetes.io/name=cloudnative-pg -o json
+        } | complete)
+        # discovery.k8s.io/v1 EndpointSlices for the webhook Service — the core
+        # Endpoints API is deprecated and must not be used here.
+        let slice_result = (do {
+            kubectl get endpointslices.discovery.k8s.io -n $operator_ns -l $"kubernetes.io/service-name=($webhook_service)" -o json
+        } | complete)
+
+        if $dep_result.exit_code == 0 and $slice_result.exit_code == 0 {
+            let operator_ok = (cnpg_operator_available $dep_result.stdout)
+            let webhook_ok = (cnpg_webhook_endpoint_ready $slice_result.stdout)
+            $last_diagnostic = $"operatorAvailable=($operator_ok) webhookEndpointReady=($webhook_ok)"
+            print $"  cnpg readiness: ($last_diagnostic) [attempt ($attempt)/60]"
+            if $operator_ok and $webhook_ok {
+                print $"(ansi green)✓ CNPG operator is Available and the webhook endpoint is ready(ansi reset)"
+                return
+            }
+        } else {
+            $last_diagnostic = (redact_sync_diagnostic (($dep_result.stderr + " " + $slice_result.stderr) | str trim))
+        }
+        sleep 5sec
+    }
+    error make {msg: $"CNPG operator Deployment/webhook endpoint did not become ready before the CNPG Cluster apply: ($last_diagnostic)"}
+}
+
+# Issue #281: promote the script-driven `cnpg-cluster` Application only after the
+# operator webhook is ready, then sync it with a genuinely fresh operation (new
+# startedAt — never re-read a stale terminal operation). Rerunning is safe: an
+# already Synced/Healthy Cluster reconciles as a no-op. Fails closed.
+def promote_cnpg_cluster [poll_interval: duration = 10sec] {
+    $env.KUBECONFIG = $KUBECONFIG_PATH
+
+    print ""
+    print $"(ansi cyan_bold)Promoting CNPG Cluster after operator/webhook readiness(ansi reset)"
+
+    mut exists = false
+    for attempt in 1..60 {
+        let get_result = (do { kubectl get application cnpg-cluster -n argocd -o name } | complete)
+        if $get_result.exit_code == 0 {
+            $exists = true
+            break
+        }
+        sleep 2sec
+    }
+    if not $exists {
+        error make {msg: "ArgoCD Application cnpg-cluster was not created by the root app"}
+    }
+
+    # Order the Cluster apply strictly AFTER the operator webhook is serving.
+    wait_for_cnpg_webhook_ready
+
+    let sync_payload = '{"operation":{"sync":{"prune":true,"syncOptions":["CreateNamespace=true","ServerSideApply=true"]}}}'
+    let initial_state = (kubectl get application cnpg-cluster -n argocd -o json | from json)
+    let previous_started = ($initial_state | get -o status.operationState.startedAt | default "")
+    let initial_phase = ($initial_state | get -o status.operationState.phase | default "")
+    let initial_sync = ($initial_state | get -o status.sync.status | default "")
+    let initial_health = ($initial_state | get -o status.health.status | default "")
+
+    # A resumed setup must not overwrite an operation that the previous invocation
+    # already started: Argo rejects that with "another operation is already in
+    # progress". Observe it to completion instead. Conversely, a terminal stale
+    # operation is never accepted as fresh; patching below must produce a changed
+    # startedAt. An already converged Application is a true idempotent no-op.
+    if $initial_phase == "Succeeded" and $initial_sync == "Synced" and $initial_health == "Healthy" {
+        print $"(ansi green)  ✓ cnpg-cluster is already Synced and Healthy(ansi reset)"
+        return
+    }
+
+    mut resuming_existing_operation = false
+    if $initial_phase == "Running" {
+        if ($previous_started | is-empty) {
+            error make {msg: "Running cnpg-cluster operation has no startedAt identity; refusing to overwrite an unidentifiable in-flight operation"}
+        }
+        $resuming_existing_operation = true
+        print $"  Resuming observation of in-flight cnpg-cluster operation started at ($previous_started)..."
+    } else {
+        print "  Syncing cnpg-cluster with a fresh operation..."
+        let sync_result = (do {
+            kubectl patch application cnpg-cluster -n argocd --type merge -p $sync_payload
+        } | complete)
+        if $sync_result.exit_code != 0 {
+            error make {msg: $"Could not start CNPG Cluster sync: (redact_sync_diagnostic ($sync_result.stderr | str trim))"}
+        }
+    }
+
+    mut completed = false
+    mut saw_new_operation = $resuming_existing_operation
+    mut succeeded = false
+    mut last_state = {}
+    for attempt in 1..90 {
+        let state_result = (do { kubectl get application cnpg-cluster -n argocd -o json } | complete)
+        if $state_result.exit_code == 0 {
+            let state = ($state_result.stdout | from json)
+            $last_state = $state
+            let phase = ($state | get -o status.operationState.phase | default "")
+            let started = ($state | get -o status.operationState.startedAt | default "")
+            let sync = ($state | get -o status.sync.status | default "")
+            let health = ($state | get -o status.health.status | default "")
+            if not $resuming_existing_operation and not ($started | is-empty) and $started != $previous_started {
+                $saw_new_operation = true
+            }
+            if $resuming_existing_operation and $started != $previous_started {
+                error make {msg: "The in-flight CNPG operation identity changed unexpectedly during resume"}
+            }
+            if $saw_new_operation and $phase in ["Failed" "Error"] {
+                $completed = true
+                break
+            }
+            if $saw_new_operation and $phase == "Succeeded" and $sync == "Synced" and $health == "Healthy" {
+                $completed = true
+                $succeeded = true
+                break
+            }
+        }
+        sleep $poll_interval
+    }
+
+    if not $completed {
+        if not ($last_state | is-empty) {
+            print_sync_diagnostics $last_state
+        }
+        error make {msg: "CNPG Cluster did not reach a fresh Synced+Healthy operation before the timeout"}
+    }
+    if not $succeeded {
+        print_sync_diagnostics $last_state
+        let message = ($last_state | get -o status.operationState.message | default "")
+        error make {msg: $"CNPG Cluster sync failed: (redact_sync_diagnostic $message)"}
+    }
+    print $"(ansi green)  ✓ cnpg-cluster sync Succeeded, Synced and Healthy(ansi reset)"
+}
+
 # Argo CD 3.x can retain stale per-resource OutOfSync status after a successful
 # Helm sync even when its own diff engine reports no material difference (seen
 # with API-defaulted CRD fields). Use the CLI only as a fail-closed secondary
@@ -1033,15 +1252,38 @@ def argocd_app_has_no_material_diff [app: string] {
     }
 }
 
+# Render a bounded, redacted one-line-per-app report of the non-ready
+# Applications. Input is a list of {name, health, sync, phase} records; only
+# those enum-like status fields are printed (never operation messages, which
+# can echo credentials), and each line is still passed through the shared
+# redaction as defence-in-depth. Empty input yields an empty string.
+def format_non_ready_report [non_ready: list] {
+    $non_ready
+    | each {|a|
+        let name = ($a | get -o name | default "")
+        let health = ($a | get -o health | default "")
+        let sync = ($a | get -o sync | default "")
+        let phase = ($a | get -o phase | default "")
+        redact_sync_diagnostic $"    ($name): health=($health) sync=($sync) phase=($phase)"
+    }
+    | str join "\n"
+}
+
 # Wait for ArgoCD apps to become healthy
 def wait_for_argocd_apps [] {
     $env.KUBECONFIG = $KUBECONFIG_PATH
-    
+
     print "Waiting for ArgoCD applications to sync (this may take 10-20 minutes)..."
     print ""
-    
-    # Apps to wait for (in wave order) — must match apps/platform/*.yaml exactly
+
+    # Apps to wait for — this client-side readiness inventory must match
+    # apps/platform/*.yaml EXACTLY (one entry per child Application, including
+    # `namespaces`). A contract test (test_bootstrap_convergence.py) fails if
+    # this list drifts from the manifests, so a stale inventory can no longer
+    # silently under-count readiness (issue #281: the omitted `namespaces`).
     let apps = [
+        # Wave -1
+        "namespaces",
         # Wave 0
         "cert-manager", "cnpg", "external-secrets", "nats", "postgresql",
         # Wave 1
@@ -1061,64 +1303,157 @@ def wait_for_argocd_apps [] {
         # Wave 8
         "core-catalog"
     ]
-    
+
     mut all_healthy = false
     mut attempts = 0
     let max_attempts = 150  # 25 minutes with 10sec intervals — platform has grown
-    
+    mut last_non_ready = []
+
     loop {
         $attempts = $attempts + 1
         if $attempts > $max_attempts {
-            error make {msg: "Timeout waiting for every required ArgoCD Application to become Synced and Healthy"}
+            # Fail closed, but first name every blocking Application with bounded,
+            # redacted health/sync/phase, then print the full status table — both
+            # were previously unreachable once the timeout aborted (issue #281).
+            print ""
+            print $"(ansi red)Non-ready ArgoCD Applications at timeout:(ansi reset)"
+            print (format_non_ready_report $last_non_ready)
+            print ""
+            print "ArgoCD Application Status:"
+            kubectl get applications -n argocd -o wide
+            let blocking = ($last_non_ready | get -o name | default [] | str join ", ")
+            error make {msg: $"Timeout waiting for every required ArgoCD Application to become Synced and Healthy; non-ready: ($blocking)"}
         }
-        
+
         mut ready_count = 0
-        
+        mut non_ready = []
+
         for app in $apps {
             let status = (do {
                 kubectl get application $app -n argocd -o json
             } | complete)
+            mut is_ready = false
+            mut health = "Unknown"
+            mut sync = "Unknown"
+            mut phase = ""
             if $status.exit_code == 0 {
                 let state = ($status.stdout | from json)
-                let health = ($state | get -o status.health.status | default "")
-                let sync = ($state | get -o status.sync.status | default "")
+                $health = ($state | get -o status.health.status | default "")
+                $sync = ($state | get -o status.sync.status | default "")
+                $phase = ($state | get -o status.operationState.phase | default "")
                 if $health == "Healthy" and $sync == "Synced" {
-                    $ready_count = $ready_count + 1
+                    $is_ready = true
                 } else if $health == "Healthy" and $sync == "OutOfSync" and (argocd_app_has_no_material_diff $app) {
                     # Count only a successful, fresh Argo core diff with zero
                     # material changes; every tool/error path remains closed.
                     print $"  ($app): stale OutOfSync status, but Argo reports no material diff"
-                    $ready_count = $ready_count + 1
+                    $is_ready = true
                 }
             }
+            if $is_ready {
+                $ready_count = $ready_count + 1
+            } else {
+                $non_ready = ($non_ready | append {name: $app, health: $health, sync: $sync, phase: $phase})
+            }
         }
+        $last_non_ready = $non_ready
 
         print $"  Apps Synced+Healthy: ($ready_count)/($apps | length) [attempt ($attempts)/($max_attempts)]"
+        # Surface which Applications are blocking during the final attempts so a
+        # stall is diagnosable well before the timeout error fires.
+        if ($non_ready | is-not-empty) and $attempts > ($max_attempts - 5) {
+            print (format_non_ready_report $non_ready)
+        }
 
         if $ready_count == ($apps | length) {
             $all_healthy = true
             break
         }
-        
+
         sleep 10sec
     }
-    
+
     if $all_healthy {
         print $"(ansi green)✓ All ArgoCD applications are healthy!(ansi reset)"
     }
-    
-    # Show final status
+
+    # Show final status (success path — the timeout path prints its own table)
     print ""
     print "ArgoCD Application Status:"
     kubectl get applications -n argocd -o wide
-
-    # Patch ArgoCD OIDC config with self-signed CA cert
-    patch_argocd_oidc_ca
 }
 
 # -----------------------------------------------------------------------------
 # Phase 3: Configure Apps Functions
 # -----------------------------------------------------------------------------
+
+# Wait only for the direct dependencies of an identity-configuration phase.
+# This lets Gitea/SonarQube configuration proceed independently of unrelated
+# late-wave drift while remaining bounded and fail-closed. App and Certificate
+# names are trusted repository constants; no untrusted operation messages or
+# Secret data are emitted.
+def wait_for_configuration_dependencies [phase: string, apps: list, certificates: list] {
+    $env.KUBECONFIG = $KUBECONFIG_PATH
+
+    mut last_non_ready = []
+    for attempt in 1..60 {
+        mut non_ready = []
+
+        for app in $apps {
+            let result = (do { kubectl get application $app -n argocd -o json } | complete)
+            if $result.exit_code != 0 {
+                $non_ready = ($non_ready | append $"Application/($app)=missing")
+                continue
+            }
+            let state = (try { $result.stdout | from json } catch { null })
+            if ($state | describe | str starts-with "record") == false {
+                $non_ready = ($non_ready | append $"Application/($app)=invalid-status")
+                continue
+            }
+            let health = ($state | get -o status.health.status | default "Unknown")
+            let sync = ($state | get -o status.sync.status | default "Unknown")
+            if not ($health == "Healthy" and $sync == "Synced") {
+                $non_ready = ($non_ready | append $"Application/($app)=health:($health),sync:($sync)")
+            }
+        }
+
+        for cert in $certificates {
+            let namespace = ($cert | get namespace)
+            let name = ($cert | get name)
+            let result = (do { kubectl get certificate $name -n $namespace -o json } | complete)
+            if $result.exit_code != 0 {
+                $non_ready = ($non_ready | append $"Certificate/($namespace)/($name)=missing")
+                continue
+            }
+            let resource = (try { $result.stdout | from json } catch { null })
+            if ($resource | describe | str starts-with "record") == false {
+                $non_ready = ($non_ready | append $"Certificate/($namespace)/($name)=invalid-status")
+                continue
+            }
+            let conditions = ($resource | get -o status.conditions | default [])
+            let ready = ($conditions | any {|condition|
+                (($condition | get -o type | default "") == "Ready") and (($condition | get -o status | default "") == "True")
+            })
+            if not $ready {
+                $non_ready = ($non_ready | append $"Certificate/($namespace)/($name)=Ready:False")
+            }
+        }
+
+        $last_non_ready = $non_ready
+        if ($non_ready | is-empty) {
+            print $"(ansi green)✓ ($phase) configuration dependencies are ready(ansi reset)"
+            return
+        }
+
+        if $attempt > 55 {
+            print $"  ($phase) dependencies pending: (($non_ready | str join ', ')) [attempt ($attempt)/60]"
+        }
+        sleep 5sec
+    }
+
+    let bounded = ($last_non_ready | first 20 | str join ", ")
+    error make {msg: $"($phase) configuration dependencies did not become ready: ($bounded)"}
+}
 
 # Configure Gitea (register self-signed CA cert + add Keycloak OIDC provider + create initial users/org)
 def configure_gitea [] {
@@ -1142,15 +1477,24 @@ def configure_gitea [] {
         sleep 10sec
     }
     if not $gitea_ready {
-        print $"(ansi yellow)Warning: Gitea pod not ready, skipping OIDC configuration(ansi reset)"
-        return
+        error make {msg: "Gitea pod did not become ready for OIDC configuration"}
     }
     let gitea_pod = (kubectl --kubeconfig $KUBECONFIG_PATH get pods -n gitea -l app.kubernetes.io/name=gitea -o jsonpath='{.items[0].metadata.name}' | str trim)
 
     # Extract CA cert from cert-manager secret
-    # Copy CA cert into Gitea container and update trust store
-    kubectl --kubeconfig $KUBECONFIG_PATH cp digiorg-local-ca.crt -c gitea gitea/($gitea_pod):/usr/local/share/ca-certificates/digiorg-local-ca.crt | complete
-    kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- update-ca-certificates | complete
+    # Copy CA cert into Gitea container and update trust store.
+    let ca_copy = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH cp digiorg-local-ca.crt -c gitea gitea/($gitea_pod):/usr/local/share/ca-certificates/digiorg-local-ca.crt
+    } | complete)
+    if $ca_copy.exit_code != 0 {
+        error make {msg: "Failed to copy the local CA certificate into Gitea"}
+    }
+    let ca_update = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- update-ca-certificates
+    } | complete)
+    if $ca_update.exit_code != 0 {
+        error make {msg: "Failed to update the Gitea trust store"}
+    }
     print $"(ansi green)✓ CA cert registered in Gitea trust store(ansi reset)"
 
     # --- Step 2: Add Keycloak as OIDC authentication source ---
@@ -1176,19 +1520,40 @@ def configure_gitea [] {
         if $add_result.exit_code == 0 {
             print $"(ansi green)✓ Keycloak OIDC provider added to Gitea(ansi reset)"
         } else {
-            print $"(ansi red)✗ Failed to add Keycloak OIDC provider: ($add_result.stderr)(ansi reset)"
-            return
+            error make {msg: "Failed to add the Keycloak OIDC provider to Gitea"}
         }
     } else {
         print $"(ansi yellow)✓ Keycloak OIDC provider already exists in Gitea(ansi reset)"
     }
 
-    # --- Step 3: Create initial users in Gitea ---
-    print "3. Creating initial users in Gitea..."
+    # --- Step 3: Create initial users in Gitea (resume-safe) ---
+    print "3. Ensuring initial users exist in Gitea..."
 
-    kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c 'gitea admin user create --username "digiorgadmin" --email "admin@digiorg.local" --password "digiorgadmin" --must-change-password false --admin true'
-    kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c 'gitea admin user create --username "digiorgdeveloper" --email "developer@digiorg.local" --password "digiorgdeveloper" --must-change-password false --admin false'
-    print $"(ansi green)✓ Initial users created(ansi reset)"
+    let users_result = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c 'gitea admin user list --page 1 --page-size 1000'
+    } | complete)
+    if $users_result.exit_code != 0 {
+        error make {msg: "Failed to list existing Gitea users"}
+    }
+
+    if not ($users_result.stdout | lines | any {|line| $line | str contains "digiorgadmin" }) {
+        let create_admin = (do {
+            kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c 'gitea admin user create --username "digiorgadmin" --email "admin@digiorg.local" --password "digiorgadmin" --must-change-password false --admin true'
+        } | complete)
+        if $create_admin.exit_code != 0 {
+            error make {msg: "Failed to create the initial Gitea administrator"}
+        }
+    }
+
+    if not ($users_result.stdout | lines | any {|line| $line | str contains "digiorgdeveloper" }) {
+        let create_developer = (do {
+            kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c 'gitea admin user create --username "digiorgdeveloper" --email "developer@digiorg.local" --password "digiorgdeveloper" --must-change-password false --admin false'
+        } | complete)
+        if $create_developer.exit_code != 0 {
+            error make {msg: "Failed to create the initial Gitea developer"}
+        }
+    }
+    print $"(ansi green)✓ Initial users are present(ansi reset)"
 
     # --- Step 4: Create DigiOrg organisation via tea CLI ---
     print "4. Creating DigiOrg organisation in Gitea..."
@@ -1207,8 +1572,7 @@ def configure_gitea [] {
         if $tea_install.exit_code == 0 {
             print $"(ansi green)✓ tea CLI installed(ansi reset)"
         } else {
-            print $"(ansi red)✗ Failed to install tea CLI: ($tea_install.stderr)(ansi reset)"
-            return
+            error make {msg: "Failed to install the pinned tea CLI in Gitea"}
         }
     }
 
@@ -1225,28 +1589,36 @@ def configure_gitea [] {
         let token_extract = (do {
             kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- sh -c 'grep -A10 "teaadmin-digiorg" /root/.config/tea/config.yml | grep "token:" | head -1 | sed "s/.*token: //"'
         } | complete)
-        $token_extract.stdout | str trim
+        let stored_token = ($token_extract.stdout | str trim)
+        if $token_extract.exit_code != 0 or ($stored_token | is-empty) {
+            error make {msg: "The existing Gitea tea login has no usable stored token"}
+        }
+        $stored_token
     } else {
         # 4c: Generate access token — must run as git user, not root
         let token_result = (do {
             kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c 'gitea admin user generate-access-token --username gitea_admin --token-name teaadmin --scopes write:activitypub,write:admin,write:issue,write:misc,write:notification,write:organization,write:package,write:repository,write:user --raw'
         } | complete)
         if $token_result.exit_code != 0 {
-            print $"(ansi red)✗ Failed to generate access token: ($token_result.stderr)(ansi reset)"
-            return
+            error make {msg: "Failed to generate the Gitea configuration access token"}
         }
         let token = ($token_result.stdout | str trim)
+        if ($token | is-empty) {
+            error make {msg: "Gitea returned an empty configuration access token"}
+        }
         print $"(ansi green)✓ Access token generated(ansi reset)"
 
-        # 4d: Set up tea login (token-based, using immutable $token — capturable in closures)
+        # 4d: Set up tea login without placing the token in a process argument.
+        # Tea itself receives only a fixed placeholder. POSIX-shell builtins then
+        # replace that placeholder in tea's config while the real token arrives
+        # exclusively over stdin; no child process sees it in argv.
         let login_add = (do {
-            kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- sh -c $"tea login add --name=teaadmin-digiorg --url=https://digiorg.local/gitea --token=($token)"
+            $token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'set -eu; IFS= read -r token; placeholder=__DIGIORG_TOKEN_PLACEHOLDER__; tea login add --name=teaadmin-digiorg --url=https://digiorg.local/gitea --token="$placeholder" >/dev/null; cfg="${HOME:-/root}/.config/tea/config.yml"; tmp="${cfg}.tmp"; : > "$tmp"; while IFS= read -r line; do case "$line" in *"$placeholder"*) prefix=${line%%$placeholder*}; suffix=${line#*$placeholder}; printf "%s%s%s\n" "$prefix" "$token" "$suffix" ;; *) printf "%s\n" "$line" ;; esac; done < "$cfg" > "$tmp"; mv "$tmp" "$cfg"'
         } | complete)
         if $login_add.exit_code == 0 {
             print $"(ansi green)✓ tea login 'teaadmin-digiorg' configured(ansi reset)"
         } else {
-            print $"(ansi red)✗ Failed to configure tea login: ($login_add.stderr)(ansi reset)"
-            return
+            error make {msg: "Failed to configure the Gitea tea login"}
         }
         $token
     }
@@ -1265,75 +1637,110 @@ def configure_gitea [] {
         if $org_create.exit_code == 0 {
             print $"(ansi green)✓ Organisation 'DigiOrg' created(ansi reset)"
         } else {
-            print $"(ansi red)✗ Failed to create organisation 'DigiOrg': ($org_create.stderr)(ansi reset)"
-            return
+            error make {msg: "Failed to create the DigiOrg organisation in Gitea"}
         }
     }
 
-    # 4f: Get Owners team ID via Gitea API
+    # 4f: Get Owners team ID via Gitea API. Feed the token on stdin so it is
+    # never embedded in a process argument or printed command; --fail turns
+    # every HTTP 4xx/5xx response into a fail-closed command result.
     let teams_result = (do {
-        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- sh -c $"curl -sk -H 'Authorization: token ($gitea_token)' https://digiorg.local/gitea/api/v1/orgs/DigiOrg/teams"
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -fsSk https://digiorg.local/gitea/api/v1/orgs/DigiOrg/teams'
     } | complete)
+
     if $teams_result.exit_code != 0 {
-        print $"(ansi red)✗ Failed to retrieve DigiOrg teams: ($teams_result.stderr)(ansi reset)"
-        return
+        error make {msg: "Failed to retrieve the DigiOrg teams from Gitea"}
     }
     let owners_team = ($teams_result.stdout | from json | where name == "Owners")
     if ($owners_team | is-empty) {
-        print $"(ansi red)✗ Could not find Owners team in DigiOrg(ansi reset)"
-        return
+        error make {msg: "Could not find the Owners team in the DigiOrg organisation"}
     }
     let owners_team_id = ($owners_team | get id | first)
     print $"(ansi green)✓ DigiOrg Owners team ID: ($owners_team_id)(ansi reset)"
 
     # 4g: Add digiorgadmin to Owners team (idempotent)
     let admin_check = (do {
-        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- sh -c $"curl -sk -o /dev/null -w '%{http_code}' -H 'Authorization: token ($gitea_token)' https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgadmin"
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -sSk -o /dev/null -w "%{http_code}" https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgadmin'
     } | complete)
 
     if ($admin_check.exit_code == 0) and (($admin_check.stdout | str trim) == "204") {
         print $"(ansi yellow)✓ 'digiorgadmin' already member of Owners team(ansi reset)"
     } else {
         let admin_add = (do {
-            kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- sh -c $"curl -sk -X PUT -H 'Authorization: token ($gitea_token)' https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgadmin"
+            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -fsSk -X PUT https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgadmin'
         } | complete)
         if $admin_add.exit_code == 0 {
             print $"(ansi green)✓ 'digiorgadmin' added to Owners team(ansi reset)"
         } else {
-            print $"(ansi red)✗ Failed to add 'digiorgadmin' to Owners team: ($admin_add.stderr)(ansi reset)"
-            return
+            error make {msg: "Failed to add digiorgadmin to the Gitea Owners team"}
         }
     }
 
     # 4h: Add digiorgdeveloper to Owners team (idempotent)
     let dev_check = (do {
-        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- sh -c $"curl -sk -o /dev/null -w '%{http_code}' -H 'Authorization: token ($gitea_token)' https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgdeveloper"
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -sSk -o /dev/null -w "%{http_code}" https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgdeveloper'
     } | complete)
 
     if ($dev_check.exit_code == 0) and (($dev_check.stdout | str trim) == "204") {
         print $"(ansi yellow)✓ 'digiorgdeveloper' already member of Owners team(ansi reset)"
     } else {
         let dev_add = (do {
-            kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- sh -c $"curl -sk -X PUT -H 'Authorization: token ($gitea_token)' https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgdeveloper"
+            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -fsSk -X PUT https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgdeveloper'
         } | complete)
         if $dev_add.exit_code == 0 {
             print $"(ansi green)✓ 'digiorgdeveloper' added to Owners team(ansi reset)"
         } else {
-            print $"(ansi red)✗ Failed to add 'digiorgdeveloper' to Owners team: ($dev_add.stderr)(ansi reset)"
-            return
+            error make {msg: "Failed to add digiorgdeveloper to the Gitea Owners team"}
         }
     }
 
     # 4i: Verification — list Owners team members
     let verify = (do {
-        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- sh -c $"curl -sk -H 'Authorization: token ($gitea_token)' https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members"
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -fsSk https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members'
     } | complete)
     if $verify.exit_code == 0 {
-        let members = ($verify.stdout | from json | get login | str join ", ")
-        print $"(ansi green)✓ DigiOrg Owners team members: ($members)(ansi reset)"
+        let members = ($verify.stdout | from json | get login)
+        let required_members = ["digiorgadmin" "digiorgdeveloper"]
+        let missing_members = ($required_members | where {|username| $username not-in $members })
+        if not ($missing_members | is-empty) {
+            error make {msg: $"Required Gitea Owners team members are missing: ($missing_members | str join ', ')"}
+        }
+        print $"(ansi green)✓ DigiOrg Owners team members: ($members | str join ', ')(ansi reset)"
+    } else {
+        error make {msg: "Failed to verify the Gitea Owners team membership"}
     }
 
     print $"(ansi green)✓ Gitea OIDC integration configured(ansi reset)"
+}
+
+# Compare SonarQube's /api/settings/values response with an expected JSON record.
+# The secured certificate itself is intentionally excluded from readback because
+# SonarQube does not return secured values. Invalid/missing JSON fails closed.
+def sonarqube_settings_match [settings_json: string, expected_json: string] {
+    let parsed = (try { $settings_json | from json } catch { null })
+    let expected = (try { $expected_json | from json } catch { null })
+    if (($parsed | describe | str starts-with "record") == false) or (($expected | describe | str starts-with "record") == false) {
+        return false
+    }
+    let settings = ($parsed | get -o settings | default [])
+    $expected | transpose key value | all {|entry|
+        $settings | any {|setting|
+            (($setting | get -o key | default "") == $entry.key) and (($setting | get -o value | default "") == $entry.value)
+        }
+    }
+}
+
+def sonarqube_setting_present [settings_json: string, required_key: string] {
+    let parsed = (try { $settings_json | from json } catch { null })
+    if (($parsed | describe | str starts-with "record") == false) {
+        return false
+    }
+    let settings = ($parsed | get -o settings | default [])
+    $settings | any {|setting| ($setting | get -o key | default "") == $required_key }
+}
+
+def sonarqube_http_status_matches [exit_code: int, status: string, expected: string] {
+    $exit_code == 0 and ($status | str trim) == $expected
 }
 
 # Configure SonarQube
@@ -1341,18 +1748,29 @@ def configure_sonarqube [] {
     let sonar_url = "https://digiorg.local/sonarqube"
     let keycloak_saml_descriptor_url = "https://digiorg.local/keycloak/realms/digiorg-core-platform/protocol/saml/descriptor"
     let admin_pass = (do -i { kubectl --kubeconfig $KUBECONFIG_PATH get secret sonarqube-admin-secret -n code-quality -o jsonpath='{.data.password}' } | complete)
-
     let password = if $admin_pass.exit_code == 0 {
-        $admin_pass.stdout | str trim | decode base64
+        try { $admin_pass.stdout | str trim | decode base64 } catch { "" }
+    } else if ($admin_pass.stderr | str contains 'secrets "sonarqube-admin-secret" not found') {
+        # The upstream local-development chart starts with the documented default
+        # admin password and does not create an admin Secret. Operators can provide
+        # SONARQUBE_ADMIN_PASSWORD after changing it. Only exact NotFound falls back;
+        # auth, kubeconfig and transport errors remain fatal.
+        $env.SONARQUBE_ADMIN_PASSWORD? | default "admin"
     } else {
-        ($env.SONARQUBE_ADMIN_PASSWORD? | default "admin")
+        error make {msg: "Failed to read the SonarQube admin password from sonarqube-admin-secret"}
     }
+    if ($password | is-empty) {
+        error make {msg: "Failed to read the SonarQube admin password from sonarqube-admin-secret"}
+    }
+    # Feed curl credentials through stdin config so the password is not exposed
+    # in a process argument. Never print this value.
+    let sonar_auth_config = $"user = \"admin:($password)\"\n"
 
     # Wait for SonarQube to be ready (up to 5 min)
     mut sonar_ready = false
     for attempt in 1..30 {
         let status = (do -i {
-            curl --noproxy "*" -sk -u $"admin:($password)" $"($sonar_url)/api/system/status"
+            $sonar_auth_config | curl --config - --noproxy "*" -fsSk $"($sonar_url)/api/system/status"
         } | complete)
         if $status.exit_code == 0 and ($status.stdout | str contains '"status":"UP"') {
             $sonar_ready = true
@@ -1363,32 +1781,29 @@ def configure_sonarqube [] {
     }
 
     if not $sonar_ready {
-        print $"(ansi yellow)Warning: SonarQube not ready, skipping Server Base URL configuration(ansi reset)"
-        return
+        error make {msg: "SonarQube did not become ready for SAML configuration"}
     }
 
     # Set sonar.core.serverBaseURL via Settings API
-    let result = (do -i { curl --noproxy "*" -sk -u $"admin:($password)" -X POST $"($sonar_url)/api/settings/set" --data-urlencode "key=sonar.core.serverBaseURL" --data-urlencode $"value=($sonar_url)" } | complete)
+    let result = (do -i { $sonar_auth_config | curl --config - --noproxy "*" -sSk -o /dev/null -w "%{http_code}" -X POST $"($sonar_url)/api/settings/set" --data-urlencode "key=sonar.core.serverBaseURL" --data-urlencode $"value=($sonar_url)" } | complete)
 
-    if $result.exit_code == 0 {
+    if (sonarqube_http_status_matches $result.exit_code $result.stdout "204") {
         print $"(ansi green)✓ SonarQube Server Base URL set to ($sonar_url)(ansi reset)"
     } else {
-        print $"(ansi red)✗ Failed to set Server Base URL: ($result.stderr)(ansi reset)"
+        error make {msg: "Failed to set the SonarQube Server Base URL"}
     }
 
     # --- Step 1: Fetch Keycloak IdP X.509 certificate from SAML descriptor ---
     # The SAML metadata descriptor endpoint returns the full X.509 certificate
     # (not just the raw public key), which is what SonarQube requires.
     print "  1. Fetching Keycloak IdP X.509 certificate from SAML descriptor..."
-    let cert_result = (do -i { curl --noproxy "*" -sk $keycloak_saml_descriptor_url } | complete)
+    let cert_result = (do -i { curl --noproxy "*" -fsSk $keycloak_saml_descriptor_url } | complete)
     if $cert_result.exit_code != 0 {
-        print $"(ansi red)✗ Failed to reach Keycloak SAML descriptor endpoint: ($cert_result.stderr)(ansi reset)"
-        return
+        error make {msg: "Failed to reach the Keycloak SAML descriptor endpoint"}
     }
     let keycloak_cert = ($cert_result.stdout | parse --regex '(?s)<ds:X509Certificate>(.*?)</ds:X509Certificate>' | get capture0 | first | str trim)
     if ($keycloak_cert | is-empty) {
-        print $"(ansi red)✗ Could not extract X509Certificate from SAML descriptor(ansi reset)"
-        return
+        error make {msg: "Could not extract the X509Certificate from the Keycloak SAML descriptor"}
     }
     print $"(ansi green)✓ Keycloak IdP X.509 certificate fetched(ansi reset)"
 
@@ -1410,72 +1825,96 @@ def configure_sonarqube [] {
 
     mut all_ok = true
     for setting in $saml_settings {
-        let r = (do -i { curl --noproxy "*" -sk -u $"admin:($password)" -X POST $"($sonar_url)/api/settings/set" --data-urlencode $"key=($setting.key)" --data-urlencode $"value=($setting.value)" } | complete)
-        if $r.exit_code != 0 {
-            print $"(ansi red)✗ Failed to set ($setting.key): ($r.stderr)(ansi reset)"
+        let r = (do -i { $sonar_auth_config | curl --config - --noproxy "*" -sSk -o /dev/null -w "%{http_code}" -X POST $"($sonar_url)/api/settings/set" --data-urlencode $"key=($setting.key)" --data-urlencode $"value=($setting.value)" } | complete)
+        if not (sonarqube_http_status_matches $r.exit_code $r.stdout "204") {
+            print $"(ansi red)✗ Failed to set ($setting.key)(ansi reset)"
             $all_ok = false
         }
     }
 
     # --- Step 4: Enable SAML ---
-    let enable_result = (do -i { curl --noproxy "*" -sk -u $"admin:($password)" -X POST $"($sonar_url)/api/settings/set" --data-urlencode "key=sonar.auth.saml.enabled" --data-urlencode "value=true" } | complete)
-    if $enable_result.exit_code != 0 {
-        print $"(ansi red)✗ Failed to enable SAML: ($enable_result.stderr)(ansi reset)"
+    let enable_result = (do -i { $sonar_auth_config | curl --config - --noproxy "*" -sSk -o /dev/null -w "%{http_code}" -X POST $"($sonar_url)/api/settings/set" --data-urlencode "key=sonar.auth.saml.enabled" --data-urlencode "value=true" } | complete)
+    if not (sonarqube_http_status_matches $enable_result.exit_code $enable_result.stdout "204") {
+        print $"(ansi red)✗ Failed to enable SAML(ansi reset)"
         $all_ok = false
     }
 
-    if $all_ok {
-        print $"(ansi green)✓ SAML fully configured and enabled in SonarQube(ansi reset)"
-    } else {
-        print $"(ansi yellow)Warning: Some SAML settings may not have been applied(ansi reset)"
+    if not $all_ok {
+        error make {msg: "One or more SonarQube SAML settings could not be applied"}
     }
+
+    # Mandatory readback of every non-secured setting. Successful POST status is
+    # insufficient: proxies or API compatibility errors can otherwise leave the
+    # platform unconfigured while the bootstrap reports success.
+    let expected_readback = {
+        "sonar.core.serverBaseURL": $sonar_url
+        "sonar.auth.saml.applicationId": "sonarqube"
+        "sonar.auth.saml.providerName": "Keycloak"
+        "sonar.auth.saml.providerId": "https://digiorg.local/keycloak/realms/digiorg-core-platform"
+        "sonar.auth.saml.loginUrl": "https://digiorg.local/keycloak/realms/digiorg-core-platform/protocol/saml"
+        "sonar.auth.saml.user.login": "login"
+        "sonar.auth.saml.user.name": "name"
+        "sonar.auth.saml.user.email": "email"
+        "sonar.auth.saml.group.name": "groups"
+        "sonar.auth.saml.allowUsersToSignUp": "true"
+        "sonar.auth.saml.enabled": "true"
+    }
+    let secured_certificate_key = "sonar.auth.saml.certificate.secured"
+    let readback_keys = ($expected_readback | columns | append $secured_certificate_key | str join ",")
+    let readback = (do -i {
+        $sonar_auth_config | curl --config - --noproxy "*" -sSk -w "\n%{http_code}" --get $"($sonar_url)/api/settings/values" --data-urlencode $"keys=($readback_keys)"
+    } | complete)
+    let readback_lines = ($readback.stdout | lines)
+    let readback_status = ($readback_lines | last | default "")
+    let readback_body = ($readback_lines | drop 1 | str join "\n")
+    if not (sonarqube_http_status_matches $readback.exit_code $readback_status "200") or not (sonarqube_settings_match $readback_body ($expected_readback | to json)) or not (sonarqube_setting_present $readback_body $secured_certificate_key) {
+        error make {msg: "SonarQube settings readback did not match the required SAML configuration"}
+    }
+
+    print $"(ansi green)✓ SAML fully configured, enabled and verified in SonarQube(ansi reset)"
 }
 
-# Restart pods that depend on OIDC/Keycloak
+# Restart one existing OIDC-dependent deployment and fail closed if either the
+# restart request or rollout cannot complete. A missing deployment is left to the
+# final Application convergence gate; it must not be reported as restarted.
+def restart_oidc_deployment [namespace: string, deployment: string, timeout: string] {
+    let exists = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH get deployment $deployment -n $namespace -o name
+    } | complete)
+    if $exists.exit_code != 0 {
+        error make {msg: $"Required OIDC-dependent deployment ($namespace)/($deployment) is not present"}
+    }
+
+    let restart = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH rollout restart deployment $deployment -n $namespace
+    } | complete)
+    if $restart.exit_code != 0 {
+        error make {msg: $"Failed to restart OIDC-dependent deployment ($namespace)/($deployment)"}
+    }
+
+    let rollout = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH rollout status deployment $deployment -n $namespace $"--timeout=($timeout)"
+    } | complete)
+    if $rollout.exit_code != 0 {
+        error make {msg: $"OIDC-dependent deployment ($namespace)/($deployment) did not complete its rollout"}
+    }
+    print $"(ansi green)✓ ($namespace)/($deployment) restarted(ansi reset)"
+}
+
+# Restart pods that depend on OIDC/Keycloak. This function is called only after
+# both Gitea and SonarQube configuration returned successfully.
 def restart_oidc_dependent_pods [] {
     $env.KUBECONFIG = $KUBECONFIG_PATH
     print "Restarting OIDC-dependent pods to refresh DNS/config..."
-    
-    
-    # ArgoCD Server
-    try {
-        kubectl rollout restart deployment argocd-server -n argocd
-        kubectl rollout status deployment argocd-server -n argocd --timeout=120s
-        print $"(ansi green)✓ ArgoCD Server restarted(ansi reset)"
-    } catch {
-        print $"(ansi yellow)Warning: Could not restart ArgoCD Server(ansi reset)"
-    }
-    
-    # Grafana
-    try {
-        let grafana_exists = (do { kubectl get deployment prometheus-grafana -n monitoring } | complete)
-        if $grafana_exists.exit_code == 0 {
-            kubectl rollout restart deployment prometheus-grafana -n monitoring
-            kubectl rollout status deployment prometheus-grafana -n monitoring --timeout=120s
-            print $"(ansi green)✓ Grafana restarted(ansi reset)"
-        }
-    } catch { }
-    
-    # Backstage
-    try {
-        let backstage_exists = (do { kubectl get deployment backstage -n backstage } | complete)
-        if $backstage_exists.exit_code == 0 {
-            kubectl rollout restart deployment backstage -n backstage
-            kubectl rollout status deployment backstage -n backstage --timeout=180s
-            print $"(ansi green)✓ Backstage restarted(ansi reset)"
-        }
-    } catch { }
 
-    # Landing Page
-    try {
-        let lp_exists = (do { kubectl get deployment landingpage -n platform-apps } | complete)
-        if $lp_exists.exit_code == 0 {
-            kubectl rollout restart deployment landingpage -n platform-apps
-            print $"(ansi green)✓ Landing Page restarted(ansi reset)"
-        }
-    } catch { }
-    
-    print $"(ansi green)✓ OIDC-dependent pods restarted(ansi reset)"
+    wait_for_configuration_dependencies "OIDC restarts" ["argocd" "grafana" "backstage" "landingpage"] []
+
+    restart_oidc_deployment "argocd" "argocd-server" "120s"
+    restart_oidc_deployment "monitoring" "prometheus-grafana" "120s"
+    restart_oidc_deployment "backstage" "backstage" "180s"
+    restart_oidc_deployment "platform-apps" "landingpage" "120s"
+
+    print $"(ansi green)✓ Existing OIDC-dependent deployments restarted(ansi reset)"
 }
 
 # -----------------------------------------------------------------------------
@@ -1496,8 +1935,7 @@ def patch_argocd_oidc_ca [] {
     loop {
         $attempts = $attempts + 1
         if $attempts > 30 {
-            print $"(ansi yellow)Warning: CA cert not available yet, skipping ArgoCD OIDC patch(ansi reset)"
-            return
+            error make {msg: "CA certificate did not become available for the ArgoCD OIDC configuration"}
         }
         let secret_result = (do {
             kubectl get secret digiorg-local-ca-secret -n cert-manager --ignore-not-found -o name
@@ -1514,8 +1952,7 @@ def patch_argocd_oidc_ca [] {
         kubectl get secret digiorg-local-ca-secret -n cert-manager -o jsonpath='{.data.ca\.crt}'
     } | complete)
     if $ca_cert_b64_result.exit_code != 0 or ($ca_cert_b64_result.stdout | str trim | is-empty) {
-        print $"(ansi yellow)Warning: Could not extract CA cert, skipping ArgoCD OIDC patch(ansi reset)"
-        return
+        error make {msg: "Could not extract the CA certificate for the ArgoCD OIDC configuration"}
     }
 
     # Decode using Nushell native decode (portable across macOS and Linux)
@@ -1546,21 +1983,17 @@ rootCA: |\n($indented_cert)
     # Re-run helm upgrade with the override — embeds CA cert in the Helm release
     # so ArgoCD self-sync will not overwrite it
     print "  Running helm upgrade to embed CA cert in ArgoCD release..."
-    (helm upgrade argocd argo/argo-cd
-        --version 10.1.4
-        --namespace argocd
-        --reuse-values
-        --values platform/base/argocd/values.yaml
-        --values ./argocd-oidc-override.yaml
-        --force-conflicts
-        --wait --timeout 5m)
+    let helm_result = (do {
+        helm upgrade argocd argo/argo-cd --version 10.1.4 --namespace argocd --reuse-values --values platform/base/argocd/values.yaml --values ./argocd-oidc-override.yaml --force-conflicts --wait --timeout 5m
+    } | complete)
+    if $helm_result.exit_code != 0 {
+        error make {msg: "Failed to update the ArgoCD OIDC CA configuration via Helm"}
+    }
 
     print $"(ansi green)✓ ArgoCD OIDC config updated with CA cert via Helm(ansi reset)"
 
-    # Restart ArgoCD server to pick up new config immediately
-    kubectl rollout restart deployment argocd-server -n argocd
-    kubectl rollout status deployment argocd-server -n argocd --timeout=120s
-    print $"(ansi green)✓ ArgoCD server restarted(ansi reset)"
+    # Restart ArgoCD server to pick up new config immediately.
+    restart_oidc_deployment "argocd" "argocd-server" "120s"
 
     # Print CA trust instructions
     print ""
@@ -1584,6 +2017,17 @@ rootCA: |\n($indented_cert)
     print $"(ansi yellow)Restart your browser after importing the CA certificate.(ansi reset)"
 }
 
+# Parse the real `argocd version --client --short` output and compare the
+# semantic version exactly. Build metadata is allowed; prefix/suffix versions
+# such as v3.4.50 must not satisfy a v3.4.5 requirement.
+def argocd_client_version_matches [output: string, expected: string] {
+    let parsed = ($output | str trim | parse --regex '^argocd:\s+v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)(?:\+[0-9A-Za-z.-]+)?$')
+    if ($parsed | length) != 1 {
+        return false
+    }
+    (($parsed | get version | first) == $expected)
+}
+
 # Check if prequisite tools (kind, kubectl, helm) are installed before proceeding
 def check_prerequisites [] {
     print "Checking prerequisites..."
@@ -1591,7 +2035,14 @@ def check_prerequisites [] {
     let tools = [
         ["kind", "https://kind.sigs.k8s.io/docs/user/quick-start/#installation"],
         ["kubectl", "https://kubernetes.io/docs/tasks/tools/"],
-        ["helm", "https://helm.sh/docs/intro/install/"]
+        ["helm", "https://helm.sh/docs/intro/install/"],
+        # Issue #281: `argocd` is required, not optional. Final readiness treats a
+        # stale Healthy/OutOfSync Application as ready ONLY when the Argo CD core
+        # diff proves zero material change (see argocd_app_has_no_material_diff).
+        # A missing CLI silently disabled that fallback and stalled the bootstrap
+        # at 24/26 for the full timeout. Pin a CLI that matches the deployed
+        # Argo CD server (v3.4.5 — see docs/guides/platform-versions.md).
+        ["argocd", "https://argo-cd.readthedocs.io/en/stable/cli_installation/"]
     ]
     
     mut missing = []
@@ -1614,6 +2065,16 @@ def check_prerequisites [] {
         print $"(ansi red_bold)Missing required tools. Please install them and try again.(ansi reset)"
         exit 1
     }
+
+    # The zero-diff fallback is part of readiness semantics, so merely finding an
+    # arbitrary argocd binary is insufficient. Match the deployed Argo CD v3.4.5
+    # client exactly on Windows and Linux before any long-running bootstrap work.
+    let expected_argocd_version = "3.4.5"
+    let argocd_version = (do { argocd version --client --short } | complete)
+    if $argocd_version.exit_code != 0 or not (argocd_client_version_matches $argocd_version.stdout $expected_argocd_version) {
+        error make {msg: $"argocd CLI v($expected_argocd_version) is required to match the deployed server"}
+    }
+    print $"(ansi green)✓ argocd CLI v($expected_argocd_version)(ansi reset)"
     
     print ""
 }

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -1503,7 +1503,7 @@ def configure_gitea [] {
     
     # Check if Keycloak OIDC source already exists (idempotency)
     let existing_oauth = (do {
-        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git gitea admin auth list --vertical
+        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c 'gitea admin auth list'
     } | complete)
 
     mut oidc_exists = false

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -609,6 +609,7 @@ def install_argocd [] {
         --values platform/base/argocd/values.yaml
         --set 'server.service.type=ClusterIP'
         --set 'configs.params.server\.insecure=true'
+        --force-conflicts
         --wait --timeout 10m)
 
     print $"(ansi green)✓ ArgoCD installed [Helm](ansi reset)"

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -592,6 +592,26 @@ type: kubernetes.io/service-account-token" | save --force $token_secret_file
     print $"(ansi green)✓ Platform namespaces and secrets created.(ansi reset)"
 }
 
+def helm_force_conflicts_args_for_version [version: string] {
+    let parsed = ($version | str trim | parse --regex '^v(?P<major>[0-9]+)\.[0-9]+\.[0-9]+(?:[+-].*)?$')
+    if ($parsed | length) != 1 {
+        error make {msg: $"Could not parse Helm version: ($version | str trim)"}
+    }
+    let major = ($parsed | get major | first | into int)
+    if $major >= 4 { ["--force-conflicts"] } else { [] }
+}
+
+def helm_force_conflicts_args [] {
+    let version = (do { helm version --short } | complete)
+    if $version.exit_code != 0 {
+        error make {msg: "Failed to determine the Helm version"}
+    }
+    helm_force_conflicts_args_for_version $version.stdout
+}
+
+# Helm 4 uses server-side apply and needs explicit conflict ownership when the
+# self-managed Argo CD Application has touched Helm-owned fields. Helm 3 does
+# not support that flag, so compute a version-aware optional argument list.
 def install_argocd [] {
     kubectl create namespace argocd --dry-run=client -o yaml | kubectl apply -f -
 
@@ -602,6 +622,7 @@ def install_argocd [] {
     # reproducible. argo-cd 10.1.4 ships Argo CD app v3.4.5. Keep in sync with
     # the ARGOCD_CHART_VERSION comment in docs/guides/platform-versions.md and
     # the second (OIDC CA) helm upgrade below.
+    let helm_conflict_args = (helm_force_conflicts_args)
     (helm upgrade --install argocd argo/argo-cd
         --version 10.1.4
         --namespace argocd
@@ -609,7 +630,7 @@ def install_argocd [] {
         --values platform/base/argocd/values.yaml
         --set 'server.service.type=ClusterIP'
         --set 'configs.params.server\.insecure=true'
-        --force-conflicts
+        ...$helm_conflict_args
         --wait --timeout 10m)
 
     print $"(ansi green)✓ ArgoCD installed [Helm](ansi reset)"
@@ -1456,6 +1477,39 @@ def wait_for_configuration_dependencies [phase: string, apps: list, certificates
     error make {msg: $"($phase) configuration dependencies did not become ready: ($bounded)"}
 }
 
+def persist_gitea_bootstrap_token [token: string] {
+    if ($token | is-empty) {
+        error make {msg: "Refusing to persist an empty Gitea bootstrap token"}
+    }
+    let manifest = ({
+        apiVersion: "v1"
+        kind: "Secret"
+        metadata: {name: "gitea-bootstrap-token", namespace: "gitea"}
+        type: "Opaque"
+        data: {token: ($token | encode base64)}
+    } | to json)
+    let apply_result = (do {
+        $manifest | kubectl --kubeconfig $KUBECONFIG_PATH apply -f -
+    } | complete)
+    if $apply_result.exit_code != 0 {
+        error make {msg: "Failed to persist the Gitea bootstrap token"}
+    }
+
+    # Read back and compare without printing either value. This catches apply
+    # transport failures and malformed persistence while keeping the token out of
+    # argv and remaining portable across Linux, macOS and Windows hosts.
+    let readback = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH get secret gitea-bootstrap-token -n gitea -o jsonpath='{.data.token}'
+    } | complete)
+    if $readback.exit_code != 0 {
+        error make {msg: "Failed to verify the persisted Gitea bootstrap token"}
+    }
+    let persisted = (try { $readback.stdout | str trim | decode base64 | decode utf-8 } catch { "" })
+    if ($persisted | is-empty) or ($persisted != $token) {
+        error make {msg: "Persisted Gitea bootstrap token did not match its source"}
+    }
+}
+
 # Configure Gitea (register self-signed CA cert + add Keycloak OIDC provider + create initial users/org)
 def configure_gitea [] {
     $env.KUBECONFIG = $KUBECONFIG_PATH
@@ -1565,7 +1619,7 @@ def configure_gitea [] {
         kubectl --kubeconfig $KUBECONFIG_PATH get secret gitea-bootstrap-token -n gitea -o jsonpath='{.data.token}'
     } | complete)
     let gitea_token = if $token_secret.exit_code == 0 {
-        let stored_token = (try { $token_secret.stdout | str trim | decode base64 } catch { "" })
+        let stored_token = (try { $token_secret.stdout | str trim | decode base64 | decode utf-8 } catch { "" })
         if ($stored_token | is-empty) {
             error make {msg: "The existing gitea-bootstrap-token Secret has no usable token"}
         }
@@ -1583,12 +1637,7 @@ def configure_gitea [] {
         if ($token | is-empty) {
             error make {msg: "Gitea returned an empty configuration access token"}
         }
-        let token_store = (do {
-            $token | kubectl --kubeconfig $KUBECONFIG_PATH create secret generic gitea-bootstrap-token -n gitea --from-file=token=/dev/stdin --dry-run=client -o yaml | kubectl --kubeconfig $KUBECONFIG_PATH apply -f -
-        } | complete)
-        if $token_store.exit_code != 0 {
-            error make {msg: "Failed to persist the Gitea bootstrap token"}
-        }
+        persist_gitea_bootstrap_token $token
         print $"(ansi green)✓ Gitea bootstrap token generated and persisted(ansi reset)"
         $token
     } else {
@@ -1983,8 +2032,9 @@ rootCA: |\n($indented_cert)
     # Re-run helm upgrade with the override — embeds CA cert in the Helm release
     # so ArgoCD self-sync will not overwrite it
     print "  Running helm upgrade to embed CA cert in ArgoCD release..."
+    let helm_conflict_args = (helm_force_conflicts_args)
     let helm_result = (do {
-        helm upgrade argocd argo/argo-cd --version 10.1.4 --namespace argocd --reuse-values --values platform/base/argocd/values.yaml --values ./argocd-oidc-override.yaml --force-conflicts --wait --timeout 5m
+        helm upgrade argocd argo/argo-cd --version 10.1.4 --namespace argocd --reuse-values --values platform/base/argocd/values.yaml --values ./argocd-oidc-override.yaml ...$helm_conflict_args --wait --timeout 5m
     } | complete)
     if $helm_result.exit_code != 0 {
         error make {msg: "Failed to update the ArgoCD OIDC CA configuration via Helm"}


### PR DESCRIPTION
## Summary

- make the final Argo CD readiness gate inventory-complete, bounded, diagnostic, redacted, and fail-closed
- require an exact Argo CD v3.4.5 CLI and accept `Healthy/OutOfSync` only after a successful read-only core zero-diff
- prevent the CNPG admission-webhook startup race by promoting `cnpg-cluster` only after the operator and webhook EndpointSlice are ready
- bind the `WaitForFirstConsumer` backup PVC with an idempotent same-wave Sync hook
- preserve CNPG operation identity and safely resume or no-op existing operations
- make Gitea, SonarQube, OIDC, CA, and generated-secret configuration dependency-aware and resume-safe
- preserve generated Kubernetes Secret values across `up` runs; explicit overrides remain the only rotation path
- classify Kubernetes NotFound fallback conditions exactly and fail closed on auth, permission, proxy, transport, wrong-resource, and mixed diagnostics
- keep Gitea tokens out of argv and local CLI config, persist them through stdin, and verify Secret readback
- use `Recreate` for the single-replica persistent Gitea deployment to avoid shared-volume LevelDB lock deadlocks
- retain Helm 3 support while enabling Helm 4 `--force-conflicts` for self-managed Argo CD resume
- configure SonarQube through in-cluster services and verify secured-setting compatibility without reading secret values
- update the manually gated core catalog to the canonical reviewed merge revision

## Root cause

The original clean bootstrap applied `Cluster/postgresql-cnpg` before the CNPG admission webhook accepted connections. The apply failed with `connection refused`, while the idle backup PVC remained `Pending/WaitForFirstConsumer` and kept the Argo operation `Running`, preventing a fresh retry. Kyverno had no material drift, but the missing/misconfigured Argo CD core-diff path could not classify its stale `Healthy/OutOfSync` status. The hard-coded readiness inventory also omitted `namespaces` and did not identify blockers.

Real resume testing additionally exposed compatibility and idempotency defects in Helm 4 field ownership, pinned Gitea CLI behavior, generated Secret rotation, persistent Gitea configuration, Gitea rolling updates, host-side SonarQube DNS, secured SonarQube setting readback, and exact Kubernetes NotFound classification. Each defect received a focused regression test before correction.

## Validation

### Local release gate

- `make test` — PASS (**331 tests**)
- `python3 scripts/check_pins.py` — PASS
- `python3 scripts/render_platform_charts.py` — PASS (`HELM_RENDER_PASS=12`)
- real Helm 12.6.0 Gitea render — `strategy.type=Recreate`, no `rollingUpdate`
- Nushell source/IDE check — PASS
- `git diff --check` — PASS
- bounded added-line secret scan — PASS
- branch CI `platform-validation` on exact feature HEAD `9eea0c2` — PASS ([run 29740290535](https://github.com/digiorg/core/actions/runs/29740290535))

### `digiorg-core-dev` clean bootstrap and resume

Controlled pre-test cleanup was limited to the KinD cluster, the three approved custom images, and the unused KinD network; no broad Docker prune was used.

The clean bootstrap crossed the issue #281 failure point successfully:

- CNPG operator available before Cluster promotion
- admission webhook EndpointSlice ready before apply
- `cnpg-cluster` operation reached `Succeeded/Synced/Healthy`
- backup PVC reached `Bound`
- no persistent admission-webhook/backup-PVC deadlock

Repeated resume runs validated:

- generated Secret values remain unchanged
- CNPG can complete a fresh identified operation and can also no-op when already `Synced/Healthy`
- Gitea reuses its bootstrap token, OIDC provider, organisation, users, and team memberships
- Gitea has one ready pod under `Recreate`
- SonarQube Base URL and SAML configuration are applied and read back through in-cluster services
- required OIDC deployment restarts complete
- final platform gate reports `Platform Ready`

Final invariant capture:

- Application inventory: **28 expected / 28 actual** (27 children plus `root-app`)
- missing/extra Applications: none
- running Argo operations: none
- CNPG operator: `desired=1`, `available=1`
- CNPG webhook ready endpoints: `1`
- CNPG cluster: `1/1` ready, healthy
- backup PVC: `Bound`
- Gitea: `Recreate`, one ready/running pod
- Kyverno: stale `Healthy/OutOfSync`, but `argocd app diff --core --refresh` exit `0`
- credential/token/private-key log scan: no findings after summary hardening

## Safety

- no broad `ignoreDifferences` or Kyverno exception
- no broad retry classification for admission, hook, auth, permission, policy, or manifest failures
- diagnostics are redacted before being length-bounded
- tokens and API credentials are transported through stdin, not argv
- Secret fallback is allowed only for the exact expected Kubernetes `(NotFound)` diagnostic
- Namespace `Prune=false` ownership contract is unchanged
- `core-catalog` remains manually gated

Fixes #281
