### PR TITLE
fix: stabilize fresh platform bootstrap races

### DIFF
--- a/platform/tests/test_clean_bootstrap_runtime_regressions.py
+++ b/platform/tests/test_clean_bootstrap_runtime_regressions.py
@@ -86,46 +86,57 @@ class CrossplaneHarborOrderingTest(unittest.TestCase):
         loop = func_body("sync_gated_apps_for_local_dev")
         self.assertLess(loop.index("wait_for_provider_http_ready"), loop.index("kubectl patch application $app"))
 
-    def test_harbor_bootstrap_waits_for_ca_before_sync_without_depending_on_harbor_app(self):
-        """Issue #285 runtime-v10: `crossplane-harbor-bootstrap` was promoted
-        by this gated loop before Phase 3 (main up) had copied the
-        digiorg.local CA into crossplane-system, so `Request
-        harbor-crossplane-system-robot` went OutOfSync/Synced=False with
-        ReconcileError: missing crossplane-system/digiorg-local-ca. The
-        branch that gates this Application must wait only for cert-manager
-        itself (never the not-yet-synced Harbor Application -- that would
-        deadlock on Harbor's own PostSync hooks) and its Certificate, then
-        copy the CA, then run the existing provider-http gate, in that exact
-        order, before this Application is patched to sync."""
+    def test_ca_copy_happens_once_before_first_gated_app_sync_not_gated_on_harbor(self):
+        """Issue #285 runtime-v11 (stdout10 live evidence): Harbor's
+        Application reaches Synced/Healthy with every pod Ready, but its own
+        PostSync hook Job/harbor-oidc-config sits Running because harbor's
+        namespace never received the digiorg.local CA before the hook fired
+        -- the CA copy used to be staged only into crossplane-system,
+        immediately before the crossplane-harbor-bootstrap branch, while the
+        copy into harbor happened in Phase 3, strictly after this entire
+        gated loop. Both copies must happen exactly once, before the very
+        first gated Application is patched to sync (root-app has already
+        created every Application by then), waiting only for cert-manager
+        itself and its Certificate -- never for the not-yet-synced Harbor
+        Application, which would deadlock on its own PostSync hook."""
         body = func_body("sync_gated_apps_for_local_dev")
-        branch_start = body.index('if $app == "crossplane-harbor-bootstrap"')
-        branch_end = body.index("mut exists = false", branch_start)
-        branch = body[branch_start:branch_end]
+        loop_start = body.index("for app in $gated_apps")
+        preamble = body[:loop_start]
 
-        self.assertIn("wait_for_configuration_dependencies", branch)
-        self.assertIn('copy_digiorg_local_ca_to_namespace "crossplane-system"', branch)
-        self.assertIn("wait_for_provider_http_ready", branch)
+        self.assertIn("wait_for_configuration_dependencies", preamble)
+        self.assertIn('copy_digiorg_local_ca_to_namespace "harbor"', preamble)
+        self.assertIn('copy_digiorg_local_ca_to_namespace "crossplane-system"', preamble)
 
-        dependency_pos = branch.index("wait_for_configuration_dependencies")
-        copy_pos = branch.index('copy_digiorg_local_ca_to_namespace "crossplane-system"')
-        provider_pos = branch.index("wait_for_provider_http_ready")
+        dependency_pos = preamble.index("wait_for_configuration_dependencies")
+        harbor_copy_pos = preamble.index('copy_digiorg_local_ca_to_namespace "harbor"')
+        crossplane_copy_pos = preamble.index('copy_digiorg_local_ca_to_namespace "crossplane-system"')
         self.assertLess(
-            dependency_pos, copy_pos,
-            "must wait for cert-manager/its Certificate before copying the CA",
+            dependency_pos, harbor_copy_pos,
+            "must wait for cert-manager/its Certificate before copying the CA to harbor",
         )
         self.assertLess(
-            copy_pos, provider_pos,
-            "must copy the CA before the existing provider-http gate runs",
+            dependency_pos, crossplane_copy_pos,
+            "must wait for cert-manager/its Certificate before copying the CA to crossplane-system",
         )
 
-        dependency_call = branch[dependency_pos:copy_pos]
+        dependency_call = preamble[dependency_pos:min(harbor_copy_pos, crossplane_copy_pos)]
         self.assertIn('"cert-manager"', dependency_call)
         self.assertIn('"digiorg-local-ca"', dependency_call)
         self.assertNotIn(
             '"harbor"', dependency_call,
             "must never wait on the not-yet-synced Harbor Application -- "
-            "that would deadlock on Harbor's own PostSync hooks",
+            "that would deadlock on Harbor's own PostSync hook",
         )
+
+        # The crossplane-harbor-bootstrap branch must retain only the
+        # provider-http gate -- the CA wait/copy moved above must not be
+        # duplicated inside it.
+        branch_start = body.index('if $app == "crossplane-harbor-bootstrap"')
+        branch_end = body.index("mut exists = false", branch_start)
+        branch = body[branch_start:branch_end]
+        self.assertIn("wait_for_provider_http_ready", branch)
+        self.assertNotIn("wait_for_configuration_dependencies", branch)
+        self.assertNotIn("copy_digiorg_local_ca_to_namespace", branch)
 
 
     def test_gate_fails_fast_and_redacts_deterministic_kubectl_failures(self):

--- a/platform/tests/test_gated_sync_retry_classification.py
+++ b/platform/tests/test_gated_sync_retry_classification.py
@@ -64,6 +64,43 @@ CASES = [
         "rpc error: code = Internal desc = error reading from server: EOF",
         True,
     ),
+    # stdout10 (Issue #285 fresh-cluster run): confirmed live evidence -- the
+    # initial grafana sync failed with this exact Prometheus resource message,
+    # and minutes later, with no intervention, Grafana was Synced/Healthy and
+    # Prometheus was Available=True/Reconciled=True with every monitoring
+    # container Ready and zero restarts. Same config-reloader startup race as
+    # the "incomplete status: [init-config-reloader]" case above, just the
+    # main-container wording instead of the init-container wording.
+    (
+        "one or more synchronization tasks completed unsuccessfully\n"
+        "Prometheus/prometheus: shard 0: pod prometheus-0: containers with "
+        "unready status: [prometheus config-reloader]",
+        True,
+    ),
+    # Guards: an "unready status" message must NOT be accepted for an
+    # unrelated container set, either alone or concatenated with the confirmed
+    # Prometheus race. Argo combines all failed resource diagnostics before
+    # classification, so an allowlisted failure must never mask another one.
+    (
+        "containers with unready status: [some-other-container]",
+        False,
+    ),
+    (
+        "Prometheus/prometheus: containers with unready status: "
+        "[prometheus config-reloader]\n"
+        "Deployment/other: containers with unready status: "
+        "[some-other-container]",
+        False,
+    ),
+    (
+        "Prometheus/prometheus: containers with unready status: "
+        "[prometheus config-reloader]\n"
+        "Deployment/other: containers with unready status: "
+        "[some-other-container",
+        False,
+    ),
+    ("containers with unready status: []", False),
+    ("containers with pending status: [some-other-container]", False,),
     (
         "rpc error: code = InvalidArgument desc = failed to unmarshal manifest: "
         "yaml: line 7: mapping values are not allowed here",

--- a/scripts/local-setup.nu
+++ b/scripts/local-setup.nu
@@ -1185,9 +1185,34 @@ def is_retryable_sync_error [message: string] {
         }
     }
 
-    # One narrowly identified resource-health race is transient only when no
-    # deterministic marker occurs anywhere in the combined diagnostics.
-    if ($normalized | str contains "containers with incomplete status:") {
+    # Two narrowly identified resource-health races are transient only when no
+    # deterministic marker occurs anywhere in the combined diagnostics: the
+    # Prometheus config-reloader sidecar taking a few seconds to become ready
+    # after container start, confirmed under two exact wordings (init-container
+    # form and stdout10's live main-container form). Argo concatenates all failed
+    # resource diagnostics. Validate every line containing a container-health
+    # fragment independently and require one complete allowlisted fragment per
+    # line; malformed, unknown, duplicated, or mixed failures stay fail-closed.
+    let container_health_lines = (
+        $normalized
+        | lines
+        | where {|line| $line | str contains "containers with " }
+    )
+    if not ($container_health_lines | is-empty) {
+        for line in $container_health_lines {
+            if (($line | split row "containers with " | length) != 2) {
+                return false
+            }
+            let confirmed_init_race = (
+                $line | str ends-with "containers with incomplete status: [init-config-reloader]"
+            )
+            let confirmed_sidecar_race = (
+                $line | str ends-with "containers with unready status: [prometheus config-reloader]"
+            )
+            if not ($confirmed_init_race or $confirmed_sidecar_race) {
+                return false
+            }
+        }
         return true
     }
 
@@ -1423,20 +1448,27 @@ def sync_gated_apps_for_local_dev [] {
 
     print ""
     print $"(ansi cyan_bold)Promoting gated upgrades sequentially on local KinD(ansi reset)"
+
+    # Issue #285 runtime-v11: crossplane-harbor-bootstrap's Request objects need
+    # crossplane-system/digiorg-local-ca (proven live ReconcileError: missing
+    # crossplane-system/digiorg-local-ca), and Harbor's own PostSync hook
+    # (Job/harbor-oidc-config) needs that same CA copied into harbor's own
+    # namespace too (proven live: Harbor's Application reaches Synced/Healthy
+    # with every pod Ready while its Running operation still waits on that
+    # hook, because Phase 3's copy into harbor runs AFTER this entire gated
+    # loop). Copy the CA into both namespaces once, before the very first
+    # gated Application sync -- root-app has already created every
+    # Application by this point -- waiting only for cert-manager itself and
+    # its Certificate, never for Harbor (which is not yet synced and would
+    # deadlock on its own PostSync hook). Idempotent with Phase 3's copies.
+    wait_for_configuration_dependencies "Digiorg local CA" ["cert-manager"] [
+        {namespace: "cert-manager", name: "digiorg-local-ca"}
+    ]
+    copy_digiorg_local_ca_to_namespace "harbor"
+    copy_digiorg_local_ca_to_namespace "crossplane-system"
+
     for app in $gated_apps {
         if $app == "crossplane-harbor-bootstrap" {
-            # Issue #285 runtime-v10: this Application's Request objects need
-            # crossplane-system/digiorg-local-ca (proven live ReconcileError:
-            # missing crossplane-system/digiorg-local-ca), but Phase 3's CA
-            # copy in `main up` runs AFTER this gated sync loop. Wait only for
-            # cert-manager itself and its Certificate here -- never for the
-            # Harbor Application, which is not yet synced and would deadlock
-            # on Harbor's own PostSync hooks -- then copy the CA before the
-            # existing provider-http gate runs. Idempotent with Phase 3's copy.
-            wait_for_configuration_dependencies "Crossplane Harbor bootstrap TLS" ["cert-manager"] [
-                {namespace: "cert-manager", name: "digiorg-local-ca"}
-            ]
-            copy_digiorg_local_ca_to_namespace "crossplane-system"
             wait_for_provider_http_ready
         }
         mut exists = false


### PR DESCRIPTION
## Summary

Follow-up to merged PR #286 based on fresh Windows/Docker Desktop evidence from `stdout9.txt`, `stdout10.txt`, and `stdout11.txt`.

- stage the public `digiorg.local` CA in both `harbor` and `crossplane-system` immediately after cert-manager readiness and before the first gated sync
- unblock Harbor's `harbor-oidc-config` and `harbor-proxy-cache-config` PostSync hooks without waiting on the Harbor Application
- retry the exact confirmed Prometheus `config-reloader` startup race observed on a fresh cluster
- keep arbitrary, mixed, malformed, duplicated, and unknown container-health diagnostics fail-closed

## Runtime evidence

- Grafana initially failed with `containers with unready status: [prometheus config-reloader]`, then recovered without intervention to `Synced/Healthy`; Prometheus became `Available=True/Reconciled=True` and all monitoring containers were Ready with zero restarts.
- Harbor was `Synced/Healthy` but its operation remained `Running` waiting for `Job/harbor-oidc-config`. Copying the public CA into `harbor` made both Harbor hook Jobs complete and Argo converge to `Synced/Healthy/Succeeded`.
- The CA is still copied idempotently in Phase 3; this change fixes the earlier ordering before gated syncs.

## Validation

- focused retry classifier: 12/12
- focused bootstrap/runtime regressions: 20/20
- full platform suite: 589/589
- Helm render contracts: 13/13
- source pin policy: pass
- Nushell source + IDE checks: pass
- `git diff --check`: pass
- credential-pattern scan: no findings
- independent final review: CLEAN

## Safety

No credential values, response bodies, Request JSON, provider logs, or Secret data are emitted. CA handling copies only the existing public certificate.
